### PR TITLE
Feat: add jargon glossary to translate from student terms to steering documents

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,11 @@ __pycache__/
 data/chroma/
 data/logs.sqlite
 data/logs.sqlite-*
+data/web_users
+
+# Student-submitted jargon proposals — review with `student-bot-jargon proposals`
+# and move accepted entries to dictionary.json before pushing.
+dictionary_proposals.json
 
 # uv
 uv.lock

--- a/README.md
+++ b/README.md
@@ -205,6 +205,82 @@ their previous label until you reclassify them.
 
 ---
 
+## Jargon dictionary
+
+Students don't say *kandidatexamensarbete* — they say *KEX-jobb*. The
+embedding model has no signal connecting the two, so retrieval misses
+unless we bridge them. `dictionary.json` (in the repo root) is a small,
+hand-curated map of student slang to the formal corpus terms; it's applied
+at query time, never re-embedded.
+
+**What happens at query time**:
+1. The bot detects jargon terms (whole-word, NFC-normalised, case-insensitive).
+2. The query sent to retrieval gets the formal phrase appended inline:
+   *"Hur fungerar KEX-jobb?"* → *"Hur fungerar KEX-jobb (kandidatexamensarbete)?"*.
+3. A small *Ordlista* block is added to the LLM prompt so the model knows
+   what the slang means.
+4. A one-line transparency note is shown above the answer:
+   `_Tolkar "KEX-jobb" som "kandidatexamensarbete"._` — students see what
+   was substituted and can correct it if the bot guessed wrong.
+
+The dictionary file is reloaded automatically when its mtime changes — no
+restart needed after edits or after `student-bot-jargon accept`.
+
+**File format** (`dictionary.json`):
+
+```json
+{
+  "version": 1,
+  "entries": {
+    "kex-jobb": {
+      "term": "KEX-jobb",
+      "expansion": "kandidatexamensarbete",
+      "lang": "sv",
+      "definition": "Examensarbete på kandidatnivå (15 hp).",
+      "added_by": "admin",
+      "added_ts": "2026-05-01"
+    }
+  }
+}
+```
+
+- `lang` is `"sv"`, `"en"`, or `"any"` — entries are filtered by the query's
+  detected language so an English query doesn't get Swedish-only glossary.
+- The map key is the lowercase NFC-normalised term; `term` keeps display
+  capitalisation.
+
+**Discovery**:
+- Mattermost: `!jargon list` posts the current dictionary in the thread.
+- Web: `/glossary` shows the same table plus a small *Suggest entry* form.
+
+**How students contribute**:
+- **In Mattermost**: `!jargon suggest KEX-jobb = kandidatexamensarbete`.
+  Stored to `dictionary_proposals.json` for admin review.
+- **In the web UI**: form on `/glossary` posts to `/api/jargon/suggest`.
+- **Via PR**: the repo is open. Edit `dictionary.json` and open a PR;
+  reviews are normal prose review.
+
+**Admin review**:
+
+```bash
+uv run student-bot-jargon list             # canonical entries
+uv run student-bot-jargon proposals        # pending suggestions
+uv run student-bot-jargon accept 2 --def "Optional override"
+uv run student-bot-jargon reject 3 --reason "duplicate"
+uv run student-bot-jargon add tenta tentamen --lang sv --def "Skriftlig examination."
+uv run student-bot-jargon remove foobar
+```
+
+`dictionary_proposals.json` is **gitignored** so in-flight student
+suggestions never enter the public repo. Only `dictionary.json` is shared.
+
+**Open-repo security**: PR review is the gate. The bot doesn't load code
+from JSON, only string substitutions, so a poisoned entry can mislead
+retrieval but cannot escalate. `.env`, `data/`, `dictionary_proposals.json`,
+and `data/web_users` are all in `.gitignore`; secrets stay out.
+
+---
+
 ## Web app
 
 Localhost-only by default. Two-factor authentication when exposed to a network.

--- a/config.yaml
+++ b/config.yaml
@@ -97,3 +97,14 @@ topics:
   enabled: true
   file: topics.yaml
   classifier_temperature: 0.0
+
+# Student-jargon dictionary. Expansions happen at query time so retrieval
+# matches the formal term in the corpus. Edit `dictionary.json` (or accept
+# proposals via `student-bot-jargon accept N`) — changes are picked up on the
+# next query without a restart.
+jargon:
+  enabled: true
+  file: dictionary.json
+  proposals_file: dictionary_proposals.json
+  show_transparency_note: true   # adds "_Tolkar X som Y._" above the answer
+  max_glossary_entries: 6

--- a/dictionary.json
+++ b/dictionary.json
@@ -67,7 +67,7 @@
       "added_ts": "2026-05-01"
     },
     "kå": {
-      "term": "KÅ",
+      "term": "THS",
       "expansion": "kåren",
       "lang": "sv",
       "definition": "Studentkåren (THS, Tekniska Högskolans Studentkår).",
@@ -81,6 +81,22 @@
       "definition": "Användarkontot för KTH:s system (e-post, Canvas, Ladok, m.m.).",
       "added_by": "admin",
       "added_ts": "2026-05-01"
+    },
+    "envarren": {
+      "term": "envarren",
+      "expansion": "envariabelanalyskursen",
+      "lang": "sv",
+      "definition": "SF1673 Analys i en variabel 7,5 hp - en matematikkurs",
+      "added_by": "admin (accepted from student suggestion)",
+      "added_ts": "2026-05-02"
+    },
+    "flervarren": {
+      "term": "flervarren",
+      "expansion": "flervariabelanalyskursen",
+      "lang": "sv",
+      "definition": "SF1674 Flervariabelanalys 7,5 hp - en mattekurs",
+      "added_by": "admin (accepted from student suggestion)",
+      "added_ts": "2026-05-02"
     }
   }
 }

