### PR TITLE
Improving bot knowledge base by adding sources based on analysis of conversation history

### DIFF
--- a/data/url_manifest_KTH.yaml
+++ b/data/url_manifest_KTH.yaml
@@ -1,64 +1,115 @@
 entries:
-  # - url: https://www.kth.se/student/kurser/program/CTFYS
-  #   # Defaults:
-  #   #   follow_links: false
-  #   #   max_depth: 1            # only used when follow_links: true (url_ingest.default_max_depth)
-  #   #   include_patterns: []    # include all paths
-  #   #   exclude_patterns: []    # exclude none
-  #   #   type_hint: auto         # html|pdf|auto
-  #   #   doc_title_override: ""  # use detected title if empty
-  #   follow_links: true
-  #   max_depth: 1
-  #   include_patterns:
-  #     - "/student/kurser/program/CTFYS/"
+  # Per-entry knobs (defaults shown):
+  #   follow_links: false
+  #   max_depth: 1            # only used when follow_links: true (default
+  #                           # comes from url_ingest.default_max_depth)
+  #   include_patterns: []    # regex on URL path; '^'-anchor recommended
+  #                           # so `/student/studier/val/` does not also
+  #                           # match `/student/studier/val-foo/`.
   #   exclude_patterns: []
-  #   type_hint: auto
-  #   doc_title_override: ""
+  #   type_hint: auto         # html|pdf|auto
+  #   doc_title_override: ""  # use detected title if empty
+  #   max_pages:              # per-entry override of
+  #                           # url_ingest.max_pages_per_seed; raise this
+  #                           # for content-rich section trees.
 
- - url: https://www.kth.se/student/kurser/kurser-inom-program
-   follow_links: false
-   max_depth: 1
-   include_patterns: []
-   exclude_patterns: []
-   type_hint: auto
-   doc_title_override: ""
+  - url: https://www.kth.se/student/kurser/kurser-inom-program
+    follow_links: false
+    max_depth: 1
+    include_patterns: []
+    exclude_patterns: []
+    type_hint: auto
+    doc_title_override: ""
 
- - url: https://www.kth.se/utbildning/anmalan-antagning-behorighet/antagning
-   follow_links: false
-   max_depth: 1
-   include_patterns: []
-   exclude_patterns: []
-   type_hint: auto
-   doc_title_override: ""
+  - url: https://www.kth.se/utbildning/anmalan-antagning-behorighet/antagning
+    follow_links: false
+    max_depth: 1
+    include_patterns: []
+    exclude_patterns: []
+    type_hint: auto
+    doc_title_override: ""
 
- - url: https://www.kth.se/student/studier/administrera/administrera-dina-studier
-   follow_links: false
-   max_depth: 1
-   include_patterns: []
-   exclude_patterns: []
-   type_hint: auto
-   doc_title_override: ""
+  # Widened to follow_links so the index page's section sub-pages
+  # (studieuppehall, tillgodoraknande, …) are pulled automatically.
+  - url: https://www.kth.se/student/studier/administrera/administrera-dina-studier
+    follow_links: true
+    max_depth: 1
+    include_patterns:
+      - "^/student/studier/administrera/"
+    exclude_patterns: []
+    type_hint: auto
+    doc_title_override: ""
 
- - url: https://www.kth.se/student/studier/kurs/kurs-och-examination
-   follow_links: true
-   max_depth: 2
-   include_patterns: []
-   exclude_patterns: []
-   type_hint: auto
-   doc_title_override: ""
+  - url: https://www.kth.se/student/studier/kurs/kurs-och-examination
+    follow_links: true
+    max_depth: 2
+    include_patterns: []
+    exclude_patterns: []
+    type_hint: auto
+    doc_title_override: ""
 
- - url: https://www.kth.se/student/studier/val
-   follow_links: false
-   max_depth: 1
-   include_patterns: []
-   exclude_patterns: []
-   type_hint: auto
-   doc_title_override: ""
+  # Widened to follow_links so masterprogram and val-under-studierna land
+  # in the corpus without separate seeds.
+  - url: https://www.kth.se/student/studier/val
+    follow_links: true
+    max_depth: 1
+    include_patterns:
+      - "^/student/studier/val/"
+    exclude_patterns: []
+    type_hint: auto
+    doc_title_override: ""
 
