### PR TITLE
Filtering refs in Mattermost responses

### DIFF
--- a/src/student_bot/bot/citations.py
+++ b/src/student_bot/bot/citations.py
@@ -9,10 +9,14 @@ Citations are the bot's primary defence against blind trust:
 from __future__ import annotations
 
 import random
+import re
 from urllib.parse import quote
 
 from student_bot.bot.retrieval import RetrievedChunk
 from student_bot.config import Config
+
+
+_INLINE_CITATION_RE = re.compile(r"\[([^\[\]]+?)\]")
 
 
 def build_doc_url(rel_source: str, page_start: int | None, base_url: str) -> str:
@@ -98,6 +102,78 @@ def literacy_footer(lang: str, *, seed: int | None = None) -> str:
     return rng.choice(pool)
 
 
+def apply_citation_numbering(
+    body: str,
+    chunks: list[RetrievedChunk],
+) -> tuple[str, list[RetrievedChunk]]:
+    """Replace inline ``[Title · Section]`` citations in ``body`` with
+    ``[N]`` markers numbered in citation order, and return only the
+    chunks the model actually cited (one per (title, section, page)
+    dedup row, in citation order). Citations that don't match any
+    retrieved chunk are left in the body untouched.
+
+    Numbering happens server-side so every channel — Mattermost, CLI,
+    and the web UI — gets the same compact reference list and inline
+    `[N]` markers, instead of leaving filter+renumber logic to the
+    web client to repeat.
+    """
+    if not chunks:
+        return body, []
+
+    # Dedupe by the same key format_sources_block uses, so each Sources
+    # row maps to exactly one citation number.
+    rows: list[RetrievedChunk] = []
+    seen: dict[tuple, int] = {}
+    for c in chunks:
+        key = (c.doc_title, c.section_path or None, c.page_start)
+        if key not in seen:
+            seen[key] = len(rows)
+            rows.append(c)
+
+    by_full: dict[str, int] = {}
+    by_title: dict[str, list[int]] = {}
+    for i, c in enumerate(rows):
+        title = c.doc_title
+        section = c.section_path or ""
+        if section:
+            by_full[f"{title} — {section}"] = i
+            by_full[f"{title} · {section}"] = i
+        by_title.setdefault(title, []).append(i)
+
+    cited_indices: list[int] = []
+    number_for: dict[int, int] = {}
+
+    def _assign(idx: int) -> int:
+        n = number_for.get(idx)
+        if n is None:
+            n = len(cited_indices) + 1
+            number_for[idx] = n
+            cited_indices.append(idx)
+        return n
+
+    def _replace(m: re.Match) -> str:
+        content = m.group(1).strip()
+        idx = by_full.get(content)
+        if idx is None:
+            idx = by_full.get(content.replace(" · ", " — "))
+        if idx is None:
+            idx = by_full.get(content.replace(" — ", " · "))
+        if idx is None:
+            # Title-only fallback when unambiguous.
+            sep = content.find(" · ")
+            title = (content[:sep] if sep > -1 else content).strip()
+            candidates = by_title.get(title, [])
+            if len(candidates) == 1:
+                idx = candidates[0]
+        if idx is None:
+            return m.group(0)
+        return f"[{_assign(idx)}]"
+
+    new_body = _INLINE_CITATION_RE.sub(_replace, body)
+    cited = [rows[i] for i in cited_indices]
+    return new_body, cited
+
+
 def confidence_badge(lang: str, top1: float) -> str:
     """Tiny one-word confidence label derived from the gate's top1 score."""
     if top1 >= 3.0:
@@ -110,6 +186,7 @@ def confidence_badge(lang: str, top1: float) -> str:
 __all__ = [
     "build_doc_url",
     "format_sources_block",
+    "apply_citation_numbering",
     "literacy_footer",
     "confidence_badge",
 ]

--- a/src/student_bot/bot/pipeline.py
+++ b/src/student_bot/bot/pipeline.py
@@ -22,6 +22,7 @@ import click
 from rich.console import Console
 
 from student_bot.bot.citations import (
+    apply_citation_numbering,
     confidence_badge,
     format_sources_block,
     literacy_footer,
@@ -148,7 +149,9 @@ def _render(
 ) -> str:
     # Order: [jargon] + body + [conf badge] + [sources] + tip. Keeping
     # everything *after* the body makes the streaming tail (= rendered
-    # minus already-streamed prefix) a clean suffix.
+    # minus already-streamed prefix) a clean suffix. Citation numbering
+    # is applied separately by pipeline.answer() in the answered path,
+    # because rewriting body here would break the streaming-tail math.
     parts: list[str] = []
     if jargon_note and cfg.jargon.show_transparency_note:
         parts.append(jargon_note + "\n\n")
@@ -297,15 +300,42 @@ def answer(
         if on_token:
             on_token(body)
 
-    rendered = _render(cfg, lang, body, retrieval.reranked, gate,
-                       include_sources=True, jargon_note=jargon_note)
-    if on_token:
-        # Compute the tail from the rendered version *minus* what we've
-        # already streamed (jargon note + body).
-        already = (jargon_note + "\n\n" if jargon_note and cfg.jargon.show_transparency_note else "") + body
-        tail = rendered[len(already):]
-        if tail:
-            on_token(tail)
+    # Replace inline [Title · Section] citations with [N] numbering and
+    # trim the Sources block to only those actually cited (or fall back
+    # to all retrieved when the model cited nothing). Done server-side
+    # so Mattermost / CLI / web all get the same compact reference list.
+    sources_chunks = retrieval.reranked
+    numbered_body = body
+    if retrieval.reranked:
+        numbered_body, cited = apply_citation_numbering(body, retrieval.reranked)
+        sources_chunks = cited or retrieval.reranked
+
+    # Build everything that comes after the body: confidence badge,
+    # sources block, literacy tip. Same content for the streaming tail
+    # and for the final rendered string consumed by non-streaming
+    # channels (Mattermost, CLI --no-stream).
+    tail_parts: list[str] = []
+    if cfg.guardrails.show_confidence_badge:
+        label = "Tillförlitlighet" if lang == "sv" else "Confidence"
+        tail_parts.append(f"\n\n_{label}: {confidence_badge(lang, gate.top1)}_")
+    sources_md = format_sources_block(cfg, sources_chunks, lang)
+    if sources_md:
+        tail_parts.append(sources_md)
+    tail_parts.append("\n\n" + literacy_footer(lang))
+    tail = "".join(tail_parts)
+
+    if on_token and tail:
+        on_token(tail)
+
+    # `result.rendered` uses the numbered body so non-streaming consumers
+    # render with [N] inline. The streaming consumers (web) saw the raw
+    # body during the stream and re-render it client-side using the same
+    # numbering algorithm — the outputs match.
+    jargon_prefix = (
+        jargon_note + "\n\n"
+        if jargon_note and cfg.jargon.show_transparency_note else ""
+    )
+    rendered = (jargon_prefix + numbered_body + tail).strip()
 
     return AnswerResult(
         question=question, lang=lang, answered=answered,


### PR DESCRIPTION
Now filtering the references listed also in the Mattermost bot responses, not only via the web ui (was so far done client side there). Now only those used by LLM in response (rather than top 5 of the hits from the chroma db query) are listed, and the inline citations are brief numeric ones, explained through references listed at the end of the response.

<img width="853" height="463" alt="Screenshot 2026-05-04 at 08 14 52" src="https://github.com/user-attachments/assets/7dd08ace-5601-473c-81bf-ef36aea2ef59" />