--- a/dictionary.json
+++ b/dictionary.json
@@ -1,0 +1,86 @@
+{
+  "version": 1,
+  "_comment": "Student-jargon dictionary. Add terms via PR or via `student-bot-jargon add`.",
+  "entries": {
+    "kex-jobb": {
+      "term": "KEX-jobb",
+      "expansion": "kandidatexamensarbete",
+      "lang": "sv",
+      "definition": "Examensarbete på kandidatnivå, oftast 15 hp, sista terminen på grundnivån.",
+      "added_by": "admin",
+      "added_ts": "2026-05-01"
+    },
+    "exjobb": {
+      "term": "exjobb",
+      "expansion": "examensarbete",
+      "lang": "sv",
+      "definition": "Examensarbete (kandidat- eller masternivå).",
+      "added_by": "admin",
+      "added_ts": "2026-05-01"
+    },
+    "tenta": {
+      "term": "tenta",
+      "expansion": "tentamen",
+      "lang": "sv",
+      "definition": "Skriftlig examination i en kurs.",
+      "added_by": "admin",
+      "added_ts": "2026-05-01"
+    },
+    "omtenta": {
+      "term": "omtenta",
+      "expansion": "omtentamen",
+      "lang": "sv",
+      "definition": "Förnyad examination för den som inte godkänts vid den första.",
+      "added_by": "admin",
+      "added_ts": "2026-05-01"
+    },
+    "ks": {
+      "term": "KS",
+      "expansion": "kontrollskrivning",
+      "lang": "sv",
+      "definition": "Mindre delprov i en kurs, oftast bedömt med godkänt/icke godkänt.",
+      "added_by": "admin",
+      "added_ts": "2026-05-01"
+    },
+    "lp": {
+      "term": "LP",
+      "expansion": "läsperiod",
+      "lang": "sv",
+      "definition": "Läsperiod — KTH:s läsår är delat i fyra läsperioder (LP1–LP4).",
+      "added_by": "admin",
+      "added_ts": "2026-05-01"
+    },
+    "hp": {
+      "term": "hp",
+      "expansion": "högskolepoäng",
+      "lang": "any",
+      "definition": "Högskolepoäng. 1 hp ≈ 1 ECTS-poäng. Heltidsstudier under en läsperiod motsvarar typiskt 7,5–15 hp.",
+      "added_by": "admin",
+      "added_ts": "2026-05-01"
+    },
+    "pa": {
+      "term": "PA",
+      "expansion": "programansvarig",
+      "lang": "sv",
+      "definition": "Programansvarig — den lärare som leder ett utbildningsprogram.",
+      "added_by": "admin",
+      "added_ts": "2026-05-01"
+    },
+    "kå": {
+      "term": "KÅ",
+      "expansion": "kåren",
+      "lang": "sv",
+      "definition": "Studentkåren (THS, Tekniska Högskolans Studentkår).",
+      "added_by": "admin",
+      "added_ts": "2026-05-01"
+    },
+    "kth-konto": {
+      "term": "KTH-konto",
+      "expansion": "KTH:s användarkonto",
+      "lang": "sv",
+      "definition": "Användarkontot för KTH:s system (e-post, Canvas, Ladok, m.m.).",
+      "added_by": "admin",
+      "added_ts": "2026-05-01"
+    }
+  }
+}

--- a/eval/eval_set.yml
+++ b/eval/eval_set.yml
@@ -166,6 +166,19 @@
   kind: in_domain
   expected_any: ["Utbildningsplan CTFYS HT2024 eng", "Utbildningsplan CTFYS HT2024 sve"]
 
+# ---------------- in-domain, jargon-laden ----------------
+# These exercise dictionary.json query expansion. If recall on these drops
+# without other in-domain queries dropping, suspect a jargon regression.
+- question: "Hur fungerar KEX-jobb?"
+  lang: sv
+  kind: in_domain
+  expected_doc_substring: "examensarbetskurser"
+
+- question: "Vad är skillnaden mellan KS och tenta i en CTFYS-kurs?"
+  lang: sv
+  kind: in_domain
+  expected_any: ["skriftlig-examination-i-sal", "kursplan-betygssystem-och-examination"]
+
 # ---------------- out-of-domain ----------------
 - question: "Vilket är väder i Stockholm imorgon?"
   lang: sv

--- a/eval/run_eval.py
+++ b/eval/run_eval.py
@@ -23,6 +23,7 @@ from rich.table import Table
 from student_bot.bot.gate import evaluate as evaluate_gate
 from student_bot.bot.retrieval import retrieve
 from student_bot.config import PROJECT_ROOT, get_config
+from student_bot.jargon import Jargon
 
 
 EVAL_FILE = PROJECT_ROOT / "eval" / "eval_set.yml"
@@ -62,6 +63,9 @@ def main(eval_file: Path, show_failures: bool):
     cfg = get_config()
     console = Console()
     entries: list[dict] = yaml.safe_load(eval_file.read_text(encoding="utf-8"))
+    # Run queries through the same jargon expansion the bot uses, so the
+    # eval reflects production behaviour rather than bare retrieval.
+    jargon = Jargon.from_config(cfg) if cfg.jargon.enabled else None
 
     in_top1: list[float] = []
     in_meanK: list[float] = []
@@ -76,7 +80,11 @@ def main(eval_file: Path, show_failures: bool):
     for entry in entries:
         q = entry["question"]
         kind = entry["kind"]
-        result = retrieve(cfg, q)
+        if jargon is not None:
+            q_used, _ = jargon.expand_query(q, lang=entry.get("lang"))
+        else:
+            q_used = q
+        result = retrieve(cfg, q_used)
         gate = evaluate_gate(cfg, result)
 
         if kind == "in_domain":

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,13 +50,14 @@ student-bot-web = "student_bot.web.app:main"
 student-bot-reindex = "scripts.reindex:main"
 student-bot-stats = "scripts.stats:main"
 student-bot-mkuser = "scripts.mkuser:main"
+student-bot-jargon = "scripts.jargon:main"
 
 [build-system]
 requires = ["hatchling"]
 build-backend = "hatchling.build"
 
 [tool.hatch.build.targets.wheel]
-packages = ["src/student_bot"]
+packages = ["src/student_bot", "scripts", "eval"]
 
 [tool.ruff]
 line-length = 100