- - url: https://www.kth.se/student/stod/studier/fusk
-   follow_links: false
-   max_depth: 1
-   include_patterns:
-   exclude_patterns: []
-   type_hint: auto
-   doc_title_override: ""
+  - url: https://www.kth.se/student/stod/studier/fusk
+    follow_links: false
+    max_depth: 1
+    include_patterns: []
+    exclude_patterns: []
+    type_hint: auto
+    doc_title_override: ""
+
+  # Exchange-studies tree — content-rich (~14 sub-pages including funding,
+  # eligibility, partner universities). Bumped max_pages so we don't hit
+  # the global 12-page cap mid-section.
+  - url: https://www.kth.se/student/studier/utlandsstudier/utbyte
+    follow_links: true
+    max_depth: 2
+    include_patterns:
+      - "^/student/studier/utlandsstudier/utbyte/"
+    exclude_patterns: []
+    type_hint: auto
+    doc_title_override: ""
+    max_pages: 20
+
+  - url: https://www.kth.se/student/studier/examensarbete
+    follow_links: true
+    max_depth: 1
+    include_patterns:
+      - "^/student/studier/examensarbete"
+    exclude_patterns: []
+    type_hint: auto
+    doc_title_override: ""
+
+  - url: https://www.kth.se/student/studier/examen
+    follow_links: true
+    max_depth: 1
+    include_patterns:
+      - "^/student/studier/examen"
+    exclude_patterns: []
+    type_hint: auto
+    doc_title_override: ""
+
+  - url: https://www.kth.se/student/studier/rattigheter-och-skyldigheter
+    follow_links: false
+    max_depth: 0
+    include_patterns: []
+    exclude_patterns: []
+    type_hint: auto
+    doc_title_override: ""
+
+  - url: https://www.kth.se/student/studier/schema/lasarsindelning-1.912374
+    follow_links: false
+    max_depth: 0
+    include_patterns: []
+    exclude_patterns: []
+    type_hint: auto
+    doc_title_override: ""

--- a/eval/eval_set.yml
+++ b/eval/eval_set.yml
@@ -90,6 +90,31 @@
   kind: in_domain
   expected_doc_substring: "Utbildningsplan CTFYS HT2024 sve"
 
+# Regression coverage for failure clusters seen in production logs.
+- question: "Hur ansöker jag om studieuppehåll?"
+  lang: sv
+  kind: in_domain
+  expected_doc_substring: "studieuppehall"
+  notes: "qa_id 261, 262 — students asking how to apply for study leave."
+
+- question: "Hur många gånger får jag tenta om en kurs?"
+  lang: sv
+  kind: in_domain
+  expected_any: ["tentamensregler", "omregistrering-pa-kurs", "examination"]
+  notes: "qa_id 260 — re-exam attempt limit."
+
+- question: "Kan jag åka på utbytesstudier till USA?"
+  lang: sv
+  kind: in_domain
+  expected_any: ["utbyte", "utbytesstudier", "utbytesuniversitet"]
+  notes: "qa_id 263 — exchange-studies destination question."
+
+- question: "Hur väljer jag masterprogram inom mitt civilingenjörsprogram?"
+  lang: sv
+  kind: in_domain
+  expected_any: ["masteranmalan", "kthmastermassa", "masterprogram", "val-"]
+  notes: "qa_id 229, 232, 259 — master selection. Section parent /val/masterprogram is only reachable via the navigation pane (stripped at scrape), so the relevant pages are the sub-leaves masteranmalan and kthmastermassa plus the val parent."
+
 # ---------------- in-domain, English ----------------
 - question: "How do I appeal a grade?"
   lang: en

--- a/scripts/fetch_url_corpus.py
+++ b/scripts/fetch_url_corpus.py
@@ -42,6 +42,8 @@ class UrlSeed:
     exclude_patterns: list[str] | None = None
     type_hint: str = "auto"
     doc_title_override: str = ""
+    # Per-entry override of `cfg.url_ingest.max_pages_per_seed`. None = use global.
+    max_pages: int | None = None
 
 
 def _canonicalize_url(url: str) -> str:
@@ -76,6 +78,11 @@ def _load_manifest(path: Path, cfg: Config) -> list[UrlSeed]:
         include_list = include_raw if isinstance(include_raw, list) else []
         exclude_list = exclude_raw if isinstance(exclude_raw, list) else []
 
+        max_pages_raw = e.get("max_pages")
+        max_pages = (
+            int(max_pages_raw) if isinstance(max_pages_raw, int) and max_pages_raw > 0 else None
+        )
+
         out.append(
             UrlSeed(
                 url=_canonicalize_url(str(e["url"])),
@@ -85,6 +92,7 @@ def _load_manifest(path: Path, cfg: Config) -> list[UrlSeed]:
                 exclude_patterns=[str(x) for x in exclude_list] or None,
                 type_hint=str(e.get("type_hint", "auto")).lower(),
                 doc_title_override=str(e.get("doc_title_override", "")).strip(),
+                max_pages=max_pages,
             )
         )
     return out