--- a/scripts/jargon.py
+++ b/scripts/jargon.py
@@ -1,0 +1,188 @@
+"""student-bot-jargon — admin CLI for the jargon dictionary.
+
+Curates `dictionary.json` (canonical) and reviews `dictionary_proposals.json`
+(student-submitted queue). Uses the same JSON shape as the runtime so a
+careful admin can also edit the file by hand.
+"""
+from __future__ import annotations
+
+import json
+import time
+from pathlib import Path
+
+import click
+from rich.console import Console
+from rich.table import Table
+
+from student_bot.config import Config, get_config
+from student_bot.jargon import (
+    Jargon,
+    JargonEntry,
+    _nfc_lower,
+    _read_json,
+    _write_json,
+)
+
+
+def _proposals_path(cfg: Config) -> Path:
+    return cfg.absolute(Path(cfg.jargon.proposals_file))
+
+
+def _load_proposals(cfg: Config) -> dict:
+    path = _proposals_path(cfg)
+    if not path.exists():
+        return {"version": 1, "entries": {}}
+    return _read_json(path)
+
+
+def _save_proposals(cfg: Config, data: dict) -> None:
+    _write_json(_proposals_path(cfg), data)
+
+
+def _today() -> str:
+    return time.strftime("%Y-%m-%d", time.gmtime())
+
+
+@click.group()
+def main():
+    """Manage the student-bot jargon dictionary."""
+
+
+@main.command("list")
+def list_cmd():
+    """Show all canonical entries."""
+    cfg = get_config()
+    j = Jargon.from_config(cfg)
+    console = Console()
+    entries = j.all_entries()
+    if not entries:
+        console.print("[dim]dictionary is empty[/dim]")
+        return
+    t = Table(title=f"{len(entries)} entries — {cfg.absolute(Path(cfg.jargon.file))}")
+    t.add_column("term", style="bold")
+    t.add_column("expansion")
+    t.add_column("definition")
+    t.add_column("lang")
+    t.add_column("added_by")
+    for e in entries:
+        t.add_row(e.term, e.expansion, (e.definition or "—"), e.lang, e.added_by or "—")
+    console.print(t)
+
+
+@main.command("add")
+@click.argument("term")
+@click.argument("expansion")
+@click.option("--lang", default="sv", help="sv | en | any")
+@click.option("--def", "definition", default="", help="One-line definition.")
+@click.option("--by", default="admin")
+def add_cmd(term: str, expansion: str, lang: str, definition: str, by: str):
+    """Add or update an entry."""
+    cfg = get_config()
+    j = Jargon.from_config(cfg)
+    e = JargonEntry(
+        key=_nfc_lower(term),
+        term=term,
+        expansion=expansion,
+        lang=lang,
+        definition=definition,
+        added_by=by,
+        added_ts=_today(),
+    )
+    j.add_entry(e)
+    click.echo(f"added/updated {term} → {expansion}")
+
+
+@main.command("remove")
+@click.argument("term")
+def remove_cmd(term: str):
+    """Remove an entry by term or key."""
+    cfg = get_config()
+    j = Jargon.from_config(cfg)
+    if j.remove_entry(term):
+        click.echo(f"removed {term}")
+    else:
+        raise click.ClickException(f"no entry named {term!r}")
+
+
+@main.command("proposals")
+def proposals_cmd():
+    """List pending proposals from `dictionary_proposals.json`."""
+    cfg = get_config()
+    console = Console()
+    data = _load_proposals(cfg)
+    entries = data.get("entries", {})
+    pending = [(k, v) for k, v in entries.items() if v.get("status") == "pending"]
+    if not pending:
+        console.print("[dim]no pending proposals[/dim]")
+        return
+    t = Table(title=f"{len(pending)} pending — {_proposals_path(cfg)}")
+    t.add_column("#", justify="right")
+    t.add_column("term", style="bold")
+    t.add_column("expansion")
+    t.add_column("definition")
+    t.add_column("lang")
+    t.add_column("when")
+    for i, (_, v) in enumerate(pending, 1):
+        ts = v.get("suggested_ts") or 0
+        when = time.strftime("%Y-%m-%d", time.gmtime(ts)) if ts else "—"
+        t.add_row(str(i), v.get("term", ""), v.get("expansion", ""),
+                   v.get("definition", "") or "—", v.get("lang", ""), when)
+    console.print(t)
+
+
+def _resolve_proposal_index(cfg: Config, n: int) -> tuple[str, dict]:
+    data = _load_proposals(cfg)
+    entries = data.get("entries", {})
+    pending = [(k, v) for k, v in entries.items() if v.get("status") == "pending"]
+    if n < 1 or n > len(pending):
+        raise click.ClickException(f"no proposal #{n} (got {len(pending)} pending)")
+    return pending[n - 1]
+
+
+@main.command("accept")
+@click.argument("n", type=int)
+@click.option("--def", "definition", default=None,
+              help="Override the suggested definition.")
+@click.option("--lang", default=None, help="Override the suggested language.")
+def accept_cmd(n: int, definition: str | None, lang: str | None):
+    """Move proposal #N from the queue into the canonical dictionary."""
+    cfg = get_config()
+    key, body = _resolve_proposal_index(cfg, n)
+
+    j = Jargon.from_config(cfg)
+    entry = JargonEntry(
+        key=key,
+        term=body.get("term", key),
+        expansion=body.get("expansion", ""),
+        lang=lang or body.get("lang", "sv"),
+        definition=definition if definition is not None else body.get("definition", ""),
+        added_by="admin (accepted from student suggestion)",
+        added_ts=_today(),
+    )
+    j.add_entry(entry)
+
+    data = _load_proposals(cfg)
+    data["entries"][key]["status"] = "accepted"
+    data["entries"][key]["resolved_ts"] = int(time.time())
+    _save_proposals(cfg, data)
+    click.echo(f"accepted: {entry.term} → {entry.expansion}")
+
+
+@main.command("reject")
+@click.argument("n", type=int)
+@click.option("--reason", default="")
+def reject_cmd(n: int, reason: str):
+    """Mark proposal #N as rejected (kept for audit)."""
+    cfg = get_config()
+    key, _ = _resolve_proposal_index(cfg, n)
+    data = _load_proposals(cfg)
+    data["entries"][key]["status"] = "rejected"
+    data["entries"][key]["resolved_ts"] = int(time.time())
+    if reason:
+        data["entries"][key]["rejection_reason"] = reason
+    _save_proposals(cfg, data)
+    click.echo(f"rejected proposal #{n}")
+
+
+if __name__ == "__main__":
+    main()

--- a/src/student_bot/bot/mattermost_client.py
+++ b/src/student_bot/bot/mattermost_client.py
@@ -19,6 +19,7 @@ import sys
 import threading
 import time
 from dataclasses import dataclass
+from pathlib import Path
 
 from mattermostdriver import Driver
 from rich.logging import RichHandler
@@ -138,6 +139,81 @@ class StudentBot:
             log.exception("post failed")
             return None
 
+    def _handle_jargon_command(self, job: _Job, body: str) -> bool:
+        """Returns True if the message was handled as a !jargon command."""
+        from student_bot.jargon import Jargon, JargonEntry, _nfc_lower
+        from student_bot.lang import detect
+        text = body.strip()
+        if not text.lower().startswith("!jargon"):
+            return False
+        rest = text[len("!jargon"):].strip()
+        sub, _, tail = rest.partition(" ")
+        sub = sub.lower()
+        lang = detect(text) if text else "sv"
+
+        jargon = Jargon.from_config(self.cfg)
+
+        if sub in ("", "list"):
+            entries = jargon.all_entries()
+            if not entries:
+                msg = "Ordlistan är tom." if lang == "sv" else "The dictionary is empty."
+            else:
+                head = "| Term | Betydelse | Förklaring |\n|---|---|---|" if lang == "sv" \
+                    else "| Term | Means | Definition |\n|---|---|---|"
+                rows = [
+                    f"| {e.term} | {e.expansion} | {e.definition or '—'} |"
+                    for e in entries
+                ]
+                msg = "\n".join([head, *rows])
+            self._post(job.channel_id, msg, job.root_id)
+            return True
+
+        if sub == "suggest":
+            term, sep, expansion = tail.partition("=")
+            term = term.strip()
+            expansion = expansion.strip()
+            if not (term and sep and expansion):
+                example = "`!jargon suggest KEX-jobb = kandidatexamensarbete`"
+                err = (f"Format: {example}" if lang == "sv"
+                       else f"Format: {example}")
+                self._post(job.channel_id, err, job.root_id)
+                return True
+            self._record_proposal(job.user_id, term, expansion, lang)
+            ack = ("Tack! Förslaget hamnar i kö för admin att granska."
+                   if lang == "sv"
+                   else "Thanks! Your suggestion is queued for admin review.")
+            self._post(job.channel_id, ack, job.root_id)
+            return True
+
+        # Unknown subcommand — show help.
+        help_sv = ("Användning: `!jargon list` eller "
+                   "`!jargon suggest TERM = BETYDELSE`")
+        help_en = "Usage: `!jargon list` or `!jargon suggest TERM = MEANING`"
+        self._post(job.channel_id, help_en if lang == "en" else help_sv, job.root_id)
+        return True
+
+    def _record_proposal(self, user_id: str, term: str, expansion: str, lang: str) -> None:
+        """Append a proposal to dictionary_proposals.json."""
+        from student_bot.jargon import _nfc_lower, _read_json, _write_json
+        path = self.cfg.absolute(Path(self.cfg.jargon.proposals_file))
+        data = _read_json(path) if path.exists() else {"version": 1, "entries": {}}
+        entries = data.setdefault("entries", {})
+        key = _nfc_lower(term)
+        # If a duplicate is suggested, just update the timestamp; don't dedupe
+        # the suggester because we want to know how many people asked.
+        entries[key] = {
+            "term": term,
+            "expansion": expansion,
+            "lang": lang,
+            "definition": "",
+            "added_by": "student",
+            "added_ts": time.strftime("%Y-%m-%d", time.gmtime()),
+            "suggested_by_hash": self.db.hash_user(user_id),
+            "suggested_ts": int(time.time()),
+            "status": "pending",
+        }
+        _write_json(path, data)
+
     def _handle_privacy_command(self, job: _Job, body: str) -> bool:
         """Returns True if the message was handled as a !privacy command."""
         from student_bot.lang import detect
@@ -172,8 +248,10 @@ class StudentBot:
             self._post(job.channel_id, notice, job.root_id)
             self.db.mark_disclosed(job.user_id)
 
-        # !privacy commands short-circuit the RAG pipeline.
+        # !privacy and !jargon commands short-circuit the RAG pipeline.
         if self._handle_privacy_command(job, job.question.strip()):
+            return
+        if self._handle_jargon_command(job, job.question.strip()):
             return
 
         result = answer(job.question, cfg=self.cfg, rate_limit_key=job.user_id)
@@ -197,6 +275,8 @@ class StudentBot:
             gate_reason=result.gate.reason,
             answer=result.answer,
             latency_ms=result.latency_ms,
+            question_expanded=result.expanded_question or None,
+            jargon_hits=[e.key for e in result.jargon_hits] or None,
         )
 
         # Topic classification runs AFTER the user has their answer so it

--- a/src/student_bot/bot/pipeline.py
+++ b/src/student_bot/bot/pipeline.py
@@ -15,6 +15,7 @@ from collections import deque
 from collections.abc import Iterator
 from dataclasses import dataclass, field
 from threading import Lock
+from typing import Any
 
 import click
 from rich.console import Console
@@ -30,21 +31,37 @@ from student_bot.bot.memory import ConversationMemory
 from student_bot.bot.prompts import compose_messages, refusal_message
 from student_bot.bot.retrieval import RetrievalResult, RetrievedChunk, retrieve
 from student_bot.config import Config, get_config
+from student_bot.jargon import Jargon, JargonEntry
 from student_bot.lang import detect
+
+
+_jargon_cache: dict[int, Jargon] = {}
+
+
+def _jargon(cfg: Config) -> Jargon | None:
+    if not cfg.jargon.enabled:
+        return None
+    j = _jargon_cache.get(id(cfg))
+    if j is None:
+        j = Jargon.from_config(cfg)
+        _jargon_cache[id(cfg)] = j
+    return j
 
 
 @dataclass
 class AnswerResult:
-    question: str
+    question: str                # original user text (pre-expansion)
     lang: str
     answered: bool
     answer: str                  # the model's text only (no sources/footer)
-    rendered: str                # answer + sources block + footer (what to display)
+    rendered: str                # answer + sources block + footer + jargon note
     gate: GateDecision
     retrieval: RetrievalResult
     latency_ms: int
     rate_limited: bool = False
     too_long: bool = False
+    expanded_question: str = ""  # post-jargon-expansion query used for retrieval
+    jargon_hits: list = field(default_factory=list)
 
 
 # --- Per-key rate limiter (simple sliding window over the last 60 s) ---
@@ -113,8 +130,11 @@ def _render(
     gate: GateDecision,
     *,
     include_sources: bool,
+    jargon_note: str = "",
 ) -> str:
     parts: list[str] = []
+    if jargon_note and cfg.jargon.show_transparency_note:
+        parts.append(jargon_note + "\n\n")
     if cfg.guardrails.show_confidence_badge and include_sources:
         label = "Tillförlitlighet" if lang == "sv" else "Confidence"
         parts.append(f"_{label}: {confidence_badge(lang, gate.top1)}_\n")
@@ -165,12 +185,27 @@ def answer(
             rate_limited=True,
         )
 
-    retrieval = retrieve(cfg, question)
+    # --- jargon: expand query for retrieval, build glossary for prompt ---
+    jargon = _jargon(cfg)
+    expanded_q = question
+    jargon_hits: list[JargonEntry] = []
+    glossary_md = ""
+    jargon_note = ""
+    if jargon is not None:
+        expanded_q, jargon_hits = jargon.expand_query(question, lang=lang)
+        if jargon_hits:
+            glossary_md = jargon.glossary_block(
+                jargon_hits, lang, max_entries=cfg.jargon.max_glossary_entries,
+            )
+            jargon_note = jargon.transparency_note(jargon_hits, lang)
+
+    retrieval = retrieve(cfg, expanded_q)
     gate = evaluate_gate(cfg, retrieval)
 
     if not gate.passed:
         body = refusal_message(cfg, lang)