@@ -160,11 +168,13 @@ def _extract_html_markdown(
         title = h1.get_text(" ", strip=True) or title
 
     lines: list[str] = []
-    for node in soup.select("h1,h2,h3,p,li,dt,dd"):
+    # H1 is captured into `title` above and re-emitted once by `_render_md`,
+    # so skip it here to avoid the page heading appearing twice in output.
+    for node in soup.select("h2,h3,p,li,dt,dd"):
         txt = _node_text_with_markdown_links(node, base_url, cfg)
         if not txt:
             continue
-        if node.name in ("h1", "h2", "h3"):
+        if node.name in ("h2", "h3"):
             lines.append(f"{'#' * int(node.name[1])} {txt}")
         else:
             lines.append(txt)
@@ -375,8 +385,9 @@ def main(limit_seeds: int | None) -> None:
         q: deque[tuple[str, int]] = deque([(seed.url, 0)])
         seen: set[str] = set()
         processed = 0
+        seed_cap = seed.max_pages or cfg.url_ingest.max_pages_per_seed
 
-        while q and processed < cfg.url_ingest.max_pages_per_seed:
+        while q and processed < seed_cap:
             url, depth = q.popleft()
             discovered_total += 1
             is_seed = depth == 0


### PR DESCRIPTION
Addressing #25.

# Expand KTH web corpus to fix recent answer failures

## Why
Production logs (`data/logs.sqlite`, last 24 h) showed clusters of refusals and low-confidence passes for questions whose answers live on `kth.se` pages that aren't in the corpus:
| qa_id | gate | topic |
|---|---|---|
| 263 | top1<-0.5 | utbytesstudier (Stanford) |
| 262 | top1<-0.5 | studieuppehåll (military leave) |
| 261 | pass top1=0.3 | studieuppehåll |
| 260 | top1<-0.5 | omtentamensregler |
| 229 / 232 / 259 | programme_clarification | masterprogram-val |
## What changed
### `scripts/fetch_url_corpus.py`

- Added an optional per-entry `max_pages` knob on `UrlSeed`, overriding the global `cfg.url_ingest.max_pages_per_seed`. Needed because `utlandsstudier/utbyte` has ~15 relevant sub-pages.
- Stopped emitting `<h1>` as a body heading in `_extract_html_markdown`. The first `<h1>` is still captured into `title` and rendered once by `_render_md`, so KTH pages no longer have a duplicated `# Title` line at the top of every scraped `.md`.
### `data/url_manifest_KTH.yaml`
- Re-indented to standard 2-space `entries:` nesting and added a comment block documenting every per-entry knob, including `max_pages`.
- Two existing entries widened to crawl their sections:
  - `administrera-dina-studier` → `follow_links: true`, depth 1, `include_patterns: ["^/student/studier/administrera/"]`. Pulls `studieuppehall-och-studieavbrott` and
`tillgodoraknande` automatically.
  - `val` → `follow_links: true`, depth 1, `include_patterns: ["^/student/studier/val/"]`. Pulls `masteranmalan`, `kthmastermassa`, `val-under-studierna`.
- Five new entries:
  - `utlandsstudier/utbyte` — `follow_links: true`, depth 2, `^/student/studier/utlandsstudier/utbyte/`, `max_pages: 20`.
  - `examensarbete` — `follow_links: true`, depth 1.
  - `examen` — `follow_links: true`, depth 1.
  - `rattigheter-och-skyldigheter` — leaf.
  - `schema/lasarsindelning-1.912374` — leaf.
### `eval/eval_set.yml`
Four new in-domain Swedish cases covering the failure clusters above (`Hur ansöker jag om studieuppehåll?`, `Hur många gånger får jag tenta om en kurs?`, `Kan jag åka på utbytesstudier till USA?`, `Hur väljer jag masterprogram inom mitt civilingenjörsprogram?`). Each links back to the originating `qa_id` in a `notes:` field.
## Verification

- `uv run student-bot-fetch-url-corpus`: 48 pages written in 6.5 s, full utbyte sub-tree captured plus all targeted leaf pages. 3 skips (`canvas.kth.se` host-blocked,
`antagning.se` / `student.ladok.se` outside ingest allowlist — expected).
- `uv run python -m scripts.reindex`: incremental, 79 files parsed, 1536 chunks total, 486 upserted.
- `uv run python -m eval.run_eval`: 4/4 new cases pass; in-domain pass-rate 26/36 = 72%, OOD refuse-rate 14/15 = 93%.
- `uv run ruff check` / `uv run ruff format --check`: clean.
## Notes

- Recall@5 on the existing eval set drifted (some pre-existing cases' `expected_doc_substring` now points at slugs that aren't optimal — e.g. for *"Hur överklagar jag ett betyg?"* the top-5 now leads with `Omprövning av betyg.pdf`, arguably more relevant than the originally expected `kursplan-betygssystem-och-examination`). Re-labelling those is a separate housekeeping pass.
- `/val/masterprogram` itself is only reachable via the navigation pane (stripped at scrape), so only its sub-leaves landed in the index. The masterprogram eval case accepts `masteranmalan` / `kthmastermassa` / `val-` accordingly.
- `data/url_manifest.yaml` is still empty/dead and can be removed in a follow-up housekeeping commit.