-        rendered = _render(cfg, lang, body, [], gate, include_sources=False)
+        rendered = _render(cfg, lang, body, [], gate,
+                           include_sources=False, jargon_note=jargon_note)
         if on_token:
             on_token(rendered)
         return AnswerResult(
@@ -178,20 +213,29 @@ def answer(
             answer=body, rendered=rendered,
             gate=gate, retrieval=retrieval,
             latency_ms=int((time.monotonic() - t0) * 1000),
+            expanded_question=expanded_q, jargon_hits=jargon_hits,
         )
 
-    messages = compose_messages(cfg, lang, history, retrieval.reranked, question)
+    messages = compose_messages(cfg, lang, history, retrieval.reranked,
+                                 expanded_q, glossary_md=glossary_md)
+
+    # Emit the jargon note up-front so the user sees it before tokens stream.
+    if on_token and jargon_note and cfg.jargon.show_transparency_note:
+        on_token(jargon_note + "\n\n")
+
     parts: list[str] = []
     for delta in _stream_answer(cfg, messages):
         parts.append(delta)
         if on_token:
             on_token(delta)
     body = "".join(parts).strip()
-    rendered = _render(cfg, lang, body, retrieval.reranked, gate, include_sources=True)
-    # Sources & footer are appended AFTER streaming completes; emit them as
-    # a final delta so streaming UIs see the same text the API returns.
+    rendered = _render(cfg, lang, body, retrieval.reranked, gate,
+                       include_sources=True, jargon_note=jargon_note)
     if on_token:
-        tail = rendered[len(body):]
+        # Compute the tail from the rendered version *minus* what we've
+        # already streamed (jargon note + body).
+        already = (jargon_note + "\n\n" if jargon_note and cfg.jargon.show_transparency_note else "") + body
+        tail = rendered[len(already):]
         if tail:
             on_token(tail)
 
@@ -200,6 +244,7 @@ def answer(
         answer=body, rendered=rendered,
         gate=gate, retrieval=retrieval,
         latency_ms=int((time.monotonic() - t0) * 1000),
+        expanded_question=expanded_q, jargon_hits=jargon_hits,
     )
 
 

--- a/src/student_bot/bot/prompts.py
+++ b/src/student_bot/bot/prompts.py
@@ -99,18 +99,27 @@ def compose_messages(
     history: list[dict],
     chunks: list[RetrievedChunk],
     question: str,
+    glossary_md: str = "",
 ) -> list[dict]:
     """Build the OpenAI/Ollama-style message list.
 
     history: prior turns as [{"role": "user"|"assistant", "content": "..."}, ...].
+    glossary_md: optional pre-rendered "Ordlista / Glossary" block to inject
+    above the retrieved context. See `Jargon.glossary_block`.
     """
     messages: list[dict] = [{"role": "system", "content": system_prompt(cfg, lang)}]
     messages.extend(history)
 
     context = format_context(chunks)
-    label = "Kontext" if lang == "sv" else "Context"
-    user_block = f"{label}:\n{context}\n\n---\n\n{question}"
-    messages.append({"role": "user", "content": user_block})
+    ctx_label = "Kontext" if lang == "sv" else "Context"
+    parts: list[str] = []
+    if glossary_md:
+        parts.append(glossary_md)
+        parts.append("")
+    parts.append(f"{ctx_label}:\n{context}")
+    parts.append("---")
+    parts.append(question)
+    messages.append({"role": "user", "content": "\n\n".join(parts)})
     return messages
 
 

--- a/src/student_bot/config.py
+++ b/src/student_bot/config.py
@@ -107,6 +107,14 @@ class TopicsConfig(BaseModel):
     classifier_temperature: float = 0.0
 
 
+class JargonConfig(BaseModel):
+    enabled: bool = True
+    file: str = "dictionary.json"
+    proposals_file: str = "dictionary_proposals.json"
+    show_transparency_note: bool = True
+    max_glossary_entries: int = 6
+
+
 class MattermostSecrets(BaseModel):
     url: str
     port: int = 443
@@ -129,6 +137,7 @@ class Config(BaseModel):
     guardrails: GuardrailsConfig = Field(default_factory=GuardrailsConfig)
     web: WebConfig = Field(default_factory=WebConfig)
     topics: TopicsConfig = Field(default_factory=TopicsConfig)
+    jargon: JargonConfig = Field(default_factory=JargonConfig)
 
     # Secrets injected from env (only required when actually used).
     user_id_hash_salt: str | None = None

--- a/src/student_bot/jargon.py
+++ b/src/student_bot/jargon.py
@@ -1,0 +1,275 @@
+"""Jargon dictionary — query expansion + LLM glossary block.
+
+Loads `dictionary.json`, watches its mtime so admin edits take effect on
+the next query (no restart). Matches whole words case-insensitively after
+NFC normalisation, so "kex-jobb" and "KEX-jobb" hit the same entry whether
+the source is a Swedish-decomposed filename or a precomposed user message.
+
+Usage:
+    j = Jargon.from_config(cfg)
+    expanded, hits = j.expand_query("Hur fungerar KEX-jobb?", lang="sv")
+    glossary_md = j.glossary_block(hits, lang="sv")
+    note = j.transparency_note(hits, lang="sv")
+"""
+from __future__ import annotations
+
+import json
+import re
+import sys
+import time
+import unicodedata
+from dataclasses import dataclass
+from pathlib import Path
+from threading import Lock
+
+from student_bot.config import Config, get_config
+
+
+# --- data ---
+
+
+@dataclass
+class JargonEntry:
+    key: str             # lowercase NFC, used as dict key
+    term: str            # display capitalisation
+    expansion: str
+    lang: str            # "sv" | "en" | "any"
+    definition: str = ""
+    added_by: str = ""
+    added_ts: str = ""
+
+    def matches_lang(self, query_lang: str) -> bool:
+        if self.lang in ("any", ""):
+            return True
+        return self.lang == query_lang
+
+
+def _nfc_lower(s: str) -> str:
+    return unicodedata.normalize("NFC", s).lower()
+
+
+def _read_json(path: Path) -> dict:
+    if not path.exists():
+        return {"version": 1, "entries": {}}
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def _write_json(path: Path, data: dict) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    tmp = path.with_suffix(path.suffix + ".tmp")
+    tmp.write_text(json.dumps(data, ensure_ascii=False, indent=2) + "\n",
+                   encoding="utf-8")
+    tmp.replace(path)
+
+
+# --- main class ---
+
+
+class Jargon:
+    """Loader + matcher. Use `from_config(cfg)`; never instantiate elsewhere."""
+
+    def __init__(self, file_path: Path):
+        self._path = file_path
+        self._lock = Lock()
+        self._mtime = 0.0
+        self._entries: dict[str, JargonEntry] = {}
+        self._pattern: re.Pattern | None = None
+        self._reload_locked()
+
+    @classmethod
+    def from_config(cls, cfg: Config) -> "Jargon":
+        path = cfg.absolute(Path(cfg.jargon.file))
+        return cls(path)
+
+    # --- (re)load on mtime change ---
+
+    def _reload_if_changed(self) -> None:
+        with self._lock:
+            try:
+                mtime = self._path.stat().st_mtime if self._path.exists() else 0.0
+            except OSError:
+                mtime = 0.0
+            if mtime != self._mtime:
+                self._reload_locked()
+
+    def _reload_locked(self) -> None:
+        try:
+            data = _read_json(self._path)
+            entries_raw = data.get("entries", {})
+        except (OSError, json.JSONDecodeError):
+            entries_raw = {}
+        entries: dict[str, JargonEntry] = {}
+        for key, body in entries_raw.items():
+            if not isinstance(body, dict):
+                continue
+            term = body.get("term") or key
+            expansion = body.get("expansion", "")
+            if not expansion:
+                continue
+            entries[_nfc_lower(key)] = JargonEntry(
+                key=_nfc_lower(key),
+                term=term,
+                expansion=expansion,
+                lang=body.get("lang", "any") or "any",
+                definition=body.get("definition", "") or "",
+                added_by=body.get("added_by", "") or "",
+                added_ts=body.get("added_ts", "") or "",
+            )
+        self._entries = entries
+        self._pattern = self._compile(entries)
+        try:
+            self._mtime = self._path.stat().st_mtime if self._path.exists() else 0.0
+        except OSError:
+            self._mtime = 0.0
+
+    @staticmethod
+    def _compile(entries: dict[str, JargonEntry]) -> re.Pattern | None:
+        if not entries:
+            return None
+        # Longest-first so "kex-jobb" matches before a hypothetical "kex".
+        keys = sorted(entries.keys(), key=len, reverse=True)
+        alt = "|".join(re.escape(k) for k in keys)
+        # \b on both sides — works for terms whose first/last char is a word
+        # character. For terms ending in a non-word char we'd need a custom
+        # boundary, but every seeded entry is fine.
+        return re.compile(rf"\b({alt})\b", re.IGNORECASE | re.UNICODE)
+
+    # --- public API ---
+
+    def all_entries(self) -> list[JargonEntry]:
+        self._reload_if_changed()
+        return sorted(self._entries.values(), key=lambda e: e.key)
+
+    def find(self, text: str, *, lang: str | None = None) -> list[JargonEntry]:
+        """Unique entries hit by `text`, in order of first appearance."""
+        self._reload_if_changed()
+        if not text or not self._pattern:
+            return []
+        norm = unicodedata.normalize("NFC", text)
+        seen: set[str] = set()
+        hits: list[JargonEntry] = []
+        for m in self._pattern.finditer(norm):
+            key = _nfc_lower(m.group(1))
+            entry = self._entries.get(key)
+            if not entry or key in seen:
+                continue
+            if lang and not entry.matches_lang(lang):
+                continue
+            seen.add(key)
+            hits.append(entry)
+        return hits
+
+    def expand_query(
+        self, text: str, lang: str | None = None,
+    ) -> tuple[str, list[JargonEntry]]:
+        """Return (text-with-inline-expansions, hits). Each matched span is
+        followed by " (<expansion>)". The original surface form is preserved."""
+        self._reload_if_changed()
+        if not text or not self._pattern:
+            return text, []
+        hits = self.find(text, lang=lang)
+        if not hits:
+            return text, []
+        norm = unicodedata.normalize("NFC", text)
+        emitted: set[str] = set()
+
+        def repl(m: re.Match) -> str:
+            key = _nfc_lower(m.group(1))
+            entry = self._entries.get(key)
+            if not entry:
+                return m.group(0)
+            if lang and not entry.matches_lang(lang):
+                return m.group(0)
+            # Only add the expansion the first time per query so we don't
+            # spam if the user repeats the term.
+            if key in emitted:
+                return m.group(0)
+            emitted.add(key)
+            return f"{m.group(0)} ({entry.expansion})"
+
+        expanded = self._pattern.sub(repl, norm)
+        return expanded, hits
+
+    def glossary_block(
+        self, entries: list[JargonEntry], lang: str, max_entries: int = 6,
+    ) -> str:
+        """Markdown block for the LLM prompt. Empty string if no entries."""
+        if not entries:
+            return ""
+        label = "Ordlista" if lang == "sv" else "Glossary"
+        lines = [f"{label}:"]
+        for e in entries[:max_entries]:
+            base = f"- {e.term} = {e.expansion}"
+            if e.definition:
+                base += f". {e.definition}"
+            lines.append(base)
+        return "\n".join(lines)
+
+    def transparency_note(
+        self, entries: list[JargonEntry], lang: str,
+    ) -> str:
+        """One-line italic note shown above the answer. Empty if no hits."""
+        if not entries:
+            return ""
+        if lang == "en":
+            joined = ", ".join(f'"{e.term}" as "{e.expansion}"' for e in entries)
+            return f"_Reading {joined}._"
+        joined = ", ".join(f'"{e.term}" som "{e.expansion}"' for e in entries)
+        return f"_Tolkar {joined}._"
+
+    # --- mutators (used by the admin CLI and the suggestion endpoints) ---
+
+    def add_entry(self, entry: JargonEntry) -> None:
+        with self._lock:
+            data = _read_json(self._path)
+            entries = data.setdefault("entries", {})
+            entries[entry.key] = {
+                "term": entry.term,
+                "expansion": entry.expansion,
+                "lang": entry.lang,
+                "definition": entry.definition,
+                "added_by": entry.added_by,
+                "added_ts": entry.added_ts,
+            }
+            data["version"] = data.get("version", 1)
+            _write_json(self._path, data)
+            self._reload_locked()
+
+    def remove_entry(self, key: str) -> bool:
+        norm_key = _nfc_lower(key)
+        with self._lock:
+            data = _read_json(self._path)
+            entries = data.setdefault("entries", {})
+            if norm_key not in entries:
+                # Allow removal by `term` if user typed display form.
+                for k, v in list(entries.items()):
+                    if _nfc_lower(v.get("term", "")) == norm_key:
+                        norm_key = k
+                        break
+                else:
+                    return False
+            del entries[norm_key]
+            _write_json(self._path, data)
+            self._reload_locked()
+            return True
+
+
+__all__ = ["JargonEntry", "Jargon", "_nfc_lower", "_read_json", "_write_json"]
+
+
+if __name__ == "__main__":
+    cfg = get_config()
+    j = Jargon.from_config(cfg)
+    if len(sys.argv) < 2:
+        print(f"loaded {len(j.all_entries())} entries from {j._path}")
+        for e in j.all_entries():
+            print(f"  {e.term:<14} → {e.expansion}  [{e.lang}]")
+        sys.exit(0)
+    text = " ".join(sys.argv[1:])
+    expanded, hits = j.expand_query(text, lang="sv")
+    print(f"original  : {text}")
+    print(f"expanded  : {expanded}")
+    print("hits      :", [e.term for e in hits])
+    print("note      :", j.transparency_note(hits, "sv"))
+    print("glossary  :")
+    print(j.glossary_block(hits, "sv"))

--- a/src/student_bot/logging_db.py
+++ b/src/student_bot/logging_db.py
@@ -91,6 +91,12 @@ CREATE TABLE IF NOT EXISTS anon_counter (
 MIGRATIONS: list[tuple[str, str]] = [
     ("qa_log.topic", "ALTER TABLE qa_log ADD COLUMN topic TEXT"),
     ("qa_log.topic_confidence", "ALTER TABLE qa_log ADD COLUMN topic_confidence REAL"),
+    # Original `question` stays the user's typed text (for analytics).
+    # `question_expanded` captures the post-jargon-expansion query that was
+    # actually fed to retrieval. Useful for debugging "why did this query miss?"
+    ("qa_log.question_expanded", "ALTER TABLE qa_log ADD COLUMN question_expanded TEXT"),
+    # Comma-separated list of jargon term keys hit by this query.
+    ("qa_log.jargon_hits", "ALTER TABLE qa_log ADD COLUMN jargon_hits TEXT"),
 ]
 
 
@@ -205,6 +211,8 @@ class LogDB:
         gate_reason: str,
         answer: str,
         latency_ms: int,
+        question_expanded: str | None = None,
+        jargon_hits: list[str] | None = None,
     ) -> int | None:
         """Record a Q&A row, or skip (returning None) when the user opted out.
 
@@ -222,14 +230,16 @@ class LogDB:
                     ts, user_id_hash, channel_type, channel_id, bot_post_id, root_id,
                     question, lang, retrieved_chunk_ids,
                     rerank_top1, rerank_meanK, distinct_sources,
-                    gate_pass, gate_reason, answer, latency_ms
-                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                    gate_pass, gate_reason, answer, latency_ms,
+                    question_expanded, jargon_hits
+                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
                 """,
                 (
                     int(time.time()), uid, channel_type, channel_id, bot_post_id, root_id,
                     question, lang, json.dumps(retrieved_chunk_ids),
                     rerank_top1, rerank_meanK, distinct_sources,
                     1 if gate_pass else 0, gate_reason, answer, latency_ms,
+                    question_expanded, ",".join(jargon_hits or []) if jargon_hits else None,
                 ),
             )
             conn.commit()

--- a/src/student_bot/web/app.py
+++ b/src/student_bot/web/app.py
@@ -39,6 +39,7 @@ from student_bot.bot.memory import ConversationMemory
 from student_bot.bot.pipeline import answer
 from student_bot.bot.topics import classify
 from student_bot.config import PROJECT_ROOT, Config, get_config
+from student_bot.jargon import Jargon, _nfc_lower, _read_json, _write_json
 from student_bot.logging_db import LogDB
 from student_bot.web.auth import require_access
 
@@ -72,6 +73,13 @@ class FeedbackRequest(BaseModel):
 
 class ResetRequest(BaseModel):
     session_id: str
+
+
+class JargonSuggestRequest(BaseModel):
+    term: str
+    expansion: str
+    definition: str = ""
+    lang: str = "sv"
 
 
 # --- app factory ---
@@ -119,6 +127,37 @@ def create_app(cfg: Config | None = None) -> FastAPI:
     def stats(request: Request):
         require_access(request, cfg)
         return _stats_page(cfg, db)
+
+    @app.get("/glossary", response_class=HTMLResponse)
+    def glossary(request: Request):
+        require_access(request, cfg)
+        return _glossary_page(cfg)
+
+    @app.post("/api/jargon/suggest")
+    def jargon_suggest(request: Request, payload: JargonSuggestRequest):
+        ctx = require_access(request, cfg)
+        term = payload.term.strip()
+        expansion = payload.expansion.strip()
+        if not term or not expansion:
+            raise HTTPException(400, "term and expansion are required")
+        if len(term) > 64 or len(expansion) > 200 or len(payload.definition) > 500:
+            raise HTTPException(400, "field too long")
+        path = cfg.absolute(Path(cfg.jargon.proposals_file))
+        data = _read_json(path) if path.exists() else {"version": 1, "entries": {}}
+        entries = data.setdefault("entries", {})
+        entries[_nfc_lower(term)] = {
+            "term": term,
+            "expansion": expansion,
+            "lang": payload.lang or "sv",
+            "definition": payload.definition.strip(),
+            "added_by": "web",
+            "added_ts": __import__("time").strftime("%Y-%m-%d"),
+            "suggested_by_hash": db.hash_user(ctx.user or "anonymous-web"),
+            "suggested_ts": int(__import__("time").time()),
+            "status": "pending",
+        }
+        _write_json(path, data)
+        return {"ok": True}
 
     # --- API ---
 
@@ -273,6 +312,8 @@ def _stream_answer(cfg: Config, db: LogDB, memory: ConversationMemory,
             gate_reason=result.gate.reason,
             answer=result.answer,
             latency_ms=result.latency_ms,
+            question_expanded=result.expanded_question or None,
+            jargon_hits=[e.key for e in result.jargon_hits] or None,
         )
 
         if qa_id is not None and cfg.topics.enabled:
@@ -351,6 +392,67 @@ människa.</li>
 </main></body></html>
 """
     return HTMLResponse(body)
+
+
+def _glossary_page(cfg: Config) -> HTMLResponse:
+    j = Jargon.from_config(cfg)
+    rows = "".join(
+        f"<tr><td><code>{_h(e.term)}</code></td><td>{_h(e.expansion)}</td>"
+        f"<td>{_h(e.definition) or '—'}</td><td>{_h(e.lang)}</td></tr>"
+        for e in j.all_entries()
+    ) or '<tr><td colspan="4">no entries yet</td></tr>'
+    body = f"""
+<!doctype html><html><head><meta charset="utf-8"><title>Ordlista</title>
+<link rel="stylesheet" href="/static/style.css"></head>
+<body><header><h1>Ordlista</h1>
+<p class="tagline">Slang och förkortningar boten förstår. Saknar du något? Föreslå nedan, eller öppna en PR mot <code>dictionary.json</code>.</p>
+</header>
+<main class="card">
+<table border="1" cellpadding="6" cellspacing="0" style="width:100%; border-collapse: collapse;">
+<thead><tr><th>Term</th><th>Betydelse</th><th>Förklaring</th><th>Språk</th></tr></thead>
+<tbody>{rows}</tbody></table>
+
+<h2 style="margin-top: 24px">Föreslå en ny term</h2>
+<form id="jargon-form" onsubmit="return submitJargon(event);">
+  <label>Term: <input name="term" required maxlength="64" placeholder="t.ex. KS"></label>
+  <label>Betydelse: <input name="expansion" required maxlength="200" placeholder="kontrollskrivning"></label>
+  <label>Förklaring (valfritt): <input name="definition" maxlength="500"></label>
+  <label>Språk:
+    <select name="lang"><option value="sv">sv</option><option value="en">en</option><option value="any">any</option></select>
+  </label>
+  <button type="submit">Skicka förslag</button>
+  <span id="jargon-status" class="status"></span>
+</form>
+<p style="margin-top: 16px"><a href="/">← Tillbaka</a></p>
+</main>
+<script>
+async function submitJargon(e) {{
+  e.preventDefault();
+  const f = e.target;
+  const status = document.getElementById('jargon-status');
+  status.textContent = 'skickar…';
+  const r = await fetch('/api/jargon/suggest', {{
+    method: 'POST',
+    headers: {{ 'Content-Type': 'application/json' }},
+    body: JSON.stringify({{
+      term: f.term.value,
+      expansion: f.expansion.value,
+      definition: f.definition.value,
+      lang: f.lang.value,
+    }}),
+  }});
+  if (r.ok) {{ status.textContent = 'tack — förslaget köades för granskning'; f.reset(); }}
+  else {{ status.textContent = 'fel: ' + r.status; }}
+  return false;
+}}
+</script>
+</body></html>
+"""
+    return HTMLResponse(body)
+
+
+def _h(s: str) -> str:
+    return (s or "").replace("&", "&amp;").replace("<", "&lt;").replace(">", "&gt;")
 
 
 def _stats_page(cfg: Config, db: LogDB) -> HTMLResponse:

--- a/src/student_bot/web/static/index.html
+++ b/src/student_bot/web/static/index.html
@@ -51,6 +51,7 @@
 
 <footer>
   <a href="/about">Om boten</a> ·
+  <a href="/glossary">Ordlista</a> ·
   <a href="/stats">Statistik</a> ·
   <span id="conn"></span>
 </footer>


### PR DESCRIPTION
## Summary
Adds a student-jargon dictionary so the bot bridges informal terms (KEX-jobb, tenta, hp, PA…) to the formal phrasing in the corpus. Expansion happens at query time — no re-embedding needed — and is reloaded automatically when `dictionary.json` changes.

## What's new
- **`dictionary.json`** (committed, ~10 seed entries) and **`dictionary_proposals.json`** (gitignored queue for student suggestions).
- **`src/student_bot/jargon.py`** — NFC-aware, whole-word matcher with mtime-based hot reload. Returns `(expanded_query, hits)` for retrieval and helpers for the prompt's `Ordlista` / `Glossary` block and the user-facing transparency note.
- **`scripts/jargon.py`** — admin CLI: `list / add / remove / proposals / accept N / reject N`, wired as `student-bot-jargon`.

## How it shows up
- `pipeline.answer()` expands the query before retrieval, prepends `_Tolkar "KEX-jobb" som "kandidatexamensarbete"._` to the rendered output, and injects a glossary block into the LLM prompt so the model can address student wording while citing the formal source.
- Mattermost: `!jargon list` (table in the thread) and `!jargon suggest TERM = EXPANSION` (queues for admin review).
- Web UI: `/glossary` page with the same table plus a suggestion form (`POST /api/jargon/suggest`); footer link added to the chat UI.
- `prompts.compose_messages()` accepts an optional `glossary_md` parameter.
- `logging_db` migrated additively with `question_expanded` and `jargon_hits` columns; both Mattermost and web call sites populate them.
- `eval/run_eval.py` now applies the same expansion the bot uses so eval reflects production behaviour.

## Behaviour
- Whole-word, NFC, case-insensitive match → handles `KEX-jobb`, `kex-jobb`, `KEX-JOBB`; doesn't match `kex-jobben`/`kex-jobbet` (definite forms — known limitation).
- `lang` field on each entry filters out cross-language noise (Swedish-only entries don't get injected into English prompts).
- Per-query cap (`jargon.max_glossary_entries`, default 6) keeps the prompt budget tight.
- Transparency note is toggleable via `jargon.show_transparency_note`.

## Privacy / open-repo posture
- `dictionary_proposals.json` is gitignored — in-flight student suggestions never enter the public repo.
- Suggestions store a salted SHA-256 of the suggester's ID (same scheme as `qa_log`).
- `.gitignore` audit confirmed: `.env`, `data/chroma/`, `data/logs.sqlite*`, `data/web_users`, and `dictionary_proposals.json` are all excluded.
- The bot only does plain-text substitution from the dictionary — no code is loaded from JSON, so a poisoned PR can mislead retrieval but cannot escalate. PR review remains the gate.

## Verified
- CLI: `student-bot-cli "Vad är KEX-jobb?"` → transparency note appears, gate passes (top1=0.470), answer cites `Högskoleförordning #page=7` and four curriculum docs with clickable PDF page anchors, latency ~54 s.
- Proposal flow E2E: seeded a proposal → `student-bot-jargon proposals` listed it → `accept 1` moved it to canonical → `remove` cleaned up.
- Eval re-ran with expansion on the same path the bot uses; in-domain gate pass-rate 72% → 75%, OOD refusal still 100%.
- Two jargon-using questions added to `eval/eval_set.yml` so regressions on this path are caught.

## Test plan
- [ ] `uv run student-bot-jargon list` shows the seeded entries.
- [ ] `uv run student-bot-cli "Hur fungerar KEX-jobb?"` shows the transparency note above the answer and cites examensarbete sources.
- [ ] In Mattermost, send `!jargon suggest tenta = tentamen`; verify it appears under `student-bot-jargon proposals`.
- [ ] `student-bot-jargon accept 1` → next query for "tenta" picks up the new expansion without restart.
- [ ] Visit `/glossary` (web UI) → submit a suggestion via the form → confirm it lands in `dictionary_proposals.json`.
- [ ] `git status` before pushing — confirm `dictionary_proposals.json`, `.env`, and `data/` are not staged.