### PR TITLE
Export conversation, cosmetics, and eligibility-query improvements

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -35,6 +35,13 @@ COPY config.yaml ./
 COPY topics.yaml ./
 COPY data/dictionary.json ./data/dictionary.json
 
+# Surface the git version into the runtime env so the About page can show a
+# commit hash / release tag even though `.git/` is not copied into the image.
+# Pass at build time, e.g.
+#     docker compose build --build-arg STUDENT_BOT_VERSION=$(git rev-parse --short HEAD)
+ARG STUDENT_BOT_VERSION=""
+ENV STUDENT_BOT_VERSION=${STUDENT_BOT_VERSION}
+
 # Pre-cache the embedding + reranker models so the container is offline-ready.
 # Download happens at build time using the same library that loads them at runtime.
 ENV TRANSFORMERS_OFFLINE=0 \

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,9 @@
 services:
   bot:
-    build: .
+    build:
+      context: .
+      args:
+        STUDENT_BOT_VERSION: ${STUDENT_BOT_VERSION:-}
     image: student-bot:latest
     container_name: student-bot
     restart: unless-stopped
@@ -25,7 +28,10 @@ services:
 
   # Beta web UI (authenticated). Start alone: docker compose up -d beta-web
   beta-web:
-    build: .
+    build:
+      context: .
+      args:
+        STUDENT_BOT_VERSION: ${STUDENT_BOT_VERSION:-}
     image: student-bot:latest
     container_name: student-bot-beta-web
     restart: unless-stopped

--- a/src/student_bot/bot/web_retrieval.py
+++ b/src/student_bot/bot/web_retrieval.py
@@ -1335,6 +1335,30 @@ def _studyplan_chunks_from_year_page(
     raw_courses = target.get("courses")
     out: list[RetrievedChunk] = []
 
+    # If this year's page carries a "behörighetsgivande kurser per
+    # masterprogram" block, emit it as a dedicated, high-priority chunk so
+    # retrieval doesn't bury it inside the per-Valvillkor course tables.
+    elig_text = _eligibility_text_from_store(store)
+    if elig_text:
+        title_prefix = programme_name.strip() if programme_name else "Studieplan"
+        elig_body = (
+            f"## Årskurs {year} – behörighetsgivande kurser per masterprogram\n\n{elig_text}"
+        )
+        try:
+            out.append(
+                _build_studyplan_chunk(
+                    text=elig_body,
+                    page_url=page_url,
+                    fragment=f"arskurs{year}-behorighet-master",
+                    section_path=(f"Årskurs {year} – behörighetsgivande kurser per masterprogram"),
+                    doc_title=f"{title_prefix} årskurs {year}: behörighetsgivande kurser",
+                    fetched_at=fetched_at,
+                    is_stale=is_stale,
+                )
+            )
+        except ValueError:
+            pass
+
     # Some programs (e.g. CINEK arskurs1) ship the year-N course list as an
     # HTML string instead of a structured list. We can't bucket by Valvillkor
     # without parsing the HTML, so emit a single chunk preserving the markup
@@ -1555,6 +1579,198 @@ def _compressed_application_store(html: str) -> dict | None:
         return json.loads(unquote(m.group(1)))
     except (json.JSONDecodeError, ValueError):
         return None
+
+
+# Eligibility ("behörighetsgivande kurser") block extraction.
+#
+# Two formats observed on KTH study-plan pages, both expressing the same
+# information — which courses a student must complete to be eligible for a
+# given master programme. The block is critical for "what do I take in year 3
+# to qualify for the X master?" questions, but it doesn't always exist (some
+# programmes don't carry it; some terms have stopped including it). We extract
+# it as a dedicated, high-rank chunk so retrieval doesn't bury it in the
+# arskursN bucket-list noise — and so the cross-cohort fallback (when a year
+# is missing the block) has a clean payload to surface from a prior term.
+_ELIGIBILITY_RE = re.compile(r"(?im)beh[öo]righetsgivande\s+kurs(?:er|en)?\b")
+
+
+def _eligibility_text_from_store(store: dict | None) -> str | None:
+    """Return the cleanest behörighetsgivande block text in the SPA store.
+
+    Walks every string field, picks the longest one matching the regex (the
+    longer form usually has more master-programme entries), and strips HTML
+    to readable text. Returns None when no block exists.
+    """
+    if not isinstance(store, dict):
+        return None
+    candidates: list[str] = []
+
+    def _walk(node: object) -> None:
+        if isinstance(node, dict):
+            for v in node.values():
+                _walk(v)
+        elif isinstance(node, list):
+            for v in node:
+                _walk(v)
+        elif isinstance(node, str) and _ELIGIBILITY_RE.search(node):
+            candidates.append(node)
+
+    _walk(store)
+    if not candidates:
+        return None
+    candidates.sort(key=len, reverse=True)
+    text = _strip_html_to_text(candidates[0])
+    return text.strip() or None
+
+
+def _term_label_sv(term: str) -> str:
+    """KTH 5-digit programme term -> Swedish label, e.g. '20232' -> 'HT2023'."""
+    if not (isinstance(term, str) and re.fullmatch(r"\d{5}", term)):
+        return term or ""
+    season = "HT" if term[4] == "2" else "VT"
+    return f"{season}{term[:4]}"
+
+
+def _prior_term_year_urls(
+    programme_code: str,
+    current_term: str,
+    year: int,
+    store: dict | None,
+    *,
+    limit: int = 3,
+) -> list[str]:
+    """Year-page URLs for prior terms, most recent first. Used as fallback when
+    the requested term's page lacks the eligibility block."""
+    if not (programme_code and re.fullmatch(r"\d{5}", current_term or "")):
+        return []
+    base = f"https://www.kth.se/student/kurser/program/{programme_code}"
+    candidates: list[str] = []
+    # Prefer terms the page itself advertises (programmeTerms).
+    for t in _normalized_programme_terms_from_store(store):
+        if t < current_term:
+            candidates.append(f"{base}/{t}/arskurs{year}")
+    # Heuristic backstop: if the store had nothing useful, step back through
+    # plausible KTH term codes (same season N years prior, then opposite season).
+    if not candidates:
+        try:
+            yr = int(current_term[:4])
+            season = current_term[4]
+            for delta in (1, 2, 3):
+                candidates.append(f"{base}/{yr - delta}{season}/arskurs{year}")
+        except (ValueError, IndexError):
+            pass
+    # Dedupe preserving order
+    seen: set[str] = set()
+    out: list[str] = []
+    for u in candidates:
+        if u not in seen:
+            seen.add(u)
+            out.append(u)
+        if len(out) >= limit:
+            break
+    return out
+
+
+def _maybe_emit_fallback_eligibility(
+    *,
+    html: str,
+    final_url: str,
+    structured: list,
+    cfg: Config,
+    patterns,
+    cache,
+    visited: set,
+    chunks: list,
+    source_urls: list,
+) -> None:
+    """If a programme /arskursN page lacks an eligibility chunk, look back to
+    the most recent prior cohort that has one and append it as a labeled,
+    caveated chunk. No-op when the page already has the block, isn't a year
+    page, or no prior term yields a block.
+
+    Caps at one successful fallback fetch per call. Failed fetches log and
+    move on; we never raise out of this best-effort enrichment.
+    """
+    m = re.search(r"/program/([A-Z]{5})/(\d{5})/arskurs(\d+)/?$", urlsplit(final_url).path)
+    if not m:
+        return
+    if any(("behörighetsgivande" in (c.section_path or "").lower()) for c in structured):
+        return
+    programme_code, current_term, year_str = m.group(1), m.group(2), m.group(3)
+    try:
+        year = int(year_str)
+    except ValueError:
+        return
+    store = _compressed_application_store(html)
+    candidates = _prior_term_year_urls(programme_code, current_term, year, store, limit=3)
+    requested_label = _term_label_sv(current_term)
+    for prior_url in candidates:
+        if prior_url in visited:
+            continue
+        if not _is_allowed_url(prior_url, cfg, patterns):
+            continue
+        visited.add(prior_url)
+        try:
+            p_final, p_html = _fetch_html(prior_url, cfg)
+        except Exception as e:
+            log.info("eligibility-fallback: fetch failed for %s: %s", prior_url, e)
+            continue
+        if not _is_allowed_url(p_final, cfg, patterns):
+            continue
+        p_store = _compressed_application_store(p_html)
+        elig_text = _eligibility_text_from_store(p_store)
+        if not elig_text:
+            log.info("eligibility-fallback: no block on %s", p_final)
+            continue
+        # Resolve the prior term's label from the URL itself so the citation
+        # tells the user exactly which cohort the block came from.
+        pm = re.search(r"/program/[A-Z]{5}/(\d{5})/arskurs", urlsplit(p_final).path)
+        prior_term = pm.group(1) if pm else current_term
+        prior_label = _term_label_sv(prior_term)
+        programme_name = ""
+        if isinstance(p_store, dict):
+            programme_name = str(p_store.get("programmeName") or "").strip()
+        title_prefix = programme_name or "Studieplan"
+        # The caveat is intentionally bilingual-light Swedish only because
+        # the underlying corpus block is Swedish. The bot's reply prompt
+        # then renders this content in either lang.
+        body = (
+            "## Årskurs {year} – behörighetsgivande kurser per masterprogram "
+            "(från läsåret {prior})\n\n"
+            "**OBS!** Listan nedan är hämtad från utbildningsplanen för **{prior}** "
+            "eftersom **{requested}** ännu inte innehåller motsvarande avsnitt. "
+            "Reglerna är ofta stabila mellan årgångar men kan ha ändrats. "
+            "Verifiera mot ditt eget läsår eller med studievägledaren.\n\n"
+            "{elig}"
+        ).format(year=year, prior=prior_label, requested=requested_label, elig=elig_text)
+        now = int(time.time())
+        cache.put(CachedPage(url=p_final, title=title_prefix, content=body, fetched_at=now))
+        try:
+            chunk = _build_studyplan_chunk(
+                text=body,
+                page_url=p_final,
+                fragment=f"arskurs{year}-behorighet-master-fallback",
+                section_path=(
+                    f"Årskurs {year} – behörighetsgivande kurser per masterprogram "
+                    f"(läsår {prior_label})"
+                ),
+                doc_title=(
+                    f"{title_prefix} årskurs {year}: behörighetsgivande kurser ({prior_label})"
+                ),
+                fetched_at=now,
+                is_stale=False,
+            )
+        except ValueError:
+            continue
+        chunks.append(chunk)
+        if p_final not in source_urls:
+            source_urls.append(p_final)
+        log.info(
+            "eligibility-fallback: emitted block from %s -> requested %s",
+            prior_label,
+            requested_label,
+        )
+        return  # cap at one successful fallback
 
 
 def _normalized_programme_terms_from_store(store: dict | None) -> list[str]:
@@ -2187,6 +2403,23 @@ def maybe_fetch_dynamic_web(
                     "dynamic-web: emitted %d structured chunks from %s",
                     len(structured),
                     final_url,
+                )
+                # Cross-cohort fallback: if this is a /arskursN page that
+                # didn't yield an eligibility chunk for the requested term,
+                # fetch the most recent prior term that has one and surface
+                # its block as a labeled, caveated chunk. This handles the
+                # case where the läsårsplan for a fresh term hasn't been
+                # populated with the "behörighetsgivande kurser" section yet.
+                _maybe_emit_fallback_eligibility(
+                    html=html,
+                    final_url=final_url,
+                    structured=structured,
+                    cfg=cfg,
+                    patterns=patterns,
+                    cache=cache,
+                    visited=visited,
+                    chunks=chunks,
+                    source_urls=source_urls,
                 )
             else:
                 source_urls.append(final_url)

--- a/src/student_bot/web/app.py
+++ b/src/student_bot/web/app.py
@@ -672,14 +672,17 @@ _NOTICE_HTML = """\
 """
 
 # Shared header: centered brand cluster (KTH logo + title + Fraktur F)
-# with the language switch on the right. {tagline_html} is replaced per page.
+# with the language switch on the right. {tagline_html} is replaced per page;
+# {home} is the chat-home URL the brand title links back to.
 _HEADER_HTML = """\
 <header>
   <div class="brand">
     <img src="{static_prefix}/KTH_logo_RGB_bla.svg" alt="KTH" class="logo logo-kth">
-    <div class="brand-text">
-      <h1 data-i18n="brand.name"></h1>{tagline_html}
-    </div>
+    <a class="brand-link" href="{home}">
+      <div class="brand-text">
+        <h1 data-i18n="brand.name"></h1>{tagline_html}
+      </div>
+    </a>
     <img src="{static_prefix}/FrakturF2020.svg" alt="Fysiksektionen" class="logo logo-fyssek">
   </div>
   <div class="lang-switch" role="group" aria-label="Language">
@@ -692,8 +695,8 @@ _HEADER_HTML = """\
 # Loaded into <head> on every server-rendered page, before notice.js, so
 # data-i18n attributes are translated before any other scripts run.
 _NOTICE_SCRIPT = (
-    '<script src="{static_prefix}/i18n.js?v=26"></script>'
-    '<script src="{static_prefix}/notice.js?v=26" defer></script>'
+    '<script src="{static_prefix}/i18n.js?v=27"></script>'
+    '<script src="{static_prefix}/notice.js?v=27" defer></script>'
 )
 
 
@@ -705,15 +708,21 @@ def _about_page(cfg: Config, base_path: str = "") -> HTMLResponse:
     # server-side and append it after the translatable tip text.
     cl_html = f' (<a href="{link}">{link}</a>)' if link else ""
     version = get_version()
+    # Inline on the same row as the repo link, muted gray, so the version
+    # doesn't draw attention unless someone looks for it. Empty when
+    # `get_version()` can't determine anything (no STUDENT_BOT_VERSION env
+    # var, no `.git/` — typical inside Docker builds without the build arg).
     version_html = (
-        f' (<a href="{version.link}" target="_blank" rel="noopener">{version.display}</a>)'
+        f' <span class="version"> · '
+        f'<a href="{version.link}" target="_blank" rel="noopener">{version.display}</a>'
+        f"</span>"
         if version.display
         else ""
     )
     body = f"""
 <!doctype html><html lang="sv"><head><meta charset="utf-8"><title>student-bot</title>
-<link rel="stylesheet" href="{static_prefix}/style.css?v=26">{_NOTICE_SCRIPT.format(static_prefix=static_prefix)}</head>
-<body>{_HEADER_HTML.format(tagline_html="", static_prefix=static_prefix)}<main>{_NOTICE_HTML}<div class="card">
+<link rel="stylesheet" href="{static_prefix}/style.css?v=27">{_NOTICE_SCRIPT.format(static_prefix=static_prefix)}</head>
+<body>{_HEADER_HTML.format(tagline_html="", static_prefix=static_prefix, home=home)}<main>{_NOTICE_HTML}<div class="card">
 <h2 data-i18n="about.h2.what"></h2>
 <p data-i18n="about.what.body"></p>
 
@@ -754,8 +763,8 @@ def _glossary_page(cfg: Config, base_path: str = "") -> HTMLResponse:
     )
     body = f"""
 <!doctype html><html lang="sv"><head><meta charset="utf-8"><title>student-bot</title>
-<link rel="stylesheet" href="{static_prefix}/style.css?v=26">{_NOTICE_SCRIPT.format(static_prefix=static_prefix)}</head>
-<body>{_HEADER_HTML.format(tagline_html='<p class="tagline" data-i18n="glossary.tagline"></p>', static_prefix=static_prefix)}
+<link rel="stylesheet" href="{static_prefix}/style.css?v=27">{_NOTICE_SCRIPT.format(static_prefix=static_prefix)}</head>
+<body>{_HEADER_HTML.format(tagline_html='<p class="tagline" data-i18n="glossary.tagline"></p>', static_prefix=static_prefix, home=home)}
 <main>{_NOTICE_HTML}<div class="card">
 <table border="1" cellpadding="6" cellspacing="0" style="width:100%; border-collapse: collapse;">
 <thead><tr><th data-i18n="glossary.th.term"></th><th data-i18n="glossary.th.meaning"></th><th data-i18n="glossary.th.def"></th><th data-i18n="glossary.th.lang"></th></tr></thead>
@@ -865,8 +874,8 @@ def _md_doc_page(cfg: Config, docs_dir: Path, rel_source: str, base_path: str = 
 
     body = f"""
 <!doctype html><html lang="sv"><head><meta charset="utf-8"><title>{_h(doc.title)}</title>
-<link rel="stylesheet" href="{static_prefix}/style.css?v=26">{_NOTICE_SCRIPT.format(static_prefix=static_prefix)}</head>
-<body>{_HEADER_HTML.format(tagline_html="", static_prefix=static_prefix)}
+<link rel="stylesheet" href="{static_prefix}/style.css?v=27">{_NOTICE_SCRIPT.format(static_prefix=static_prefix)}</head>
+<body>{_HEADER_HTML.format(tagline_html="", static_prefix=static_prefix, home=home)}
 <main><div class="card md-doc">
 <nav class="md-nav">
   <a href="{home}"><span class="lang-sv">← Tillbaka till chatten</span><span class="lang-en">← Back to the chat</span></a>
@@ -1063,8 +1072,8 @@ def _stats_page(
 
     body = f"""
 <!doctype html><html lang="sv"><head><meta charset="utf-8"><title>student-bot</title>
-<link rel="stylesheet" href="{static_prefix}/style.css?v=26">{_NOTICE_SCRIPT.format(static_prefix=static_prefix)}</head>
-<body>{_HEADER_HTML.format(tagline_html="", static_prefix=static_prefix)}<main>{_NOTICE_HTML}<div class="card stats-card" data-channel="{channel}">
+<link rel="stylesheet" href="{static_prefix}/style.css?v=27">{_NOTICE_SCRIPT.format(static_prefix=static_prefix)}</head>
+<body>{_HEADER_HTML.format(tagline_html="", static_prefix=static_prefix, home=home)}<main>{_NOTICE_HTML}<div class="card stats-card" data-channel="{channel}">
 <h1 data-i18n="stats.title"></h1>
 {channel_switch_html}
 <p class="stats-summary" data-i18n="stats.summary"
@@ -1123,8 +1132,8 @@ def _stats_page(
 
 <p><a href="{home}" data-i18n="stats.back"></a></p>
 </div></main>
-<script src="{static_prefix}/vendor/chart.umd.min.js?v=26"></script>
-<script src="{static_prefix}/stats.js?v=26" defer></script>
+<script src="{static_prefix}/vendor/chart.umd.min.js?v=27"></script>
+<script src="{static_prefix}/stats.js?v=27" defer></script>
 </body></html>
 """
     return HTMLResponse(body)

--- a/src/student_bot/web/static/app.js
+++ b/src/student_bot/web/static/app.js
@@ -5,6 +5,10 @@ const state = {
   sessionId: localStorage.getItem("session_id") || crypto.randomUUID(),
   name: localStorage.getItem("name") || "",
   optOut: localStorage.getItem("opt_out") === "1",
+  // In-memory conversation log, mirroring what's on screen. Captured client
+  // side because that's where every conversation exists in full (the server
+  // skips qa_log writes for opted-out users). Used by exportThreadMarkdown().
+  thread: [],
 };
 localStorage.setItem("session_id", state.sessionId);
 
@@ -55,7 +59,13 @@ el("#reset").addEventListener("click", async () => {
     body: JSON.stringify({ session_id: state.sessionId }),
   }).catch(() => {});
   messages.innerHTML = "";
+  state.thread = [];
+  refreshExportButton();
   statusEl.textContent = window.t ? window.t("chat.newthread") : "ny tråd";
+});
+
+el("#export").addEventListener("click", () => {
+  exportThreadMarkdown();
 });
 
 // Enter submits, Shift+Enter (and Cmd/Ctrl+Enter) inserts a newline.
@@ -75,8 +85,23 @@ composer.addEventListener("submit", async (e) => {
   el("#question").value = "";
   el("#send").disabled = true;
   appendUser(q);
+  state.thread.push({ role: "user", ts: Date.now(), text: q });
+  refreshExportButton();
 
   const botMsg = appendBot();
+  const botEntry = {
+    role: "bot",
+    ts: Date.now(),
+    raw: "",            // full streamed text (filled at end)
+    body: "",           // body after splitMessage strips badge/sources/tip
+    jargon: "",         // jargon transparency prefix (if any)
+    confidence: "",     // confidence label, e.g. "high" / "low"
+    confidenceText: "", // localized confidence text ("Tillförlitlighet: hög")
+    sources: [],        // numbered, cited-only references
+    reaction: "",       // "positive" | "negative" | "" (only if user clicked)
+  };
+  state.thread.push(botEntry);
+  botMsg.entry = botEntry;
   let firstToken = true;
   const reqStartedAt = performance.now();
   let firstTokenAt = null;
@@ -329,6 +354,8 @@ function decorateBot(botMsg, meta) {
   // actually cited inline appear in the references list, renumbered
   // in order of first appearance.
   const raw = botMsg.body.textContent;
+  const prefixEl = botMsg.body.querySelector(".msg-prefix");
+  const jargonText = (prefixEl?.textContent || "").trim();
   const { body, sources: allSources, tip } = splitMessage(raw);
   const serverSources = Array.isArray(meta.sources) ? meta.sources : [];
   const sourceCandidates = Array.isArray(meta.source_candidates) ? meta.source_candidates : [];
@@ -356,6 +383,21 @@ function decorateBot(botMsg, meta) {
   if (tip) html += renderTip(tip);
   botMsg.body.innerHTML = html;
 
+  // Snapshot the parts of the answer we want to keep in the exportable
+  // thread log. `body` retains markdown links and inline citation markers;
+  // the export converts those to numbered links against `sources`.
+  if (botMsg.entry) {
+    botMsg.entry.raw = raw;
+    botMsg.entry.body = body;
+    botMsg.entry.jargon = jargonText;
+    botMsg.entry.confidence = meta.confidence_level || "";
+    botMsg.entry.confidenceText = meta.confidence || "";
+    botMsg.entry.sources = (citedSourcesWithUrls && citedSourcesWithUrls.length)
+      ? citedSourcesWithUrls
+      : (serverSources || []);
+    refreshExportButton();
+  }
+
   // Feedback buttons (only if we have a qa id).
   if (meta.qa_id) {
     const actions = document.createElement("div");
@@ -374,6 +416,7 @@ function decorateBot(botMsg, meta) {
       up.classList.remove("active");
       down.classList.remove("active");
       btn.classList.add("active");
+      if (botMsg.entry) botMsg.entry.reaction = sentiment;
     };
     up.addEventListener("click", () => send("positive", up));
     down.addEventListener("click", () => send("negative", down));
@@ -842,6 +885,130 @@ function renderMarkdown(text) {
   flushPara();
   flushList();
   return html;
+}
+
+// -----------------------------------------------------------------------------
+// Conversation export — write the in-memory thread to a Markdown blob the user
+// can save. The format is hand-rolled (no JS dep) and consciously preserves:
+//   - Speaker labels with timestamps (date + HH:MM in local time)
+//   - In-message body formatting (Markdown already; copied verbatim)
+//   - Numbered sources list with URLs after each bot turn
+//   - Reactions only when the user actually clicked 👍/👎
+// And consciously excludes:
+//   - Literacy tip footers (.tip)
+//   - The 👍/👎 buttons themselves (we record `reaction` instead)
+//   - Thinking-phase / streaming-only UI
+
+function refreshExportButton() {
+  const btn = document.getElementById("export");
+  if (!btn) return;
+  const has = state.thread && state.thread.length > 0;
+  btn.hidden = !has;
+}
+
+function pad2(n) { return n < 10 ? `0${n}` : `${n}`; }
+
+function formatExportTs(ts) {
+  const d = new Date(ts);
+  return (
+    `${d.getFullYear()}-${pad2(d.getMonth() + 1)}-${pad2(d.getDate())} ` +
+    `${pad2(d.getHours())}:${pad2(d.getMinutes())}`
+  );
+}
+
+function exportFilename(firstTs) {
+  const d = new Date(firstTs || Date.now());
+  return (
+    `student-bot-conversation-${d.getFullYear()}-${pad2(d.getMonth() + 1)}-` +
+    `${pad2(d.getDate())}-${pad2(d.getHours())}${pad2(d.getMinutes())}.md`
+  );
+}
+
+function exportBotName() {
+  return botDisplayName();
+}
+
+function exportUserName() {
+  const fallback = (window.t && window.t("export.user_default")) || "Användare";
+  return state.name && state.name.trim() ? state.name.trim() : fallback;
+}
+
+function exportSourcesHeading() {
+  return (window.t && window.t("export.sources_heading")) || "Källor";
+}
+
+function exportSourceLine(src) {
+  // Mirror `parseSourceLabel` in renderSources: split " — Section" suffix and
+  // trailing ", s. N" page so the markdown text reads as in the chat bubble.
+  const m = (src.label || "").match(/,\s*(?:s|p)\.\s*(\d+)\s*$/);
+  let title = src.label || "";
+  let page = "";
+  if (m) { page = m[1]; title = title.slice(0, m.index).trim(); }
+  let section = "";
+  const sepIdx = title.indexOf(" — ");
+  if (sepIdx > -1) { section = title.slice(sepIdx + 3).trim(); title = title.slice(0, sepIdx).trim(); }
+  let body = title;
+  if (section) body += ` — ${section}`;
+  if (page) body += `, s. ${page}`;
+  const href = (src.url || "").trim();
+  return href ? `[${body}](${href})` : body;
+}
+
+function exportThreadMarkdown() {
+  if (!state.thread.length) return;
+  const lines = [];
+  const firstTs = state.thread[0].ts;
+  for (const entry of state.thread) {
+    if (entry.role === "user") {
+      lines.push(`### ${exportUserName()} · ${formatExportTs(entry.ts)}`);
+      lines.push("");
+      lines.push(entry.text);
+      lines.push("");
+      lines.push("---");
+      lines.push("");
+      continue;
+    }
+    // Bot turn
+    let header = `### ${exportBotName()} · ${formatExportTs(entry.ts)}`;
+    if (entry.confidenceText) header += ` · _${entry.confidenceText}_`;
+    lines.push(header);
+    lines.push("");
+    if (entry.jargon) {
+      lines.push(`> ${entry.jargon}`);
+      lines.push("");
+    }
+    if (entry.body) {
+      lines.push(entry.body);
+      lines.push("");
+    }
+    if (entry.reaction === "positive") { lines.push("👍"); lines.push(""); }
+    else if (entry.reaction === "negative") { lines.push("👎"); lines.push(""); }
+    if (entry.sources && entry.sources.length) {
+      lines.push(`**${exportSourcesHeading()}:**`);
+      const numbered = entry.sources
+        .slice()
+        .sort((a, b) => (Number(a.n) || 0) - (Number(b.n) || 0));
+      let n = 1;
+      for (const s of numbered) {
+        lines.push(`${n}. ${exportSourceLine(s)}`);
+        n += 1;
+      }
+      lines.push("");
+    }
+    lines.push("---");
+    lines.push("");
+  }
+  const md = lines.join("\n").replace(/\n{3,}/g, "\n\n").trimEnd() + "\n";
+  const blob = new Blob([md], { type: "text/markdown;charset=utf-8" });
+  const url = URL.createObjectURL(blob);
+  const a = document.createElement("a");
+  a.href = url;
+  a.download = exportFilename(firstTs);
+  document.body.appendChild(a);
+  a.click();
+  a.remove();
+  // Defer revoke so Safari has time to read the blob.
+  setTimeout(() => URL.revokeObjectURL(url), 1000);
 }
 
 // Skip onboarding if name already set.

--- a/src/student_bot/web/static/i18n.js
+++ b/src/student_bot/web/static/i18n.js
@@ -10,7 +10,7 @@
   const T = {
     sv: {
       "brand.name": "Lux - adminbot",
-      "header.tagline": "Administrativ Q&A-bot för KTH CTFYS · baserad på officiella styrdokument och FAQ",
+      "header.tagline": "Administrativ Q&A-bot för KTH · baserad på officiella styrdokument och FAQ",
 
       "notice.title": "Experimentell testtjänst.",
       "notice.body": " Servern har begränsade resurser och språkmodellen är liten — svar kan vara långsamma och inte alltid korrekta. Första frågan kan ta extra lång tid medan modellen laddas. Använd gärna 👍 eller 👎 på svaren — feedback hjälper oss att förbättra tjänsten.",
@@ -30,6 +30,10 @@
       "chat.thinking": "tänker…",
       "chat.thinking_phase": "funderar…",
       "chat.newthread": "ny tråd",
+      "chat.export": "Exportera",
+      "chat.export.title": "Ladda ner konversationen som Markdown",
+      "export.user_default": "Användare",
+      "export.sources_heading": "Källor",
       "perf.context": "Kontext",
       "perf.tokens": "Generering",
       "perf.system": "System",
@@ -112,7 +116,7 @@
     },
     en: {
       "brand.name": "Lux - adminbot",
-      "header.tagline": "Administrative Q&A bot for KTH CTFYS · grounded in official steering documents and FAQs",
+      "header.tagline": "Administrative Q&A bot for KTH · grounded in official steering documents and FAQs",
 
       "notice.title": "Experimental test service.",
       "notice.body": " The server has limited resources and the language model is small — responses may be slow and not always correct. The first question can take noticeably longer while the model loads. Please use 👍 or 👎 on the replies — feedback helps us improve the service.",
@@ -132,6 +136,10 @@
       "chat.thinking": "thinking…",
       "chat.thinking_phase": "is thinking…",
       "chat.newthread": "new thread",
+      "chat.export": "Export",
+      "chat.export.title": "Download the conversation as Markdown",
+      "export.user_default": "User",
+      "export.sources_heading": "Sources",
       "perf.context": "Context",
       "perf.tokens": "Generation",
       "perf.system": "System",

--- a/src/student_bot/web/static/index.html
+++ b/src/student_bot/web/static/index.html
@@ -4,16 +4,18 @@
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <title>student-bot</title>
-<link rel="stylesheet" href="static/style.css?v=26">
+<link rel="stylesheet" href="static/style.css?v=27">
 </head>
 <body>
 <header>
   <div class="brand">
     <img src="static/KTH_logo_RGB_bla.svg" alt="KTH" class="logo logo-kth">
-    <div class="brand-text">
-      <h1 data-i18n="brand.name"></h1>
-      <p class="tagline" data-i18n="header.tagline"></p>
-    </div>
+    <a class="brand-link" href="./">
+      <div class="brand-text">
+        <h1 data-i18n="brand.name"></h1>
+        <p class="tagline" data-i18n="header.tagline"></p>
+      </div>
+    </a>
     <img src="static/FrakturF2020.svg" alt="Fysiksektionen" class="logo logo-fyssek">
   </div>
   <div class="lang-switch" role="group" aria-label="Language">
@@ -64,6 +66,8 @@
           <span id="status" class="status"></span>
         </div>
         <div class="composer-actions">
+          <button type="button" id="export" class="ghost" hidden
+                  data-i18n="chat.export" data-i18n-title="chat.export.title"></button>
           <button type="button" id="reset" class="ghost" data-i18n="chat.reset"></button>
           <button type="submit" id="send" data-i18n="chat.send"></button>
         </div>
@@ -79,8 +83,8 @@
   <span id="conn"></span>
 </footer>
 
-<script src="static/i18n.js?v=26"></script>
-<script src="static/notice.js?v=26" defer></script>
-<script src="static/app.js?v=26"></script>
+<script src="static/i18n.js?v=27"></script>
+<script src="static/notice.js?v=27" defer></script>
+<script src="static/app.js?v=27"></script>
 </body>
 </html>

--- a/src/student_bot/web/static/style.css
+++ b/src/student_bot/web/static/style.css
@@ -72,10 +72,14 @@ header { padding: 24px 32px 0; display: grid; grid-template-columns: 1fr auto 1f
 .brand-text { text-align: center; min-width: 0; }
 .brand-text h1 { margin: 0; }
 .brand-text .tagline { margin: 4px 0 0; }
-.logo { height: 40px; width: auto; flex-shrink: 0; display: block; }
+.brand-link { text-decoration: none; color: inherit; display: block; }
+.brand-link h1 { color: var(--kth-blue); transition: color 120ms ease; }
+.brand-link:hover h1,
+.brand-link:focus-visible h1 { color: var(--kth-skyblue); }
+.logo { height: 56px; width: auto; flex-shrink: 0; display: block; }
 /* The Fraktur F SVG has a square viewBox with whitespace around the glyph.
    A small upscale brings its visual weight in line with the KTH logo. */
-.logo-fyssek { height: 44px; }
+.logo-fyssek { height: 62px; }
 .lang-switch { grid-column: 3; justify-self: end; display: flex; gap: 4px; flex-shrink: 0; }
 .lang-switch button { background: transparent; color: var(--muted); border: 1px solid var(--border); border-radius: 4px; padding: 3px 9px; font-size: 12px; font-weight: 600; letter-spacing: 0.04em; cursor: pointer; }
 .lang-switch button:hover:not(.active) { color: var(--fg); border-color: var(--muted); }
@@ -213,6 +217,9 @@ button:disabled { opacity: 0.5; cursor: progress; }
 }
 .github-link a:hover { text-decoration: underline; }
 .github-mark { width: 16px; height: 16px; fill: currentColor; }
+.github-link .version { color: var(--muted); font-size: 13px; }
+.github-link .version a { color: inherit; text-decoration: none; display: inline; }
+.github-link .version a:hover { color: var(--fg); text-decoration: underline; }
 
 /* Curated-markdown viewer (/doc/<rel_source>) — typography for FAQ etc. */
 .md-doc { max-width: 760px; }

--- a/tests/fixtures/program_CELTE_20232_arskurs3.html
+++ b/tests/fixtures/program_CELTE_20232_arskurs3.html
@@ -1,0 +1,681 @@
+<!DOCTYPE html>
+<html lang="sv">
+
+<head>
+  <title>Civilingenjörsutbildning i elektroteknik (CELTE), Utbildningsplan kull HT2023, Årskurs 3 | KTH</title>
+  <meta charset="utf-8">
+  <meta http-equiv="X-UA-Compatible" content="IE=edge">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <meta name="description" content="">
+  <link rel="shortcut icon" id="favicon" href="/student/kurser/static/icon/favicon">
+
+
+  
+  
+  
+
+  <link href="/student/kurser/static/kth-style/css/kth-bootstrap.css?v=2.0.0-20260427.1_59b0" media="screen" rel="stylesheet">
+<link href="/student/kurser/assets/fonts.css?v=2.0.0-20260427.1_59b0" media="screen" rel="stylesheet">
+<link href="/student/kurser/static/app.css?v=2.0.0-20260427.1_59b0" media="screen" rel="stylesheet">
+
+    
+
+
+
+
+  <!-- Begin JavaScript contentId-1_1137647 -->
+  <script>var klaroConfig = {
+    testing: false,
+  acceptAll: true,
+  styling: {
+      theme: [],
+  },
+  htmlTexts: false,
+  groupByPurpose: false,
+  storageMethod: 'cookie',
+  cookieDomain: 'kth.se',
+  cookieExpiresAfterDays: 30,
+  hideDeclineAll: false,
+  translations: {
+      sv: {
+          service: {
+            disableAll: {
+              description: 'Använd detta reglage för att tillåta alla tjänster eller endast nödvändiga.',
+              title: 'Ändra för alla tjänster',
+            },
+          },
+          consentModal: {
+            description:
+              'Här kan du se och anpassa vilken information vi samlar om dig.',
+          },
+          privacyPolicy: {
+              name: 'kakor',
+              text: 'Läs mer om hur vi hanterar {privacyPolicy}.',
+          },
+          privacyPolicyUrl: 'https://www.kth.se/gemensamt/om-kakor-cookies-pa-kth-s-webbplats-1.844',
+          consentNotice: {
+              title: '',
+              testing: 'Observera att Klaro körs i testläge',
+              description: 'Denna webbplats använder tjänster som kan lagra information om dig och hur du använder denna webbplats. Vissa tjänster är nödvändiga för att webbplatsen ska fungera och andra är valbara.',
+              learnMore: 'Hantera valbara tjänster',
+          },
+          decline: 'Tillåt bara nödvändiga tjänster',
+          ok: 'Tillåt alla tjänster',
+          purposeItem: {
+              service: 'Tjänster'
+          },
+            contextualConsent:{
+                acceptAlways: 'Alltid',
+                acceptOnce: 'Ja',
+                description: 'Du har tidigare nekat visning av innehåll av typen "{title}". Vill du visa innehållet?',
+          }
+      },
+      en: {
+          service: {
+            disableAll: {
+              description: 'Use this slider to allow all cookies or only necessary.',
+              title: 'Change for all services',
+            },
+          },
+        consentModal: {
+            description:
+              'Here you can assess and customise the services we use on this website.',
+          },
+          privacyPolicy: {
+              name: 'cookies',
+              text: 'Find out more about our usage of {privacyPolicy}.',
+          },
+          privacyPolicyUrl: 'https://www.kth.se/en/gemensamt/om-kakor-cookies-pa-kth-s-webbplats-1.844',
+          consentNotice: {
+              title: '',
+              testing: 'Please note that Klaro is currently running in test mode',
+              description: 'This website uses services that may store information about you and how you use the website. Some services are necessary for the website to work, and others are optional.',
+              learnMore: 'Manage services',
+          },
+          decline: 'Accept only necessary services',
+          ok: 'Accept all services',
+          purposeItem: {
+              service: 'Services'
+          },
+            contextualConsent:{
+                acceptAlways: 'Always',
+                acceptOnce: 'Yes',
+                description: 'You have previously denied the display of content of the type "{title}". Do you want to show content?',
+          }
+      }
+  },
+  services: [
+      {
+          name: "required-consent",
+          default: true,
+          contextualConsentOnly: false,
+          required: true,
+          translations: {
+              zz: {
+                  title: 'Required Services',
+                  description: 'These services are necessary for the site to function and cannot be turned off. They are usually used when you utilise a function on the website that needs an answer, such as setting cookies, logging in, or filling in a form.'
+              },
+              sv: {
+                  title: 'Nödvändiga tjänster',
+                  description: 'Dessa tjänster är nödvändiga för att webbplatsen ska fungera och kan inte stängas av. De används främst när du nyttjar en funktion på webbplatsen som behöver ett svar, exempelvis ställer in kakor, loggar in eller fyller i formulär.'
+              },
+          },
+      },
+      {
+          name: "media-consent",
+          default: false,
+          translations: {
+              zz: {
+                  title: 'External media',
+                  description: 'Media on the site embedded from external providers like Youtube, Vimeo and Kaltura. When these are played, the providers may use cookies and local storage.'
+              },
+              sv: {
+                  title: 'Extern media',
+                  description: 'Inbäddad media från externa leverantörer som Youtube, Vimeo och Kaltura. När media spelas upp kan leverantörerna använda sig av kakor och lokal lagring.'
+              },
+          },
+      },
+      {
+        name: "service-consent",
+        default: false,
+        translations: {
+          zz: {
+            title: 'External Services',
+            description: 'Embedded services by external providers such as forms, maps, chat applications et c. When these are loaded, the providers may use cookies and local storage.'
+          },
+          sv: {
+            title: 'Externa tjänster',
+            description: 'Inbäddade tjänster från externa leverantörer såsom formulär, kartor, chat-funktion et c. När tjänsterna laddas in kan leverantörerna använda sig av kakor och lokal lagring.'
+          },
+        },
+      },
+      {
+          name: "analytics-consent",
+          default: false,
+          translations: {
+              zz: {
+                  title: 'Analytics and Tracking',
+                  description: 'The website uses Matomo to evaluate and improve the website content, experience and structure. The information collected is anonymised and only stored at KTH servers.'
+              },
+              sv: {
+                  title: 'Analys och spårning',
+                  description: 'Webbplatsen använder Matomo för att utvärdera och förbättra webbplatsens innehåll, upplevelse och struktur. Insamlandet av informationen anonymiseras och lagras enbart på KTH-servrar.'
+              },
+          },
+      },
+      {
+        name: "marketing-consent",
+        default: false,
+        translations: {
+            zz: {
+                title: 'Marketing',
+                description: 'The website contains pages that, via cookies, communicate with advertising services and social media.'
+            },
+            sv: {
+                title: 'Marknadsföring',
+                description: 'På webbplatsen förekommer sidor som via kakor kommunicerar med annonseringstjänster och sociala medier.'
+            },
+        },
+    }
+    
+  ]
+}</script>
+  
+  
+  <!-- End JavaScript contentId-1_1137647 -->
+
+
+
+    
+
+  
+  
+  
+  <script src="/student/kurser/static/kth-style/js/klaro-no-css.js?v=2.0.0-20260427.1_59b0"></script>
+<script src="/student/kurser/static/vendor.js?v=2.0.0-20260427.1_59b0"></script>
+<script src="/student/kurser/static/browserConfig?v=2.0.0-20260427.1_59b0"></script>
+<script src="/student/kurser/static/kth-style/js/backtotop.js?v=2.0.0-20260427.1_59b0"></script>
+
+  <script src="https://www.kth.se/social/toolbar/widget.js"></script>
+
+</head>
+
+<body>
+  <a class="skipToMainContent" href="#mainContent" tabindex="1">Hoppa till huvudinnehållet</a>
+  <!--indexOff: all-->
+  <header class="kth-header student-web">
+    <div class="kth-header__container">
+      <a href="/student" class="kth-logotype">
+        <figure>
+          <img class="blue" alt="Till KTH:s startsida" width="64" height="64" src="/student/kurser/assets/logotype/logotype-blue.svg">
+        </figure>
+      </a>      
+  
+  
+  
+  
+  
+    <nav class="kth-mega-menu" aria-label="Huvudmeny" data-ajax-path="/cm/1.1066510?l=sv&amp;contentIdPath=/2.75593/1.1066510/&amp;target=">
+      <ul>
+        
+          <li><button data-id="1.1066571" class="kth-menu-item dropdown">
+              <span>
+                Studier
+              </span>
+            </button>
+            <dialog class="kth-menu-panel">
+              <div class="kth-menu-panel__container">
+                <div class="kth-menu-panel__header">
+                  <div>
+                    <a href="/student/studier">
+                      <h2>
+                        Studier
+                      </h2>
+                    </a>
+                  </div>
+                  <button class="kth-icon-button close" title="Stäng" aria-label="Stäng">
+                    <span class="kth-visually-hidden">close</span>
+                  </button>
+                </div>
+                <div class="kth-menu-panel__content"></div>
+              </div>
+            </dialog>
+          </li>
+          <li><button data-id="1.1070324" class="kth-menu-item dropdown">
+              <span>
+                Stöd och vägledning
+              </span>
+            </button>
+            <dialog class="kth-menu-panel">
+              <div class="kth-menu-panel__container">
+                <div class="kth-menu-panel__header">
+                  <div>
+                    <a href="/student/stod">
+                      <h2>
+                        Stöd och vägledning
+                      </h2>
+                    </a>
+                  </div>
+                  <button class="kth-icon-button close" title="Stäng" aria-label="Stäng">
+                    <span class="kth-visually-hidden">close</span>
+                  </button>
+                </div>
+                <div class="kth-menu-panel__content"></div>
+              </div>
+            </dialog>
+          </li>
+          <li><button data-id="1.1178595" class="kth-menu-item dropdown">
+              <span>
+                IT och digitala tjänster
+              </span>
+            </button>
+            <dialog class="kth-menu-panel">
+              <div class="kth-menu-panel__container">
+                <div class="kth-menu-panel__header">
+                  <div>
+                    <a href="/student/it">
+                      <h2>
+                        IT och digitala tjänster
+                      </h2>
+                    </a>
+                  </div>
+                  <button class="kth-icon-button close" title="Stäng" aria-label="Stäng">
+                    <span class="kth-visually-hidden">close</span>
+                  </button>
+                </div>
+                <div class="kth-menu-panel__content"></div>
+              </div>
+            </dialog>
+          </li>
+          <li><button data-id="1.1178638" class="kth-menu-item dropdown">
+              <span>
+                Kontakt
+              </span>
+            </button>
+            <dialog class="kth-menu-panel">
+              <div class="kth-menu-panel__container">
+                <div class="kth-menu-panel__header">
+                  <div>
+                    <a href="/student/kontakt">
+                      <h2>
+                        Kontakt
+                      </h2>
+                    </a>
+                  </div>
+                  <button class="kth-icon-button close" title="Stäng" aria-label="Stäng">
+                    <span class="kth-visually-hidden">close</span>
+                  </button>
+                </div>
+                <div class="kth-menu-panel__content"></div>
+              </div>
+            </dialog>
+          </li>
+        
+      </ul>
+    </nav>
+  
+    <!-- Mobile menu -->
+    <nav class="kth-mega-menu--collapsable">
+      <dialog class="kth-mobile-menu">
+        <div class="kth-mobile-menu__navigation">
+          <button class="kth-icon-button close" title="Stäng" aria-label="Stäng">
+            <span class="kth-visually-hidden">Close</span>
+          </button>
+        </div>
+        <div class="kth-mobile-menu__content">
+          <ul class="kth-mobile-menu__items">
+            <li>
+              <button class="kth-mobile-menu__item" data-id="1.1066571">
+                <span>
+                  Studier
+                </span>
+              </button>
+              <dialog class="kth-menu-panel--modal">
+                <button class="kth-icon-button close" title="Stäng" aria-label="Stäng">
+                  <span class="kth-visually-hidden">Close</span>
+                </button>
+                <div class="kth-menu-panel__content"></div>
+              </dialog>
+            </li>
+            <li>
+              <button class="kth-mobile-menu__item" data-id="1.1070324">
+                <span>
+                  Stöd och vägledning
+                </span>
+              </button>
+              <dialog class="kth-menu-panel--modal">
+                <button class="kth-icon-button close" title="Stäng" aria-label="Stäng">
+                  <span class="kth-visually-hidden">Close</span>
+                </button>
+                <div class="kth-menu-panel__content"></div>
+              </dialog>
+            </li>
+            <li>
+              <button class="kth-mobile-menu__item" data-id="1.1178595">
+                <span>
+                  IT och digitala tjänster
+                </span>
+              </button>
+              <dialog class="kth-menu-panel--modal">
+                <button class="kth-icon-button close" title="Stäng" aria-label="Stäng">
+                  <span class="kth-visually-hidden">Close</span>
+                </button>
+                <div class="kth-menu-panel__content"></div>
+              </dialog>
+            </li>
+            <li>
+              <button class="kth-mobile-menu__item" data-id="1.1178638">
+                <span>
+                  Kontakt
+                </span>
+              </button>
+              <dialog class="kth-menu-panel--modal">
+                <button class="kth-icon-button close" title="Stäng" aria-label="Stäng">
+                  <span class="kth-visually-hidden">Close</span>
+                </button>
+                <div class="kth-menu-panel__content"></div>
+              </dialog>
+            </li>
+          </ul>
+        </div>
+      </dialog>
+      <dialog class="kth-mobile-menu details" data-id="1.1066571">
+        <div class="kth-mobile-menu__navigation">
+          <button class="kth-button back">Huvudmeny</button>
+          <button class="kth-icon-button close" title="Stäng" aria-label="Stäng">
+            <span class="kth-visually-hidden">Close</span>
+          </button>
+        </div>
+        <div class="kth-mobile-menu__header">
+          <a href="/student/studier">
+            <h2>
+              Studier
+            </h2>
+          </a>
+        </div>
+        <div class="kth-mobile-menu__content">
+          <div class="kth-mobile-menu__cortina-content"></div>
+        </div>
+      </dialog><dialog class="kth-mobile-menu details" data-id="1.1070324">
+        <div class="kth-mobile-menu__navigation">
+          <button class="kth-button back">Huvudmeny</button>
+          <button class="kth-icon-button close" title="Stäng" aria-label="Stäng">
+            <span class="kth-visually-hidden">Close</span>
+          </button>
+        </div>
+        <div class="kth-mobile-menu__header">
+          <a href="/student/stod">
+            <h2>
+              Stöd och vägledning
+            </h2>
+          </a>
+        </div>
+        <div class="kth-mobile-menu__content">
+          <div class="kth-mobile-menu__cortina-content"></div>
+        </div>
+      </dialog><dialog class="kth-mobile-menu details" data-id="1.1178595">
+        <div class="kth-mobile-menu__navigation">
+          <button class="kth-button back">Huvudmeny</button>
+          <button class="kth-icon-button close" title="Stäng" aria-label="Stäng">
+            <span class="kth-visually-hidden">Close</span>
+          </button>
+        </div>
+        <div class="kth-mobile-menu__header">
+          <a href="/student/it">
+            <h2>
+              IT och digitala tjänster
+            </h2>
+          </a>
+        </div>
+        <div class="kth-mobile-menu__content">
+          <div class="kth-mobile-menu__cortina-content"></div>
+        </div>
+      </dialog><dialog class="kth-mobile-menu details" data-id="1.1178638">
+        <div class="kth-mobile-menu__navigation">
+          <button class="kth-button back">Huvudmeny</button>
+          <button class="kth-icon-button close" title="Stäng" aria-label="Stäng">
+            <span class="kth-visually-hidden">Close</span>
+          </button>
+        </div>
+        <div class="kth-mobile-menu__header">
+          <a href="/student/kontakt">
+            <h2>
+              Kontakt
+            </h2>
+          </a>
+        </div>
+        <div class="kth-mobile-menu__content">
+          <div class="kth-mobile-menu__cortina-content"></div>
+        </div>
+      </dialog>
+    </nav>
+    <!-- Mobile menu -->
+  
+    
+    <script>/* eslint-disable no-unused-expressions, no-unused-vars, no-undef */"use strict";window.addEventListener("load",(()=>{function e(e){return document.querySelector(".kth-mega-menu[data-ajax-path]")?.getAttribute("data-ajax-path")+e}function t(){document.querySelectorAll("dialog").forEach((e=>e.close()))}function n(e){const n=e.querySelector(".kth-icon-button.close");e.addEventListener("keydown",(t=>{"Escape"===t.key&&e.close()})),n instanceof HTMLButtonElement&&n.addEventListener("click",(()=>{t()}))}function o(e,o){n(e),o.addEventListener("click",(n=>{n.preventDefault(),e.open?t():(t(),e.show())})),document.addEventListener("click",(n=>{!e.open||n.composedPath().includes(o)||n.composedPath().includes(e)||(n.preventDefault(),t())}))}function c(e,o,c){const i=e.querySelector(".kth-button.back");n(e),o.addEventListener("click",(n=>{n.preventDefault(),t(),e.showModal()})),i instanceof HTMLButtonElement&&i.addEventListener("click",(()=>{e.close(),c&&c.showModal()}))}var i,l;document.querySelectorAll(".kth-menu-item[data-id], .kth-menu-item--modal[data-id]").forEach((t=>{const n=t.nextElementSibling,o=n?.querySelector(".kth-menu-panel__content");if(!(t instanceof HTMLElement))return;if(!(n instanceof HTMLDialogElement))return;const c=t.dataset.id;let i;function l(){o instanceof HTMLElement&&(i||(i=fetch(e(c)).then((e=>e.text()))),i.then((e=>{o.innerHTML=e})))}t.addEventListener("mouseover",l),t.addEventListener("click",l)})),document.querySelectorAll(".kth-mobile-menu__item[data-id]").forEach((t=>{if(!(t instanceof HTMLElement))return;const n=t.dataset.id,o=document.querySelector(`.kth-mobile-menu[data-id='${n}']`),c=o?.querySelector(".kth-mobile-menu__cortina-content");if(!(o instanceof HTMLDialogElement))return;let i;t.addEventListener("click",(function(){c instanceof HTMLElement&&(i||(i=fetch(e(n)).then((e=>e.text()))),i.then((e=>{c.innerHTML=e})))}))})),function(e,n){if(e){for(const e of n){if(!(e instanceof HTMLElement))continue;const t=e.nextElementSibling;t instanceof HTMLDialogElement&&o(t,e)}e.addEventListener("focusout",(function(n){const o=n.relatedTarget;o&&o instanceof Node&&!e.contains(o)&&t()}))}}(document.querySelector(".kth-header"),document.querySelectorAll(".kth-mega-menu .kth-menu-item")),i=document.querySelector(".kth-menu-item.collapsable"),l=document.querySelector(".kth-mobile-menu"),i instanceof HTMLElement&&l instanceof HTMLDialogElement&&c(l,i),function(e,t){if(!t||t instanceof HTMLDialogElement)for(const n of e){if(!(n instanceof HTMLElement))continue;const e=n.getAttribute("data-id"),o=document.querySelector(`.kth-mobile-menu[data-id='${e}']`);if(!(o instanceof HTMLDialogElement))return;c(o,n,t)}}(document.querySelectorAll(".kth-mobile-menu__item"),document.querySelector(".kth-mobile-menu"))})),window.addEventListener("load",(()=>{const e={threshold:32,className:"collapsed"};function t(e,{threshold:t,className:n}){window.scrollY>t?e?.classList.add(n):e?.classList.remove(n)}!function(n,o=e){t(n,o),window.addEventListener("scroll",(()=>{t(n,o)}))}(document.querySelector(".kth-header"))}));</script>
+  
+  
+  
+      <ul class="kth-header__tools">
+        <li><button class="kth-menu-item search">
+      <span>Sök</span>
+  </button>
+  <dialog class="kth-menu-panel">
+      <div class="kth-menu-panel__container search">
+          <button class="kth-icon-button close">
+              <span class="kth-visually-hidden">Stäng</span>
+          </button>
+          <div class="kth-menu-panel__content">
+                  
+  
+  
+  
+  
+    <div class="block search mainWidget default-size" data-cid="1.1066521" lang="sv">
+      <div id="widget_yhnutasc" class="searchWidgetContainer"><div class="searchWidget"><div class="searchInputBar"><form class="searchInputForm" method="GET" role="search" action="https://www.kth.se/search"><div class="searchAutoCompleteField kth-search"><label for="widget_yhnutasc_search__Field">Sök på Studentwebben</label><input id="widget_yhnutasc_search__Field" name="q" autoComplete="off" type="text" maxLength="1024" value=""/><button type="submit"><span class="kth-visually-hidden">Sök</span></button></div><input type="hidden" name="urlFilter" value="https://www.kth.se/student"/><input type="hidden" name="entityFilter" value="kth-profile,kth-course,kth-place,kth-program,kth-system"/><input type="hidden" name="metaSystemFilter" value=""/><input type="hidden" name="documentFilter" value=""/><input type="hidden" name="filterLabel" value="Sök på Studentwebben"/><input type="hidden" name="l" value="sv"/><input type="hidden" name="noscript" class="noscriptInput" value=""/></form></div><div class="searchAlternativesWidget"><div class="searchAlternativesWidgetLinks"><a href="https://www.kth.se/search?l=sv">Sök på KTH:s webbplats</a><a href="https://intra.kth.se/search?l=sv">Sök på KTH Intranät</a></div></div></div></div>
+  
+  <script>
+    (() => {
+      const SCRIPT_PATH = 'https://www.kth.se/search/static/widget.js?v=2.0.0-20250606.1_9d7abae6'
+      const STYLE_PATH = 'https://www.kth.se/search/static/widget.css?v=2.0.0-20250606.1_9d7abae6'
+      const DATA_PATH = 'https://www.kth.se/search/widgetData.js?widgetId=widget_yhnutasc&filterLabel=S%C3%B6k%20p%C3%A5%20Studentwebben&placeholder=S%C3%B6k%20p%C3%A5%20KTH%3As%20webbplats&urlFilter=https%3A%2F%2Fwww.kth.se%2Fstudent&isFilterRemovable=false&entityFilter=kth-profile%2Ckth-course%2Ckth-place%2Ckth-program%2Ckth-system&l=sv&includeLinks=true'
+      const WIDGET_ID = 'widget_yhnutasc'
+      const scriptAnchor = document.currentScript
+  
+      const observer = new IntersectionObserver((entries, observer) => {
+  
+        if (entries[0].target?.checkVisibility?.()) {
+  
+          if (!window.searchWidgetIsLoaded) {
+  
+            const styleElement = document.createElement('link')
+            styleElement.href = STYLE_PATH
+            styleElement.media = "screen"
+            styleElement.rel = "stylesheet"
+            styleElement.async = 1
+            scriptAnchor.after(styleElement)
+  
+            const scriptElement = document.createElement('script')
+            scriptElement.src = SCRIPT_PATH
+            scriptElement.async = 1
+            scriptAnchor.after(scriptElement)
+          }
+  
+          const dataElement = document.createElement('script')
+          dataElement.src = DATA_PATH
+          dataElement.async = 1
+          scriptAnchor.after(dataElement)
+  
+          window.searchWidgetIsLoaded = true
+          observer.disconnect()
+        }
+      }).observe(document.getElementById(WIDGET_ID))
+    })()
+  </script>
+      
+      <script>/* eslint-disable no-unused-expressions, no-unused-vars, no-undef */"use strict";!function(){function e(){document.querySelectorAll("dialog").forEach((e=>e.close()))}window.addEventListener("load",(function(){document.querySelectorAll(".block.search").forEach((t=>{t.parentElement.className.includes("kth-menu-panel__content")&&function(t,n){if(!(n instanceof HTMLElement))return;const c=n.nextElementSibling;if(!(c instanceof HTMLDialogElement))return;c.addEventListener("keydown",(t=>{"Escape"===t.key&&e()}));const o=c.querySelector(".close");o instanceof HTMLButtonElement&&o.addEventListener("click",(()=>{e()})),n.addEventListener("click",(n=>{n.preventDefault(),c.open?e():(e(),c.show(),function(e){const t=e.querySelector("template");if(null===t)return;const n=t.content;t.replaceWith(n)}(t),function(e){const t=e.querySelector(".searchAutoCompleteField")?.querySelector("input");t&&t.focus()}(c))})),document.addEventListener("click",(t=>{!c.open||t.composedPath().includes(n)||t.composedPath().includes(c)||(t.preventDefault(),e())}))}(t,document.querySelector(".kth-menu-item.search"))}))}))}();</script>
+    </div>
+  
+  
+  
+          </div>
+      </div>
+  </dialog></li>
+        <li><a class="kth-menu-item language" hreflang="en-US" href="?l=en">English</a></li>
+      </ul>
+      <button class="kth-menu-item menu collapsable">
+        <span>Meny</span>
+      </button>
+    </div>
+  </header>
+  <div class="kth-content articleNavigation">
+    <div class="row justify-content-between">
+      
+    <nav id="breadcrumbs" aria-label="Brödsmulor" class="kth-breadcrumbs">
+      <ol class="kth-breadcrumbs__list">
+        <li><a href="/student">Studentwebben</a></li><li><a href="/student/studier">Studier</a></li><li><a href="/student/kurser/kurser-inom-program">Kurs- och programkatalogen</a></li><li><a href="/student/kurser/program/CELTE">Civilingenjörsutbildning i elektroteknik</a></li>
+      </ol>
+    </nav>
+   
+    </div>
+  </div>
+  <!--indexOn: all-->  <div class="kth-content">
+    <div class="row">
+        <script>window.__compressedApplicationStore__ = "%7B%22browserConfig%22%3A%7B%22proxyPrefixPath%22%3A%7B%22uri%22%3A%22%2Fstudent%2Fkurser%22%2C%22searchPage%22%3A%22%2Fstudent%2Fkurser%2Fsokkurs%22%2C%22searchResult%22%3A%22%2Fstudent%2Fkurser%2Fsokkurs%2Fresultat%22%2C%22courseSearchInternApi%22%3A%22%2Fstudent%2Fkurser%2Fintern-api%2Fsok%22%2C%22department%22%3A%22%2Fstudent%2Fkurser%2Forg%22%2C%22programme%22%3A%22%2Fstudent%2Fkurser%2Fprogram%22%2C%22programmesList%22%3A%22%2Fstudent%2Fkurser%2Fkurser-inom-program%22%2C%22schoolsList%22%3A%22%2Fstudent%2Fkurser%2Fprogram%22%2C%22studyHandbook%22%3A%22%2Fstudent%2Fprogram%2Fshb%22%2C%22thirdCycleCourseSearch%22%3A%22%2Futbildning%2Fforskarutbildning%2Fkurser%2Fsok%22%2C%22thirdCycleCourseSearchResult%22%3A%22%2Futbildning%2Fforskarutbildning%2Fkurser%2Fsok%2Fresultat%22%2C%22thirdCycleSchoolsAndDepartments%22%3A%22%2Futbildning%2Fforskarutbildning%2Fkurser%2Favdelning%22%2C%22thirdCycleCoursesPerDepartment%22%3A%22%2Futbildning%2Fforskarutbildning%2Fkurser%2Forg%22%2C%22programmeSyllabusPDF%22%3A%22%2Fstudent%2Fkurser%2Fintern-api%2FPDFRenderFunction%22%7D%2C%22redirectProxyPath%22%3A%7B%22studentRoot%22%3A%22%2Fstudent%2Fkurser%22%2C%22thirdCycleRoot%22%3A%22%2Futbildning%2Fforskarutbildning%2Fkurser%22%2C%22coursesPerDepartment%22%3A%22%2Fstudent%2Fkurser%2Fkurser-per-avdelning%22%2C%22departmentCourses%22%3A%22%2Fstudent%2Fkurser%2Favdelning%2F%3AdepartmentCode%2Fkurser%2F%22%7D%2C%22markHtmlFromKopps%22%3Afalse%2C%22markHtmlFromLadok%22%3Afalse%2C%22env%22%3A%22prod%22%7D%2C%22statusCode%22%3A200%2C%22language%22%3A%22sv%22%2C%22languageIndex%22%3A1%2C%22programmeCode%22%3A%22CELTE%22%2C%22programmeName%22%3A%22Civilingenj%C3%B6rsutbildning%20i%20elektroteknik%22%2C%22owningSchoolCode%22%3A%22EECS%2FSkolan%20f%C3%B6r%20elektroteknik%20och%20datavetenskap%22%2C%22term%22%3A%2220232%22%2C%22studyYear%22%3A%223%22%2C%22curriculums%22%3A%5B%7B%22studyYears%22%3A%5B%7B%22yearNumber%22%3A1%2C%22courses%22%3A%22%3Ch3%20id%3D%5C%22gemensammakurser%5C%22%3EGemensamma%20kurser%3C%2Fh3%3E%5Cn%3Ch4%20id%3D%5C%22obligatoriskakurser%5C%22%3EObligatoriska%20kurser%3C%2Fh4%3E%5Cn%3Ctable%3E%5Cn%3Cthead%3E%5Cn%3Ctr%3E%5Cn%3Cth%3EKurskod%3C%2Fth%3E%5Cn%3Cth%3EKursnamn%3C%2Fth%3E%5Cn%3Cth%3EOmfattning%3C%2Fth%3E%5Cn%3Cth%3EUtbildningsniv%C3%A5%3C%2Fth%3E%5Cn%3C%2Ftr%3E%5Cn%3C%2Fthead%3E%5Cn%3Ctbody%3E%5Cn%3Ctr%3E%5Cn%3Ctd%3EDD1310%3C%2Ftd%3E%5Cn%3Ctd%3EProgrammeringsteknik%3C%2Ftd%3E%5Cn%3Ctd%3E6%20hp%3C%2Ftd%3E%5Cn%3Ctd%3EGrundniv%C3%A5%3C%2Ftd%3E%5Cn%3C%2Ftr%3E%5Cn%3Ctr%3E%5Cn%3Ctd%3EEH1010%3C%2Ftd%3E%5Cn%3Ctd%3EElektroprojekt%3C%2Ftd%3E%5Cn%3Ctd%3E7.5%20hp%3C%2Ftd%3E%5Cn%3Ctd%3EGrundniv%C3%A5%3C%2Ftd%3E%5Cn%3C%2Ftr%3E%5Cn%3Ctr%3E%5Cn%3Ctd%3EEH1110%3C%2Ftd%3E%5Cn%3Ctd%3EElektroteknikens%20betydelse%20f%C3%B6r%20ett%20modernt%20samh%C3%A4lle%3C%2Ftd%3E%5Cn%3Ctd%3E7.5%20hp%3C%2Ftd%3E%5Cn%3Ctd%3EGrundniv%C3%A5%3C%2Ftd%3E%5Cn%3C%2Ftr%3E%5Cn%3Ctr%3E%5Cn%3Ctd%3EEI1110%3C%2Ftd%3E%5Cn%3Ctd%3EElkretsanalys%2C%20ut%C3%B6kad%20kurs%3C%2Ftd%3E%5Cn%3Ctd%3E9%20hp%3C%2Ftd%3E%5Cn%3Ctd%3EGrundniv%C3%A5%3C%2Ftd%3E%5Cn%3C%2Ftr%3E%5Cn%3Ctr%3E%5Cn%3Ctd%3EEP1200%3C%2Ftd%3E%5Cn%3Ctd%3EIntroduktion%20till%20datorsystemteknik%3C%2Ftd%3E%5Cn%3Ctd%3E6%20hp%3C%2Ftd%3E%5Cn%3Ctd%3EGrundniv%C3%A5%3C%2Ftd%3E%5Cn%3C%2Ftr%3E%5Cn%3Ctr%3E%5Cn%3Ctd%3EIE1205%3C%2Ftd%3E%5Cn%3Ctd%3EDigital%20design%3C%2Ftd%3E%5Cn%3Ctd%3E6%20hp%3C%2Ftd%3E%5Cn%3Ctd%3EGrundniv%C3%A5%3C%2Ftd%3E%5Cn%3C%2Ftr%3E%5Cn%3Ctr%3E%5Cn%3Ctd%3ESF1624%3C%2Ftd%3E%5Cn%3Ctd%3EAlgebra%20och%20geometri%3C%2Ftd%3E%5Cn%3Ctd%3E7.5%20hp%3C%2Ftd%3E%5Cn%3Ctd%3EGrundniv%C3%A5%3C%2Ftd%3E%5Cn%3C%2Ftr%3E%5Cn%3Ctr%3E%5Cn%3Ctd%3ESF1625%3C%2Ftd%3E%5Cn%3Ctd%3EEnvariabelanalys%3C%2Ftd%3E%5Cn%3Ctd%3E7.5%20hp%3C%2Ftd%3E%5Cn%3Ctd%3EGrundniv%C3%A5%3C%2Ftd%3E%5Cn%3C%2Ftr%3E%5Cn%3Ctr%3E%5Cn%3Ctd%3ESF1626%3C%2Ftd%3E%5Cn%3Ctd%3EFlervariabelanalys%3C%2Ftd%3E%5Cn%3Ctd%3E7.5%20hp%3C%2Ftd%3E%5Cn%3Ctd%3EGrundniv%C3%A5%3C%2Ftd%3E%5Cn%3C%2Ftr%3E%5Cn%3C%2Ftbody%3E%5Cn%3C%2Ftable%3E%22%2C%22freeTexts%22%3A%5B%5D%7D%2C%7B%22yearNumber%22%3A2%2C%22courses%22%3A%22%3Ch3%20id%3D%5C%22gemensammakurser%5C%22%3EGemensamma%20kurser%3C%2Fh3%3E%5Cn%3Ch4%20id%3D%5C%22obligatoriskakurser%5C%22%3EObligatoriska%20kurser%3C%2Fh4%3E%5Cn%3Ctable%3E%5Cn%3Cthead%3E%5Cn%3Ctr%3E%5Cn%3Cth%3EKurskod%3C%2Fth%3E%5Cn%3Cth%3EKursnamn%3C%2Fth%3E%5Cn%3Cth%3EOmfattning%3C%2Fth%3E%5Cn%3Cth%3EUtbildningsniv%C3%A5%3C%2Fth%3E%5Cn%3C%2Ftr%3E%5Cn%3C%2Fthead%3E%5Cn%3Ctbody%3E%5Cn%3Ctr%3E%5Cn%3Ctd%3EED1110%3C%2Ftd%3E%5Cn%3Ctd%3EVektoranalys%3C%2Ftd%3E%5Cn%3Ctd%3E4.5%20hp%3C%2Ftd%3E%5Cn%3Ctd%3EGrundniv%C3%A5%3C%2Ftd%3E%5Cn%3C%2Ftr%3E%5Cn%3Ctr%3E%5Cn%3Ctd%3EEH1110%3C%2Ftd%3E%5Cn%3Ctd%3EElektroteknikens%20betydelse%20f%C3%B6r%20ett%20modernt%20samh%C3%A4lle%3C%2Ftd%3E%5Cn%3Ctd%3E7.5%20hp%3C%2Ftd%3E%5Cn%3Ctd%3EGrundniv%C3%A5%3C%2Ftd%3E%5Cn%3C%2Ftr%3E%5Cn%3Ctr%3E%5Cn%3Ctd%3EEI1220%3C%2Ftd%3E%5Cn%3Ctd%3ETeoretisk%20elektroteknik%20E%3C%2Ftd%3E%5Cn%3Ctd%3E10.5%20hp%3C%2Ftd%3E%5Cn%3Ctd%3EGrundniv%C3%A5%3C%2Ftd%3E%5Cn%3C%2Ftr%3E%5Cn%3Ctr%3E%5Cn%3Ctd%3EEN1020%3C%2Ftd%3E%5Cn%3Ctd%3EElektroprojekt%2C%20del%20II%3C%2Ftd%3E%5Cn%3Ctd%3E6%20hp%3C%2Ftd%3E%5Cn%3Ctd%3EGrundniv%C3%A5%3C%2Ftd%3E%5Cn%3C%2Ftr%3E%5Cn%3Ctr%3E%5Cn%3Ctd%3EEQ1110%3C%2Ftd%3E%5Cn%3Ctd%3ETidskontinuerliga%20signaler%20och%20system%3C%2Ftd%3E%5Cn%3Ctd%3E6%20hp%3C%2Ftd%3E%5Cn%3Ctd%3EGrundniv%C3%A5%3C%2Ftd%3E%5Cn%3C%2Ftr%3E%5Cn%3Ctr%3E%5Cn%3Ctd%3EEQ1120%3C%2Ftd%3E%5Cn%3Ctd%3ETidsdiskreta%20signaler%20och%20system%3C%2Ftd%3E%5Cn%3Ctd%3E6%20hp%3C%2Ftd%3E%5Cn%3Ctd%3EGrundniv%C3%A5%3C%2Ftd%3E%5Cn%3C%2Ftr%3E%5Cn%3Ctr%3E%5Cn%3Ctd%3ESF1920%3C%2Ftd%3E%5Cn%3Ctd%3ESannolikhetsteori%20och%20statistik%3C%2Ftd%3E%5Cn%3Ctd%3E6%20hp%3C%2Ftd%3E%5Cn%3Ctd%3EGrundniv%C3%A5%3C%2Ftd%3E%5Cn%3C%2Ftr%3E%5Cn%3Ctr%3E%5Cn%3Ctd%3ESK1108%3C%2Ftd%3E%5Cn%3Ctd%3EKlassisk%20fysik%2C%20mekanik%20och%20v%C3%A5g%3C%2Ftd%3E%5Cn%3Ctd%3E7.5%20hp%3C%2Ftd%3E%5Cn%3Ctd%3EGrundniv%C3%A5%3C%2Ftd%3E%5Cn%3C%2Ftr%3E%5Cn%3C%2Ftbody%3E%5Cn%3C%2Ftable%3E%5Cn%3Ch4%20id%3D%5C%22villkorligtvalfriakurser%5C%22%3EVillkorligt%20valfria%20kurser%3C%2Fh4%3E%5Cn%3Ctable%3E%5Cn%3Cthead%3E%5Cn%3Ctr%3E%5Cn%3Cth%3EKurskod%3C%2Fth%3E%5Cn%3Cth%3EKursnamn%3C%2Fth%3E%5Cn%3Cth%3EOmfattning%3C%2Fth%3E%5Cn%3Cth%3EUtbildningsniv%C3%A5%3C%2Fth%3E%5Cn%3C%2Ftr%3E%5Cn%3C%2Fthead%3E%5Cn%3Ctbody%3E%5Cn%3Ctr%3E%5Cn%3Ctd%3EDD1320%3C%2Ftd%3E%5Cn%3Ctd%3ETill%C3%A4mpad%20datalogi%3C%2Ftd%3E%5Cn%3Ctd%3E6%20hp%3C%2Ftd%3E%5Cn%3Ctd%3EGrundniv%C3%A5%3C%2Ftd%3E%5Cn%3C%2Ftr%3E%5Cn%3Ctr%3E%5Cn%3Ctd%3EDD1388%3C%2Ftd%3E%5Cn%3Ctd%3EProgramsystemkonstruktion%20med%20C%2B%2B%3C%2Ftd%3E%5Cn%3Ctd%3E7.5%20hp%3C%2Ftd%3E%5Cn%3Ctd%3EGrundniv%C3%A5%3C%2Ftd%3E%5Cn%3C%2Ftr%3E%5Cn%3Ctr%3E%5Cn%3Ctd%3EEI1222%3C%2Ftd%3E%5Cn%3Ctd%3ETeoretisk%20elektroteknik%2C%20forts%C3%A4ttningskurs%3C%2Ftd%3E%5Cn%3Ctd%3E6%20hp%3C%2Ftd%3E%5Cn%3Ctd%3EGrundniv%C3%A5%3C%2Ftd%3E%5Cn%3C%2Ftr%3E%5Cn%3Ctr%3E%5Cn%3Ctd%3EEP1100%3C%2Ftd%3E%5Cn%3Ctd%3EDatakommunikation%20och%20datorn%C3%A4t%3C%2Ftd%3E%5Cn%3Ctd%3E7.5%20hp%3C%2Ftd%3E%5Cn%3Ctd%3EGrundniv%C3%A5%3C%2Ftd%3E%5Cn%3C%2Ftr%3E%5Cn%3Ctr%3E%5Cn%3Ctd%3EIL2240%3C%2Ftd%3E%5Cn%3Ctd%3EHalvledarkomponenter%20f%C3%B6r%20integrerade%20kretsar%3C%2Ftd%3E%5Cn%3Ctd%3E7.5%20hp%3C%2Ftd%3E%5Cn%3Ctd%3EAvancerad%20niv%C3%A5%3C%2Ftd%3E%5Cn%3C%2Ftr%3E%5Cn%3Ctr%3E%5Cn%3Ctd%3EMH1023%3C%2Ftd%3E%5Cn%3Ctd%3EPraktiskt%20j%C3%A4mst%C3%A4lldhets-%20och%20m%C3%A5ngfaldsarbete%20i%20vetenskapliga%2C%20tekniska%20och%20industriella%20milj%C3%B6er%3C%2Ftd%3E%5Cn%3Ctd%3E6%20hp%3C%2Ftd%3E%5Cn%3Ctd%3EGrundniv%C3%A5%3C%2Ftd%3E%5Cn%3C%2Ftr%3E%5Cn%3Ctr%3E%5Cn%3Ctd%3ESF1546%3C%2Ftd%3E%5Cn%3Ctd%3ENumeriska%20metoder%2C%20grundkurs%3Cbr%3E%3Cem%3EKan%20ers%C3%A4ttas%20av%20SF1547.%3C%2Fem%3E%3C%2Ftd%3E%5Cn%3Ctd%3E6%20hp%3C%2Ftd%3E%5Cn%3Ctd%3EGrundniv%C3%A5%3C%2Ftd%3E%5Cn%3C%2Ftr%3E%5Cn%3Ctr%3E%5Cn%3Ctd%3ESF1679%3C%2Ftd%3E%5Cn%3Ctd%3EDiskret%20matematik%3C%2Ftd%3E%5Cn%3Ctd%3E7.5%20hp%3C%2Ftd%3E%5Cn%3Ctd%3EGrundniv%C3%A5%3C%2Ftd%3E%5Cn%3C%2Ftr%3E%5Cn%3Ctr%3E%5Cn%3Ctd%3ESF1691%3C%2Ftd%3E%5Cn%3Ctd%3EKomplex%20analys%3C%2Ftd%3E%5Cn%3Ctd%3E7.5%20hp%3C%2Ftd%3E%5Cn%3Ctd%3EGrundniv%C3%A5%3C%2Ftd%3E%5Cn%3C%2Ftr%3E%5Cn%3Ctr%3E%5Cn%3Ctd%3ESF1861%3C%2Ftd%3E%5Cn%3Ctd%3EOptimeringsl%C3%A4ra%3C%2Ftd%3E%5Cn%3Ctd%3E6%20hp%3C%2Ftd%3E%5Cn%3Ctd%3EGrundniv%C3%A5%3C%2Ftd%3E%5Cn%3C%2Ftr%3E%5Cn%3Ctr%3E%5Cn%3Ctd%3ESG1130%3C%2Ftd%3E%5Cn%3Ctd%3EMekanik%20I%3C%2Ftd%3E%5Cn%3Ctd%3E9%20hp%3C%2Ftd%3E%5Cn%3Ctd%3EGrundniv%C3%A5%3C%2Ftd%3E%5Cn%3C%2Ftr%3E%5Cn%3Ctr%3E%5Cn%3Ctd%3ESH1012%3C%2Ftd%3E%5Cn%3Ctd%3EModern%20fysik%3C%2Ftd%3E%5Cn%3Ctd%3E8%20hp%3C%2Ftd%3E%5Cn%3Ctd%3EGrundniv%C3%A5%3C%2Ftd%3E%5Cn%3C%2Ftr%3E%5Cn%3Ctr%3E%5Cn%3Ctd%3ESI1200%3C%2Ftd%3E%5Cn%3Ctd%3EFysikens%20matematiska%20metoder%3C%2Ftd%3E%5Cn%3Ctd%3E4%20hp%3C%2Ftd%3E%5Cn%3Ctd%3EGrundniv%C3%A5%3C%2Ftd%3E%5Cn%3C%2Ftr%3E%5Cn%3Ctr%3E%5Cn%3Ctd%3ESK1119%3C%2Ftd%3E%5Cn%3Ctd%3ETermodynamik%20och%20statistisk%20fysik%3C%2Ftd%3E%5Cn%3Ctd%3E7.5%20hp%3C%2Ftd%3E%5Cn%3Ctd%3EGrundniv%C3%A5%3C%2Ftd%3E%5Cn%3C%2Ftr%3E%5Cn%3C%2Ftbody%3E%5Cn%3C%2Ftable%3E%5Cn%3Ch4%20id%3D%5C%22kompletterandeinformation%5C%22%3EKompletterande%20information%3C%2Fh4%3E%5Cn%3Cp%3EUnder%20de%20f%C3%B6rsta%20tre%20%C3%A5ren%20finns%20utrymme%20f%C3%B6r%20en%20valfri%20kurs.%3C%2Fp%3E%5Cn%3Ch4%20id%3D%5C%22informationomvillkorligtvalfriakurser%5C%22%3EInformation%20om%20villkorligt%20valfria%20kurser%3C%2Fh4%3E%5Cn%3Cp%3ETre%20villkorligt%20valfria%20kurser%20ska%20l%C3%A4sas%20i%20%C3%A5rskurs%202%20eller%203.%3C%2Fp%3E%22%2C%22freeTexts%22%3A%5B%5D%2C%22supplementaryInfo%22%3A%22%3Cp%3EUnder%20de%20f%C3%B6rsta%20tre%20%C3%A5ren%20finns%20utrymme%20f%C3%B6r%20en%20valfri%20kurs.%3C%2Fp%3E%22%2C%22conditionallyElectiveCoursesInfo%22%3A%22%3Cp%3ETre%20villkorligt%20valfria%20kurser%20ska%20l%C3%A4sas%20i%20%C3%A5rskurs%202%20eller%203.%3C%2Fp%3E%22%7D%2C%7B%22yearNumber%22%3A3%2C%22courses%22%3A%5B%7B%22utbildningsinstansUid%22%3A%220f69c0d9-dc3b-11e8-ba80-894fc53b4dc9%22%2C%22uid%22%3A%22c872d7f7-7bb5-11ed-83fc-99df00a14a2f%22%2C%22tillfalleskod%22%3A%2250814%22%2C%22status%22%3A%7B%22code%22%3A%22S3%22%2C%22nameSv%22%3A%22Komplett%22%2C%22nameEn%22%3A%22Complete%22%7D%2C%22utbildningstyp%22%3A%7B%22id%22%3A%2222%22%2C%22code%22%3A%222007GKURS%22%2C%22name%22%3A%22Kurs%2C%20grundniv%C3%A5%22%2C%22nameOther%22%3A%22Course%2C%20First-cycle%22%2C%22creditsUnit%22%3A%7B%22code%22%3A%22HP%22%2C%22sv%22%3A%22H%C3%B6gskolepo%C3%A4ng%22%2C%22en%22%3A%22Credits%22%7D%2C%22level%22%3A%7B%22code%22%3A%221%22%2C%22name%22%3A%22Grundniv%C3%A5%22%7D%7D%2C%22omfattning%22%3A%7B%22number%22%3A7.5%2C%22formattedWithUnit%22%3A%227%2C5%20hp%22%7D%2C%22startperiod%22%3A%7B%22code%22%3A%22HT2023%22%2C%22startDay%22%3A%222023-08-28%22%2C%22lastDay%22%3A%222024-01-15%22%2C%22inDigits%22%3A%2220232%22%7D%2C%22Tillfallesperioder%22%3A%5B%7B%22ForstaRegistreringsdatum%22%3A%222025-06-26%22%2C%22ForstaUndervisningsdatum%22%3A%222025-07-01%22%2C%22Lasperiodsfordelning%22%3A%5B%7B%22Lasperiodskod%22%3A%22P2%22%2C%22Omfattningsvarde%22%3A0.5%2C%22link%22%3A%5B%5D%7D%5D%2C%22Omfattningsvarde%22%3A0.5%2C%22SistaRegistreringsdatum%22%3A%222025-07-07%22%2C%22SistaUndervisningsdatum%22%3A%222026-12-31%22%7D%2C%7B%22ForstaRegistreringsdatum%22%3A%222025-12-25%22%2C%22ForstaUndervisningsdatum%22%3A%222026-01-01%22%2C%22Lasperiodsfordelning%22%3A%5B%7B%22Lasperiodskod%22%3A%22P3%22%2C%22Omfattningsvarde%22%3A1.5%2C%22link%22%3A%5B%5D%7D%2C%7B%22Lasperiodskod%22%3A%22P4%22%2C%22Omfattningsvarde%22%3A1%2C%22link%22%3A%5B%5D%7D%5D%2C%22Omfattningsvarde%22%3A2.5%2C%22SistaRegistreringsdatum%22%3A%222026-01-05%22%2C%22SistaUndervisningsdatum%22%3A%222026-06-30%22%7D%5D%2C%22kod%22%3A%22EH1110%22%2C%22benamning%22%3A%22Elektroteknikens%20betydelse%20f%C3%B6r%20ett%20modernt%20samh%C3%A4lle%22%2C%22Valvillkor%22%3A%22O%22%2C%22type%22%3A%22instance%22%7D%2C%7B%22utbildningsinstansUid%22%3A%22f7c77b3f-5c52-11e9-b67f-a77d6cb34fef%22%2C%22uid%22%3A%22e7c77709-b6f0-11ef-9553-beecfac44351%22%2C%22tillfalleskod%22%3A%2251142%22%2C%22status%22%3A%7B%22code%22%3A%22S3%22%2C%22nameSv%22%3A%22Komplett%22%2C%22nameEn%22%3A%22Complete%22%7D%2C%22utbildningstyp%22%3A%7B%22id%22%3A%2222%22%2C%22code%22%3A%222007GKURS%22%2C%22name%22%3A%22Kurs%2C%20grundniv%C3%A5%22%2C%22nameOther%22%3A%22Course%2C%20First-cycle%22%2C%22creditsUnit%22%3A%7B%22code%22%3A%22HP%22%2C%22sv%22%3A%22H%C3%B6gskolepo%C3%A4ng%22%2C%22en%22%3A%22Credits%22%7D%2C%22level%22%3A%7B%22code%22%3A%221%22%2C%22name%22%3A%22Grundniv%C3%A5%22%7D%7D%2C%22omfattning%22%3A%7B%22number%22%3A6%2C%22formattedWithUnit%22%3A%226%2C0%20hp%22%7D%2C%22startperiod%22%3A%7B%22code%22%3A%22HT2025%22%2C%22startDay%22%3A%222025-08-25%22%2C%22lastDay%22%3A%222026-01-12%22%2C%22inDigits%22%3A%2220252%22%7D%2C%22Tillfallesperioder%22%3A%5B%7B%22ForstaRegistreringsdatum%22%3A%222025-10-23%22%2C%22ForstaUndervisningsdatum%22%3A%222025-10-27%22%2C%22Lasperiodsfordelning%22%3A%5B%7B%22Lasperiodskod%22%3A%22P2%22%2C%22Omfattningsvarde%22%3A6%2C%22link%22%3A%5B%5D%7D%5D%2C%22Omfattningsvarde%22%3A6%2C%22SistaRegistreringsdatum%22%3A%222025-11-03%22%2C%22SistaUndervisningsdatum%22%3A%222026-01-12%22%7D%5D%2C%22kod%22%3A%22EJ1200%22%2C%22benamning%22%3A%22Eleffektsystem%22%2C%22Valvillkor%22%3A%22O%22%2C%22type%22%3A%22instance%22%7D%2C%7B%22utbildningsinstansUid%22%3A%221ab4795f-ef2a-11e8-ba11-7cc77ecb4a78%22%2C%22uid%22%3A%225712e7e2-b24c-11ef-935c-a4329748411f%22%2C%22tillfalleskod%22%3A%2251143%22%2C%22status%22%3A%7B%22code%22%3A%22S3%22%2C%22nameSv%22%3A%22Komplett%22%2C%22nameEn%22%3A%22Complete%22%7D%2C%22utbildningstyp%22%3A%7B%22id%22%3A%2222%22%2C%22code%22%3A%222007GKURS%22%2C%22name%22%3A%22Kurs%2C%20grundniv%C3%A5%22%2C%22nameOther%22%3A%22Course%2C%20First-cycle%22%2C%22creditsUnit%22%3A%7B%22code%22%3A%22HP%22%2C%22sv%22%3A%22H%C3%B6gskolepo%C3%A4ng%22%2C%22en%22%3A%22Credits%22%7D%2C%22level%22%3A%7B%22code%22%3A%221%22%2C%22name%22%3A%22Grundniv%C3%A5%22%7D%7D%2C%22omfattning%22%3A%7B%22number%22%3A6%2C%22formattedWithUnit%22%3A%226%2C0%20hp%22%7D%2C%22startperiod%22%3A%7B%22code%22%3A%22HT2025%22%2C%22startDay%22%3A%222025-08-25%22%2C%22lastDay%22%3A%222026-01-12%22%2C%22inDigits%22%3A%2220252%22%7D%2C%22Tillfallesperioder%22%3A%5B%7B%22ForstaRegistreringsdatum%22%3A%222025-08-21%22%2C%22ForstaUndervisningsdatum%22%3A%222025-08-25%22%2C%22Lasperiodsfordelning%22%3A%5B%7B%22Lasperiodskod%22%3A%22P1%22%2C%22Omfattningsvarde%22%3A3%2C%22link%22%3A%5B%5D%7D%2C%7B%22Lasperiodskod%22%3A%22P2%22%2C%22Omfattningsvarde%22%3A3%2C%22link%22%3A%5B%5D%7D%5D%2C%22Omfattningsvarde%22%3A6%2C%22SistaRegistreringsdatum%22%3A%222025-09-01%22%2C%22SistaUndervisningsdatum%22%3A%222026-01-12%22%7D%5D%2C%22kod%22%3A%22EK1191%22%2C%22benamning%22%3A%22M%C3%A4tteknik%22%2C%22Valvillkor%22%3A%22O%22%2C%22type%22%3A%22instance%22%7D%2C%7B%22utbildningsinstansUid%22%3A%227c01f5f3-d5ff-11e8-b094-9def723747ec%22%2C%22uid%22%3A%2299b00df4-bba3-11ef-9553-beecfac44351%22%2C%22tillfalleskod%22%3A%2251144%22%2C%22status%22%3A%7B%22code%22%3A%22S3%22%2C%22nameSv%22%3A%22Komplett%22%2C%22nameEn%22%3A%22Complete%22%7D%2C%22utbildningstyp%22%3A%7B%22id%22%3A%2222%22%2C%22code%22%3A%222007GKURS%22%2C%22name%22%3A%22Kurs%2C%20grundniv%C3%A5%22%2C%22nameOther%22%3A%22Course%2C%20First-cycle%22%2C%22creditsUnit%22%3A%7B%22code%22%3A%22HP%22%2C%22sv%22%3A%22H%C3%B6gskolepo%C3%A4ng%22%2C%22en%22%3A%22Credits%22%7D%2C%22level%22%3A%7B%22code%22%3A%221%22%2C%22name%22%3A%22Grundniv%C3%A5%22%7D%7D%2C%22omfattning%22%3A%7B%22number%22%3A6%2C%22formattedWithUnit%22%3A%226%2C0%20hp%22%7D%2C%22startperiod%22%3A%7B%22code%22%3A%22HT2025%22%2C%22startDay%22%3A%222025-08-25%22%2C%22lastDay%22%3A%222026-01-12%22%2C%22inDigits%22%3A%2220252%22%7D%2C%22Tillfallesperioder%22%3A%5B%7B%22ForstaRegistreringsdatum%22%3A%222025-10-23%22%2C%22ForstaUndervisningsdatum%22%3A%222025-10-27%22%2C%22Lasperiodsfordelning%22%3A%5B%7B%22Lasperiodskod%22%3A%22P2%22%2C%22Omfattningsvarde%22%3A6%2C%22link%22%3A%5B%5D%7D%5D%2C%22Omfattningsvarde%22%3A6%2C%22SistaRegistreringsdatum%22%3A%222025-11-03%22%2C%22SistaUndervisningsdatum%22%3A%222026-01-12%22%7D%5D%2C%22kod%22%3A%22EQ1270%22%2C%22benamning%22%3A%22Stokastiska%20signaler%20och%20system%22%2C%22Valvillkor%22%3A%22O%22%2C%22type%22%3A%22instance%22%7D%2C%7B%22utbildningsinstansUid%22%3A%22148eb610-db4a-11e8-b548-8cda89c64326%22%2C%22uid%22%3A%222339b10d-bc55-11ef-9553-beecfac44351%22%2C%22tillfalleskod%22%3A%2251145%22%2C%22status%22%3A%7B%22code%22%3A%22S3%22%2C%22nameSv%22%3A%22Komplett%22%2C%22nameEn%22%3A%22Complete%22%7D%2C%22utbildningstyp%22%3A%7B%22id%22%3A%2222%22%2C%22code%22%3A%222007GKURS%22%2C%22name%22%3A%22Kurs%2C%20grundniv%C3%A5%22%2C%22nameOther%22%3A%22Course%2C%20First-cycle%22%2C%22creditsUnit%22%3A%7B%22code%22%3A%22HP%22%2C%22sv%22%3A%22H%C3%B6gskolepo%C3%A4ng%22%2C%22en%22%3A%22Credits%22%7D%2C%22level%22%3A%7B%22code%22%3A%221%22%2C%22name%22%3A%22Grundniv%C3%A5%22%7D%7D%2C%22omfattning%22%3A%7B%22number%22%3A6%2C%22formattedWithUnit%22%3A%226%2C0%20hp%22%7D%2C%22startperiod%22%3A%7B%22code%22%3A%22HT2025%22%2C%22startDay%22%3A%222025-08-25%22%2C%22lastDay%22%3A%222026-01-12%22%2C%22inDigits%22%3A%2220252%22%7D%2C%22Tillfallesperioder%22%3A%5B%7B%22ForstaRegistreringsdatum%22%3A%222025-08-21%22%2C%22ForstaUndervisningsdatum%22%3A%222025-08-25%22%2C%22Lasperiodsfordelning%22%3A%5B%7B%22Lasperiodskod%22%3A%22P1%22%2C%22Omfattningsvarde%22%3A6%2C%22link%22%3A%5B%5D%7D%5D%2C%22Omfattningsvarde%22%3A6%2C%22SistaRegistreringsdatum%22%3A%222025-09-01%22%2C%22SistaUndervisningsdatum%22%3A%222025-10-24%22%7D%5D%2C%22kod%22%3A%22IE1207%22%2C%22benamning%22%3A%22Analog%20Elektronik%22%2C%22Valvillkor%22%3A%22O%22%2C%22type%22%3A%22instance%22%7D%2C%7B%22utbildningsinstansUid%22%3A%2223ed85fb-2cee-11ec-bb06-8c8c04c8482a%22%2C%22uid%22%3A%22ff83dac5-bb9f-11ef-9553-beecfac44351%22%2C%22tillfalleskod%22%3A%2251147%22%2C%22status%22%3A%7B%22code%22%3A%22S3%22%2C%22nameSv%22%3A%22Komplett%22%2C%22nameEn%22%3A%22Complete%22%7D%2C%22utbildningstyp%22%3A%7B%22id%22%3A%2222%22%2C%22code%22%3A%222007GKURS%22%2C%22name%22%3A%22Kurs%2C%20grundniv%C3%A5%22%2C%22nameOther%22%3A%22Course%2C%20First-cycle%22%2C%22creditsUnit%22%3A%7B%22code%22%3A%22HP%22%2C%22sv%22%3A%22H%C3%B6gskolepo%C3%A4ng%22%2C%22en%22%3A%22Credits%22%7D%2C%22level%22%3A%7B%22code%22%3A%221%22%2C%22name%22%3A%22Grundniv%C3%A5%22%7D%7D%2C%22omfattning%22%3A%7B%22number%22%3A6%2C%22formattedWithUnit%22%3A%226%2C0%20hp%22%7D%2C%22startperiod%22%3A%7B%22code%22%3A%22HT2025%22%2C%22startDay%22%3A%222025-08-25%22%2C%22lastDay%22%3A%222026-01-12%22%2C%22inDigits%22%3A%2220252%22%7D%2C%22Tillfallesperioder%22%3A%5B%7B%22ForstaRegistreringsdatum%22%3A%222025-08-21%22%2C%22ForstaUndervisningsdatum%22%3A%222025-08-25%22%2C%22Lasperiodsfordelning%22%3A%5B%7B%22Lasperiodskod%22%3A%22P1%22%2C%22Omfattningsvarde%22%3A6%2C%22link%22%3A%5B%5D%7D%5D%2C%22Omfattningsvarde%22%3A6%2C%22SistaRegistreringsdatum%22%3A%222025-09-01%22%2C%22SistaUndervisningsdatum%22%3A%222025-10-24%22%7D%5D%2C%22kod%22%3A%22EL1020%22%2C%22benamning%22%3A%22Reglerteknik%2C%20allm%C3%A4n%20kurs%22%2C%22Valvillkor%22%3A%22O%22%2C%22type%22%3A%22instance%22%7D%2C%7B%22utbildningsinstansUid%22%3A%22b48a52a5-dd0c-11e8-bb7a-19f8cd1a470e%22%2C%22uid%22%3A%226728b9be-ce5c-11ef-9bca-bbbddaff469b%22%2C%22tillfalleskod%22%3A%2260889%22%2C%22status%22%3A%7B%22code%22%3A%22S3%22%2C%22nameSv%22%3A%22Komplett%22%2C%22nameEn%22%3A%22Complete%22%7D%2C%22utbildningstyp%22%3A%7B%22id%22%3A%2222%22%2C%22code%22%3A%222007GKURS%22%2C%22name%22%3A%22Kurs%2C%20grundniv%C3%A5%22%2C%22nameOther%22%3A%22Course%2C%20First-cycle%22%2C%22creditsUnit%22%3A%7B%22code%22%3A%22HP%22%2C%22sv%22%3A%22H%C3%B6gskolepo%C3%A4ng%22%2C%22en%22%3A%22Credits%22%7D%2C%22level%22%3A%7B%22code%22%3A%221%22%2C%22name%22%3A%22Grundniv%C3%A5%22%7D%7D%2C%22omfattning%22%3A%7B%22number%22%3A15%2C%22formattedWithUnit%22%3A%2215%2C0%20hp%22%7D%2C%22startperiod%22%3A%7B%22code%22%3A%22VT2026%22%2C%22startDay%22%3A%222026-01-13%22%2C%22lastDay%22%3A%222026-06-01%22%2C%22inDigits%22%3A%2220261%22%7D%2C%22Tillfallesperioder%22%3A%5B%7B%22ForstaRegistreringsdatum%22%3A%222026-01-08%22%2C%22ForstaUndervisningsdatum%22%3A%222026-01-13%22%2C%22Lasperiodsfordelning%22%3A%5B%7B%22Lasperiodskod%22%3A%22P4%22%2C%22Omfattningsvarde%22%3A7.5%2C%22link%22%3A%5B%5D%7D%2C%7B%22Lasperiodskod%22%3A%22P3%22%2C%22Omfattningsvarde%22%3A7.5%2C%22link%22%3A%5B%5D%7D%5D%2C%22Omfattningsvarde%22%3A15%2C%22SistaRegistreringsdatum%22%3A%222026-01-19%22%2C%22SistaUndervisningsdatum%22%3A%222026-06-01%22%7D%5D%2C%22kod%22%3A%22EF112X%22%2C%22benamning%22%3A%22Examensarbete%20inom%20elektroteknik%2C%20grundniv%C3%A5%22%2C%22Valvillkor%22%3A%22O%22%2C%22type%22%3A%22instance%22%7D%2C%7B%22utbildningsinstansUid%22%3A%226187815e-9ebd-11eb-b121-4a7c58ae420f%22%2C%22uid%22%3A%22e5bed7f2-bea7-11ef-9c9e-74b5caef4769%22%2C%22tillfalleskod%22%3A%2260104%22%2C%22status%22%3A%7B%22code%22%3A%22S3%22%2C%22nameSv%22%3A%22Komplett%22%2C%22nameEn%22%3A%22Complete%22%7D%2C%22utbildningstyp%22%3A%7B%22id%22%3A%2222%22%2C%22code%22%3A%222007GKURS%22%2C%22name%22%3A%22Kurs%2C%20grundniv%C3%A5%22%2C%22nameOther%22%3A%22Course%2C%20First-cycle%22%2C%22creditsUnit%22%3A%7B%22code%22%3A%22HP%22%2C%22sv%22%3A%22H%C3%B6gskolepo%C3%A4ng%22%2C%22en%22%3A%22Credits%22%7D%2C%22level%22%3A%7B%22code%22%3A%221%22%2C%22name%22%3A%22Grundniv%C3%A5%22%7D%7D%2C%22omfattning%22%3A%7B%22number%22%3A6%2C%22formattedWithUnit%22%3A%226%2C0%20hp%22%7D%2C%22startperiod%22%3A%7B%22code%22%3A%22VT2026%22%2C%22startDay%22%3A%222026-01-13%22%2C%22lastDay%22%3A%222026-06-01%22%2C%22inDigits%22%3A%2220261%22%7D%2C%22Tillfallesperioder%22%3A%5B%7B%22ForstaRegistreringsdatum%22%3A%222026-01-08%22%2C%22ForstaUndervisningsdatum%22%3A%222026-01-13%22%2C%22Lasperiodsfordelning%22%3A%5B%7B%22Lasperiodskod%22%3A%22P3%22%2C%22Omfattningsvarde%22%3A6%2C%22link%22%3A%5B%5D%7D%5D%2C%22Omfattningsvarde%22%3A6%2C%22SistaRegistreringsdatum%22%3A%222026-01-19%22%2C%22SistaUndervisningsdatum%22%3A%222026-03-13%22%7D%5D%2C%22kod%22%3A%22DD1320%22%2C%22benamning%22%3A%22Till%C3%A4mpad%20datalogi%22%2C%22Valvillkor%22%3A%22VV%22%2C%22type%22%3A%22instance%22%7D%2C%7B%22utbildningsinstansUid%22%3A%2202720d63-a834-11f0-8e06-8e0c8088416e%22%2C%22uid%22%3A%22be7fad93-cf4b-11ef-9bca-bbbddaff469b%22%2C%22tillfalleskod%22%3A%2260258%22%2C%22status%22%3A%7B%22code%22%3A%22S3%22%2C%22nameSv%22%3A%22Komplett%22%2C%22nameEn%22%3A%22Complete%22%7D%2C%22utbildningstyp%22%3A%7B%22id%22%3A%2222%22%2C%22code%22%3A%222007GKURS%22%2C%22name%22%3A%22Kurs%2C%20grundniv%C3%A5%22%2C%22nameOther%22%3A%22Course%2C%20First-cycle%22%2C%22creditsUnit%22%3A%7B%22code%22%3A%22HP%22%2C%22sv%22%3A%22H%C3%B6gskolepo%C3%A4ng%22%2C%22en%22%3A%22Credits%22%7D%2C%22level%22%3A%7B%22code%22%3A%221%22%2C%22name%22%3A%22Grundniv%C3%A5%22%7D%7D%2C%22omfattning%22%3A%7B%22number%22%3A7.5%2C%22formattedWithUnit%22%3A%227%2C5%20hp%22%7D%2C%22startperiod%22%3A%7B%22code%22%3A%22VT2026%22%2C%22startDay%22%3A%222026-01-13%22%2C%22lastDay%22%3A%222026-06-01%22%2C%22inDigits%22%3A%2220261%22%7D%2C%22Tillfallesperioder%22%3A%5B%7B%22ForstaRegistreringsdatum%22%3A%222026-01-08%22%2C%22ForstaUndervisningsdatum%22%3A%222026-01-13%22%2C%22Lasperiodsfordelning%22%3A%5B%7B%22Lasperiodskod%22%3A%22P3%22%2C%22Omfattningsvarde%22%3A7.5%2C%22link%22%3A%5B%5D%7D%5D%2C%22Omfattningsvarde%22%3A7.5%2C%22SistaRegistreringsdatum%22%3A%222026-01-19%22%2C%22SistaUndervisningsdatum%22%3A%222026-03-13%22%7D%5D%2C%22kod%22%3A%22EP1100%22%2C%22benamning%22%3A%22Datakommunikation%20och%20datorn%C3%A4t%22%2C%22Valvillkor%22%3A%22VV%22%2C%22type%22%3A%22instance%22%7D%2C%7B%22utbildningsinstansUid%22%3A%22a16e31b4-a832-11f0-8e06-8e0c8088416e%22%2C%22uid%22%3A%2210d920d0-bee8-11ef-9c9e-74b5caef4769%22%2C%22tillfalleskod%22%3A%2260314%22%2C%22status%22%3A%7B%22code%22%3A%22S3%22%2C%22nameSv%22%3A%22Komplett%22%2C%22nameEn%22%3A%22Complete%22%7D%2C%22utbildningstyp%22%3A%7B%22id%22%3A%2222%22%2C%22code%22%3A%222007GKURS%22%2C%22name%22%3A%22Kurs%2C%20grundniv%C3%A5%22%2C%22nameOther%22%3A%22Course%2C%20First-cycle%22%2C%22creditsUnit%22%3A%7B%22code%22%3A%22HP%22%2C%22sv%22%3A%22H%C3%B6gskolepo%C3%A4ng%22%2C%22en%22%3A%22Credits%22%7D%2C%22level%22%3A%7B%22code%22%3A%221%22%2C%22name%22%3A%22Grundniv%C3%A5%22%7D%7D%2C%22omfattning%22%3A%7B%22number%22%3A7.5%2C%22formattedWithUnit%22%3A%227%2C5%20hp%22%7D%2C%22startperiod%22%3A%7B%22code%22%3A%22VT2026%22%2C%22startDay%22%3A%222026-01-13%22%2C%22lastDay%22%3A%222026-06-01%22%2C%22inDigits%22%3A%2220261%22%7D%2C%22Tillfallesperioder%22%3A%5B%7B%22ForstaRegistreringsdatum%22%3A%222026-01-08%22%2C%22ForstaUndervisningsdatum%22%3A%222026-01-13%22%2C%22Lasperiodsfordelning%22%3A%5B%7B%22Lasperiodskod%22%3A%22P3%22%2C%22Omfattningsvarde%22%3A4%2C%22link%22%3A%5B%5D%7D%2C%7B%22Lasperiodskod%22%3A%22P4%22%2C%22Omfattningsvarde%22%3A3.5%2C%22link%22%3A%5B%5D%7D%5D%2C%22Omfattningsvarde%22%3A7.5%2C%22SistaRegistreringsdatum%22%3A%222026-01-19%22%2C%22SistaUndervisningsdatum%22%3A%222026-06-01%22%7D%5D%2C%22kod%22%3A%22DD1388%22%2C%22benamning%22%3A%22Programsystemkonstruktion%20med%20C%2B%2B%22%2C%22Valvillkor%22%3A%22VV%22%2C%22type%22%3A%22instance%22%7D%2C%7B%22utbildningsinstansUid%22%3A%227ec3a03d-73d8-11e8-b4e0-063f9afb40e3%22%2C%22uid%22%3A%2283d07f9c-ce66-11ef-9bca-bbbddaff469b%22%2C%22tillfalleskod%22%3A%2260335%22%2C%22status%22%3A%7B%22code%22%3A%22S3%22%2C%22nameSv%22%3A%22Komplett%22%2C%22nameEn%22%3A%22Complete%22%7D%2C%22utbildningstyp%22%3A%7B%22id%22%3A%2222%22%2C%22code%22%3A%222007GKURS%22%2C%22name%22%3A%22Kurs%2C%20grundniv%C3%A5%22%2C%22nameOther%22%3A%22Course%2C%20First-cycle%22%2C%22creditsUnit%22%3A%7B%22code%22%3A%22HP%22%2C%22sv%22%3A%22H%C3%B6gskolepo%C3%A4ng%22%2C%22en%22%3A%22Credits%22%7D%2C%22level%22%3A%7B%22code%22%3A%221%22%2C%22name%22%3A%22Grundniv%C3%A5%22%7D%7D%2C%22omfattning%22%3A%7B%22number%22%3A6%2C%22formattedWithUnit%22%3A%226%2C0%20hp%22%7D%2C%22startperiod%22%3A%7B%22code%22%3A%22VT2026%22%2C%22startDay%22%3A%222026-01-13%22%2C%22lastDay%22%3A%222026-06-01%22%2C%22inDigits%22%3A%2220261%22%7D%2C%22Tillfallesperioder%22%3A%5B%7B%22ForstaRegistreringsdatum%22%3A%222026-01-08%22%2C%22ForstaUndervisningsdatum%22%3A%222026-01-13%22%2C%22Lasperiodsfordelning%22%3A%5B%7B%22Lasperiodskod%22%3A%22P3%22%2C%22Omfattningsvarde%22%3A4%2C%22link%22%3A%5B%5D%7D%2C%7B%22Lasperiodskod%22%3A%22P4%22%2C%22Omfattningsvarde%22%3A2%2C%22link%22%3A%5B%5D%7D%5D%2C%22Omfattningsvarde%22%3A6%2C%22SistaRegistreringsdatum%22%3A%222026-01-19%22%2C%22SistaUndervisningsdatum%22%3A%222026-06-01%22%7D%5D%2C%22kod%22%3A%22SF1546%22%2C%22benamning%22%3A%22Numeriska%20metoder%2C%20grundkurs%22%2C%22Valvillkor%22%3A%22VV%22%2C%22type%22%3A%22instance%22%7D%2C%7B%22utbildningsinstansUid%22%3A%22102ef09f-31c6-11ec-8540-ebd4d50c41d5%22%2C%22uid%22%3A%22214ea196-cf4c-11ef-9bca-bbbddaff469b%22%2C%22tillfalleskod%22%3A%2260609%22%2C%22status%22%3A%7B%22code%22%3A%22S3%22%2C%22nameSv%22%3A%22Komplett%22%2C%22nameEn%22%3A%22Complete%22%7D%2C%22utbildningstyp%22%3A%7B%22id%22%3A%2224%22%2C%22code%22%3A%222007AKURS%22%2C%22name%22%3A%22Kurs%2C%20avancerad%20niv%C3%A5%22%2C%22nameOther%22%3A%22Course%2C%20Second-cycle%22%2C%22creditsUnit%22%3A%7B%22code%22%3A%22HP%22%2C%22sv%22%3A%22H%C3%B6gskolepo%C3%A4ng%22%2C%22en%22%3A%22Credits%22%7D%2C%22level%22%3A%7B%22code%22%3A%222%22%2C%22name%22%3A%22Avancerad%20niv%C3%A5%22%7D%7D%2C%22omfattning%22%3A%7B%22number%22%3A7.5%2C%22formattedWithUnit%22%3A%227%2C5%20hp%22%7D%2C%22startperiod%22%3A%7B%22code%22%3A%22VT2026%22%2C%22startDay%22%3A%222026-01-13%22%2C%22lastDay%22%3A%222026-06-01%22%2C%22inDigits%22%3A%2220261%22%7D%2C%22Tillfallesperioder%22%3A%5B%7B%22ForstaRegistreringsdatum%22%3A%222026-01-08%22%2C%22ForstaUndervisningsdatum%22%3A%222026-01-13%22%2C%22Lasperiodsfordelning%22%3A%5B%7B%22Lasperiodskod%22%3A%22P3%22%2C%22Omfattningsvarde%22%3A7.5%2C%22link%22%3A%5B%5D%7D%5D%2C%22Omfattningsvarde%22%3A7.5%2C%22SistaRegistreringsdatum%22%3A%222026-01-19%22%2C%22SistaUndervisningsdatum%22%3A%222026-03-13%22%7D%5D%2C%22kod%22%3A%22IL2240%22%2C%22benamning%22%3A%22Halvledarkomponenter%20f%C3%B6r%20integrerade%20kretsar%22%2C%22Valvillkor%22%3A%22VV%22%2C%22type%22%3A%22instance%22%7D%2C%7B%22utbildningsinstansUid%22%3A%2284d5bbc5-73d8-11e8-b4e0-063f9afb40e3%22%2C%22uid%22%3A%224ee974da-bbb2-11ef-9553-beecfac44351%22%2C%22tillfalleskod%22%3A%2260781%22%2C%22status%22%3A%7B%22code%22%3A%22S3%22%2C%22nameSv%22%3A%22Komplett%22%2C%22nameEn%22%3A%22Complete%22%7D%2C%22utbildningstyp%22%3A%7B%22id%22%3A%2222%22%2C%22code%22%3A%222007GKURS%22%2C%22name%22%3A%22Kurs%2C%20grundniv%C3%A5%22%2C%22nameOther%22%3A%22Course%2C%20First-cycle%22%2C%22creditsUnit%22%3A%7B%22code%22%3A%22HP%22%2C%22sv%22%3A%22H%C3%B6gskolepo%C3%A4ng%22%2C%22en%22%3A%22Credits%22%7D%2C%22level%22%3A%7B%22code%22%3A%221%22%2C%22name%22%3A%22Grundniv%C3%A5%22%7D%7D%2C%22omfattning%22%3A%7B%22number%22%3A7.5%2C%22formattedWithUnit%22%3A%227%2C5%20hp%22%7D%2C%22startperiod%22%3A%7B%22code%22%3A%22VT2026%22%2C%22startDay%22%3A%222026-01-13%22%2C%22lastDay%22%3A%222026-06-01%22%2C%22inDigits%22%3A%2220261%22%7D%2C%22Tillfallesperioder%22%3A%5B%7B%22ForstaRegistreringsdatum%22%3A%222026-03-12%22%2C%22ForstaUndervisningsdatum%22%3A%222026-03-16%22%2C%22Lasperiodsfordelning%22%3A%5B%7B%22Lasperiodskod%22%3A%22P4%22%2C%22Omfattningsvarde%22%3A7.5%2C%22link%22%3A%5B%5D%7D%5D%2C%22Omfattningsvarde%22%3A7.5%2C%22SistaRegistreringsdatum%22%3A%222026-03-23%22%2C%22SistaUndervisningsdatum%22%3A%222026-06-01%22%7D%5D%2C%22kod%22%3A%22SK1119%22%2C%22benamning%22%3A%22Termodynamik%20och%20statistisk%20fysik%22%2C%22Valvillkor%22%3A%22VV%22%2C%22type%22%3A%22instance%22%7D%2C%7B%22utbildningsinstansUid%22%3A%223bd6eff8-d85d-11e8-ab5d-1e2dc82a46e7%22%2C%22uid%22%3A%2242772b86-cdb7-11ef-9e07-d56117ae456b%22%2C%22tillfalleskod%22%3A%2260880%22%2C%22status%22%3A%7B%22code%22%3A%22S3%22%2C%22nameSv%22%3A%22Komplett%22%2C%22nameEn%22%3A%22Complete%22%7D%2C%22utbildningstyp%22%3A%7B%22id%22%3A%2222%22%2C%22code%22%3A%222007GKURS%22%2C%22name%22%3A%22Kurs%2C%20grundniv%C3%A5%22%2C%22nameOther%22%3A%22Course%2C%20First-cycle%22%2C%22creditsUnit%22%3A%7B%22code%22%3A%22HP%22%2C%22sv%22%3A%22H%C3%B6gskolepo%C3%A4ng%22%2C%22en%22%3A%22Credits%22%7D%2C%22level%22%3A%7B%22code%22%3A%221%22%2C%22name%22%3A%22Grundniv%C3%A5%22%7D%7D%2C%22omfattning%22%3A%7B%22number%22%3A6%2C%22formattedWithUnit%22%3A%226%2C0%20hp%22%7D%2C%22startperiod%22%3A%7B%22code%22%3A%22VT2026%22%2C%22startDay%22%3A%222026-01-13%22%2C%22lastDay%22%3A%222026-06-01%22%2C%22inDigits%22%3A%2220261%22%7D%2C%22Tillfallesperioder%22%3A%5B%7B%22ForstaRegistreringsdatum%22%3A%222026-03-12%22%2C%22ForstaUndervisningsdatum%22%3A%222026-03-16%22%2C%22Lasperiodsfordelning%22%3A%5B%7B%22Lasperiodskod%22%3A%22P4%22%2C%22Omfattningsvarde%22%3A6%2C%22link%22%3A%5B%5D%7D%5D%2C%22Omfattningsvarde%22%3A6%2C%22SistaRegistreringsdatum%22%3A%222026-03-23%22%2C%22SistaUndervisningsdatum%22%3A%222026-06-01%22%7D%5D%2C%22kod%22%3A%22EI1222%22%2C%22benamning%22%3A%22Teoretisk%20elektroteknik%2C%20forts%C3%A4ttningskurs%22%2C%22Valvillkor%22%3A%22VV%22%2C%22type%22%3A%22instance%22%7D%2C%7B%22utbildningsinstansUid%22%3A%227fe7389d-73d8-11e8-b4e0-063f9afb40e3%22%2C%22uid%22%3A%2228d67044-ce67-11ef-9bca-bbbddaff469b%22%2C%22tillfalleskod%22%3A%2260882%22%2C%22status%22%3A%7B%22code%22%3A%22S3%22%2C%22nameSv%22%3A%22Komplett%22%2C%22nameEn%22%3A%22Complete%22%7D%2C%22utbildningstyp%22%3A%7B%22id%22%3A%2222%22%2C%22code%22%3A%222007GKURS%22%2C%22name%22%3A%22Kurs%2C%20grundniv%C3%A5%22%2C%22nameOther%22%3A%22Course%2C%20First-cycle%22%2C%22creditsUnit%22%3A%7B%22code%22%3A%22HP%22%2C%22sv%22%3A%22H%C3%B6gskolepo%C3%A4ng%22%2C%22en%22%3A%22Credits%22%7D%2C%22level%22%3A%7B%22code%22%3A%221%22%2C%22name%22%3A%22Grundniv%C3%A5%22%7D%7D%2C%22omfattning%22%3A%7B%22number%22%3A7.5%2C%22formattedWithUnit%22%3A%227%2C5%20hp%22%7D%2C%22startperiod%22%3A%7B%22code%22%3A%22VT2026%22%2C%22startDay%22%3A%222026-01-13%22%2C%22lastDay%22%3A%222026-06-01%22%2C%22inDigits%22%3A%2220261%22%7D%2C%22Tillfallesperioder%22%3A%5B%7B%22ForstaRegistreringsdatum%22%3A%222026-01-08%22%2C%22ForstaUndervisningsdatum%22%3A%222026-01-13%22%2C%22Lasperiodsfordelning%22%3A%5B%7B%22Lasperiodskod%22%3A%22P3%22%2C%22Omfattningsvarde%22%3A7.5%2C%22link%22%3A%5B%5D%7D%5D%2C%22Omfattningsvarde%22%3A7.5%2C%22SistaRegistreringsdatum%22%3A%222026-01-19%22%2C%22SistaUndervisningsdatum%22%3A%222026-03-13%22%7D%5D%2C%22kod%22%3A%22SF1679%22%2C%22benamning%22%3A%22Diskret%20matematik%22%2C%22Valvillkor%22%3A%22VV%22%2C%22type%22%3A%22instance%22%7D%2C%7B%22utbildningsinstansUid%22%3A%227ffb8407-73d8-11e8-b4e0-063f9afb40e3%22%2C%22uid%22%3A%2293367eb9-ce67-11ef-9bca-bbbddaff469b%22%2C%22tillfalleskod%22%3A%2260883%22%2C%22status%22%3A%7B%22code%22%3A%22S3%22%2C%22nameSv%22%3A%22Komplett%22%2C%22nameEn%22%3A%22Complete%22%7D%2C%22utbildningstyp%22%3A%7B%22id%22%3A%2222%22%2C%22code%22%3A%222007GKURS%22%2C%22name%22%3A%22Kurs%2C%20grundniv%C3%A5%22%2C%22nameOther%22%3A%22Course%2C%20First-cycle%22%2C%22creditsUnit%22%3A%7B%22code%22%3A%22HP%22%2C%22sv%22%3A%22H%C3%B6gskolepo%C3%A4ng%22%2C%22en%22%3A%22Credits%22%7D%2C%22level%22%3A%7B%22code%22%3A%221%22%2C%22name%22%3A%22Grundniv%C3%A5%22%7D%7D%2C%22omfattning%22%3A%7B%22number%22%3A7.5%2C%22formattedWithUnit%22%3A%227%2C5%20hp%22%7D%2C%22startperiod%22%3A%7B%22code%22%3A%22VT2026%22%2C%22startDay%22%3A%222026-01-13%22%2C%22lastDay%22%3A%222026-06-01%22%2C%22inDigits%22%3A%2220261%22%7D%2C%22Tillfallesperioder%22%3A%5B%7B%22ForstaRegistreringsdatum%22%3A%222026-01-08%22%2C%22ForstaUndervisningsdatum%22%3A%222026-01-13%22%2C%22Lasperiodsfordelning%22%3A%5B%7B%22Lasperiodskod%22%3A%22P4%22%2C%22Omfattningsvarde%22%3A3.8%2C%22link%22%3A%5B%5D%7D%2C%7B%22Lasperiodskod%22%3A%22P3%22%2C%22Omfattningsvarde%22%3A3.7%2C%22link%22%3A%5B%5D%7D%5D%2C%22Omfattningsvarde%22%3A7.5%2C%22SistaRegistreringsdatum%22%3A%222026-01-19%22%2C%22SistaUndervisningsdatum%22%3A%222026-06-01%22%7D%5D%2C%22kod%22%3A%22SF1691%22%2C%22benamning%22%3A%22Komplex%20analys%22%2C%22Valvillkor%22%3A%22VV%22%2C%22type%22%3A%22instance%22%7D%2C%7B%22utbildningsinstansUid%22%3A%228010e0d4-73d8-11e8-b4e0-063f9afb40e3%22%2C%22uid%22%3A%22fa9003b2-ce67-11ef-9bca-bbbddaff469b%22%2C%22tillfalleskod%22%3A%2260884%22%2C%22status%22%3A%7B%22code%22%3A%22S3%22%2C%22nameSv%22%3A%22Komplett%22%2C%22nameEn%22%3A%22Complete%22%7D%2C%22utbildningstyp%22%3A%7B%22id%22%3A%2222%22%2C%22code%22%3A%222007GKURS%22%2C%22name%22%3A%22Kurs%2C%20grundniv%C3%A5%22%2C%22nameOther%22%3A%22Course%2C%20First-cycle%22%2C%22creditsUnit%22%3A%7B%22code%22%3A%22HP%22%2C%22sv%22%3A%22H%C3%B6gskolepo%C3%A4ng%22%2C%22en%22%3A%22Credits%22%7D%2C%22level%22%3A%7B%22code%22%3A%221%22%2C%22name%22%3A%22Grundniv%C3%A5%22%7D%7D%2C%22omfattning%22%3A%7B%22number%22%3A6%2C%22formattedWithUnit%22%3A%226%2C0%20hp%22%7D%2C%22startperiod%22%3A%7B%22code%22%3A%22VT2026%22%2C%22startDay%22%3A%222026-01-13%22%2C%22lastDay%22%3A%222026-06-01%22%2C%22inDigits%22%3A%2220261%22%7D%2C%22Tillfallesperioder%22%3A%5B%7B%22ForstaRegistreringsdatum%22%3A%222026-03-12%22%2C%22ForstaUndervisningsdatum%22%3A%222026-03-16%22%2C%22Lasperiodsfordelning%22%3A%5B%7B%22Lasperiodskod%22%3A%22P4%22%2C%22Omfattningsvarde%22%3A6%2C%22link%22%3A%5B%5D%7D%5D%2C%22Omfattningsvarde%22%3A6%2C%22SistaRegistreringsdatum%22%3A%222026-03-23%22%2C%22SistaUndervisningsdatum%22%3A%222026-06-01%22%7D%5D%2C%22kod%22%3A%22SF1861%22%2C%22benamning%22%3A%22Optimeringsl%C3%A4ra%22%2C%22Valvillkor%22%3A%22VV%22%2C%22type%22%3A%22instance%22%7D%2C%7B%22utbildningsinstansUid%22%3A%2281bbaa64-73d8-11e8-b4e0-063f9afb40e3%22%2C%22uid%22%3A%22519492ef-bea4-11ef-9c9e-74b5caef4769%22%2C%22tillfalleskod%22%3A%2260886%22%2C%22status%22%3A%7B%22code%22%3A%22S3%22%2C%22nameSv%22%3A%22Komplett%22%2C%22nameEn%22%3A%22Complete%22%7D%2C%22utbildningstyp%22%3A%7B%22id%22%3A%2222%22%2C%22code%22%3A%222007GKURS%22%2C%22name%22%3A%22Kurs%2C%20grundniv%C3%A5%22%2C%22nameOther%22%3A%22Course%2C%20First-cycle%22%2C%22creditsUnit%22%3A%7B%22code%22%3A%22HP%22%2C%22sv%22%3A%22H%C3%B6gskolepo%C3%A4ng%22%2C%22en%22%3A%22Credits%22%7D%2C%22level%22%3A%7B%22code%22%3A%221%22%2C%22name%22%3A%22Grundniv%C3%A5%22%7D%7D%2C%22omfattning%22%3A%7B%22number%22%3A9%2C%22formattedWithUnit%22%3A%229%2C0%20hp%22%7D%2C%22startperiod%22%3A%7B%22code%22%3A%22VT2026%22%2C%22startDay%22%3A%222026-01-13%22%2C%22lastDay%22%3A%222026-06-01%22%2C%22inDigits%22%3A%2220261%22%7D%2C%22Tillfallesperioder%22%3A%5B%7B%22ForstaRegistreringsdatum%22%3A%222026-01-08%22%2C%22ForstaUndervisningsdatum%22%3A%222026-01-13%22%2C%22Lasperiodsfordelning%22%3A%5B%7B%22Lasperiodskod%22%3A%22P4%22%2C%22Omfattningsvarde%22%3A4.5%2C%22link%22%3A%5B%5D%7D%2C%7B%22Lasperiodskod%22%3A%22P3%22%2C%22Omfattningsvarde%22%3A4.5%2C%22link%22%3A%5B%5D%7D%5D%2C%22Omfattningsvarde%22%3A9%2C%22SistaRegistreringsdatum%22%3A%222026-01-19%22%2C%22SistaUndervisningsdatum%22%3A%222026-06-01%22%7D%5D%2C%22kod%22%3A%22SG1130%22%2C%22benamning%22%3A%22Mekanik%20I%22%2C%22Valvillkor%22%3A%22VV%22%2C%22type%22%3A%22instance%22%7D%2C%7B%22utbildningsinstansUid%22%3A%22841e04ac-73d8-11e8-b4e0-063f9afb40e3%22%2C%22uid%22%3A%221ba5b1dd-bbab-11ef-9553-beecfac44351%22%2C%22tillfalleskod%22%3A%2260181%22%2C%22status%22%3A%7B%22code%22%3A%22S3%22%2C%22nameSv%22%3A%22Komplett%22%2C%22nameEn%22%3A%22Complete%22%7D%2C%22utbildningstyp%22%3A%7B%22id%22%3A%2222%22%2C%22code%22%3A%222007GKURS%22%2C%22name%22%3A%22Kurs%2C%20grundniv%C3%A5%22%2C%22nameOther%22%3A%22Course%2C%20First-cycle%22%2C%22creditsUnit%22%3A%7B%22code%22%3A%22HP%22%2C%22sv%22%3A%22H%C3%B6gskolepo%C3%A4ng%22%2C%22en%22%3A%22Credits%22%7D%2C%22level%22%3A%7B%22code%22%3A%221%22%2C%22name%22%3A%22Grundniv%C3%A5%22%7D%7D%2C%22omfattning%22%3A%7B%22number%22%3A4%2C%22formattedWithUnit%22%3A%224%2C0%20hp%22%7D%2C%22startperiod%22%3A%7B%22code%22%3A%22VT2026%22%2C%22startDay%22%3A%222026-01-13%22%2C%22lastDay%22%3A%222026-06-01%22%2C%22inDigits%22%3A%2220261%22%7D%2C%22Tillfallesperioder%22%3A%5B%7B%22ForstaRegistreringsdatum%22%3A%222026-01-08%22%2C%22ForstaUndervisningsdatum%22%3A%222026-01-13%22%2C%22Lasperiodsfordelning%22%3A%5B%7B%22Lasperiodskod%22%3A%22P3%22%2C%22Omfattningsvarde%22%3A4%2C%22link%22%3A%5B%5D%7D%5D%2C%22Omfattningsvarde%22%3A4%2C%22SistaRegistreringsdatum%22%3A%222026-01-19%22%2C%22SistaUndervisningsdatum%22%3A%222026-03-13%22%7D%5D%2C%22kod%22%3A%22SI1200%22%2C%22benamning%22%3A%22Fysikens%20matematiska%20metoder%22%2C%22Valvillkor%22%3A%22VV%22%2C%22type%22%3A%22instance%22%7D%2C%7B%22utbildningsinstansUid%22%3A%224e2ddf86-af0d-11f0-a2d9-d8333a7b420f%22%2C%22uid%22%3A%2202196236-cf61-11ef-9bca-bbbddaff469b%22%2C%22tillfalleskod%22%3A%2261019%22%2C%22status%22%3A%7B%22code%22%3A%22S3%22%2C%22nameSv%22%3A%22Komplett%22%2C%22nameEn%22%3A%22Complete%22%7D%2C%22utbildningstyp%22%3A%7B%22id%22%3A%2222%22%2C%22code%22%3A%222007GKURS%22%2C%22name%22%3A%22Kurs%2C%20grundniv%C3%A5%22%2C%22nameOther%22%3A%22Course%2C%20First-cycle%22%2C%22creditsUnit%22%3A%7B%22code%22%3A%22HP%22%2C%22sv%22%3A%22H%C3%B6gskolepo%C3%A4ng%22%2C%22en%22%3A%22Credits%22%7D%2C%22level%22%3A%7B%22code%22%3A%221%22%2C%22name%22%3A%22Grundniv%C3%A5%22%7D%7D%2C%22omfattning%22%3A%7B%22number%22%3A6%2C%22formattedWithUnit%22%3A%226%2C0%20hp%22%7D%2C%22startperiod%22%3A%7B%22code%22%3A%22VT2026%22%2C%22startDay%22%3A%222026-01-13%22%2C%22lastDay%22%3A%222026-06-01%22%2C%22inDigits%22%3A%2220261%22%7D%2C%22Tillfallesperioder%22%3A%5B%7B%22ForstaRegistreringsdatum%22%3A%222026-01-08%22%2C%22ForstaUndervisningsdatum%22%3A%222026-01-13%22%2C%22Lasperiodsfordelning%22%3A%5B%7B%22Lasperiodskod%22%3A%22P3%22%2C%22Omfattningsvarde%22%3A3%2C%22link%22%3A%5B%5D%7D%2C%7B%22Lasperiodskod%22%3A%22P4%22%2C%22Omfattningsvarde%22%3A3%2C%22link%22%3A%5B%5D%7D%5D%2C%22Omfattningsvarde%22%3A6%2C%22SistaRegistreringsdatum%22%3A%222026-01-19%22%2C%22SistaUndervisningsdatum%22%3A%222026-06-01%22%7D%5D%2C%22kod%22%3A%22MH1023%22%2C%22benamning%22%3A%22Praktiskt%20j%C3%A4mst%C3%A4lldhets-%20och%20m%C3%A5ngfaldsarbete%20i%20vetenskapliga%2C%20tekniska%20och%20industriella%20milj%C3%B6er%22%2C%22Valvillkor%22%3A%22VV%22%2C%22type%22%3A%22instance%22%7D%2C%7B%22utbildningsinstansUid%22%3A%2282b9b96c-73d8-11e8-b4e0-063f9afb40e3%22%2C%22uid%22%3A%22914008b3-bba7-11ef-9553-beecfac44351%22%2C%22tillfalleskod%22%3A%2261083%22%2C%22status%22%3A%7B%22code%22%3A%22S3%22%2C%22nameSv%22%3A%22Komplett%22%2C%22nameEn%22%3A%22Complete%22%7D%2C%22utbildningstyp%22%3A%7B%22id%22%3A%2222%22%2C%22code%22%3A%222007GKURS%22%2C%22name%22%3A%22Kurs%2C%20grundniv%C3%A5%22%2C%22nameOther%22%3A%22Course%2C%20First-cycle%22%2C%22creditsUnit%22%3A%7B%22code%22%3A%22HP%22%2C%22sv%22%3A%22H%C3%B6gskolepo%C3%A4ng%22%2C%22en%22%3A%22Credits%22%7D%2C%22level%22%3A%7B%22code%22%3A%221%22%2C%22name%22%3A%22Grundniv%C3%A5%22%7D%7D%2C%22omfattning%22%3A%7B%22number%22%3A8%2C%22formattedWithUnit%22%3A%228%2C0%20hp%22%7D%2C%22startperiod%22%3A%7B%22code%22%3A%22VT2026%22%2C%22startDay%22%3A%222026-01-13%22%2C%22lastDay%22%3A%222026-06-01%22%2C%22inDigits%22%3A%2220261%22%7D%2C%22Tillfallesperioder%22%3A%5B%7B%22ForstaRegistreringsdatum%22%3A%222026-01-08%22%2C%22ForstaUndervisningsdatum%22%3A%222026-01-13%22%2C%22Lasperiodsfordelning%22%3A%5B%7B%22Lasperiodskod%22%3A%22P4%22%2C%22Omfattningsvarde%22%3A6%2C%22link%22%3A%5B%5D%7D%2C%7B%22Lasperiodskod%22%3A%22P3%22%2C%22Omfattningsvarde%22%3A2%2C%22link%22%3A%5B%5D%7D%5D%2C%22Omfattningsvarde%22%3A8%2C%22SistaRegistreringsdatum%22%3A%222026-01-19%22%2C%22SistaUndervisningsdatum%22%3A%222026-06-01%22%7D%5D%2C%22kod%22%3A%22SH1012%22%2C%22benamning%22%3A%22Modern%20fysik%22%2C%22Valvillkor%22%3A%22VV%22%2C%22type%22%3A%22instance%22%7D%5D%2C%22freeTexts%22%3A%5B%5D%2C%22supplementaryInfo%22%3A%22%3Cp%3EUnder%20de%20f%C3%B6rsta%20tre%20%C3%A5ren%20finns%20utrymme%20f%C3%B6r%20en%20valfri%20kurs.%3C%2Fp%3E%22%2C%22conditionallyElectiveCoursesInfo%22%3A%22%3Cp%3ETre%20villkorligt%20valfria%20kurser%20ska%20l%C3%A4sas%20i%20%C3%A5rskurs%202%20eller%203.%3C%2Fp%3E%22%7D%2C%7B%22yearNumber%22%3A4%2C%22courses%22%3A%5B%5D%2C%22freeTexts%22%3A%5B%5D%2C%22supplementaryInfo%22%3A%22%3Cp%3E%C3%85rskurs%204-5%20l%C3%A4ses%20p%C3%A5%20ett%20masterprogram%20och%20d%C3%A5%20f%C3%B6ljs%20utbildningsplanen%20f%C3%B6r%20programmet%20i%20fr%C3%A5ga.%3C%2Fp%3E%22%7D%2C%7B%22yearNumber%22%3A5%2C%22courses%22%3A%5B%5D%2C%22freeTexts%22%3A%5B%5D%2C%22supplementaryInfo%22%3A%22%3Cp%3E%C3%85rskurs%204-5%20l%C3%A4ses%20p%C3%A5%20ett%20masterprogram%20och%20d%C3%A5%20f%C3%B6ljs%20utbildningsplanen%20f%C3%B6r%20programmet%20i%20fr%C3%A5ga.%3C%2Fp%3E%22%7D%5D%7D%5D%2C%22errorType%22%3A%7B%22MISSING_ADMISSION%22%3A%22missing_admission%22%7D%2C%22error%22%3Anull%2C%22curriculumInfos%22%3A%5B%7B%22code%22%3A%22%22%2C%22specializationName%22%3Anull%2C%22isCommon%22%3Atrue%2C%22participations%22%3A%7B%22O%22%3A%5B%7B%22course%22%3A%7B%22courseCode%22%3A%22EH1110%22%2C%22title%22%3A%22Elektroteknikens%20betydelse%20f%C3%B6r%20ett%20modernt%20samh%C3%A4lle%22%2C%22credits%22%3A7.5%2C%22formattedCredits%22%3A%227%2C5%20hp%22%2C%22educationalLevel%22%3A%22Grundniv%C3%A5%22%2C%22electiveCondition%22%3A%22O%22%2C%22status%22%3A%7B%22code%22%3A%22S3%22%2C%22nameSv%22%3A%22Komplett%22%2C%22nameEn%22%3A%22Complete%22%7D%7D%2C%22applicationCode%22%3A%2250814%22%2C%22term%22%3A%2220232%22%2C%22creditsPerPeriod%22%3A%5B0%2C0%2C0.5%2C1.5%2C1%2C0%5D%7D%2C%7B%22course%22%3A%7B%22courseCode%22%3A%22EJ1200%22%2C%22title%22%3A%22Eleffektsystem%22%2C%22credits%22%3A6%2C%22formattedCredits%22%3A%226%2C0%20hp%22%2C%22educationalLevel%22%3A%22Grundniv%C3%A5%22%2C%22electiveCondition%22%3A%22O%22%2C%22status%22%3A%7B%22code%22%3A%22S3%22%2C%22nameSv%22%3A%22Komplett%22%2C%22nameEn%22%3A%22Complete%22%7D%7D%2C%22applicationCode%22%3A%2251142%22%2C%22term%22%3A%2220252%22%2C%22creditsPerPeriod%22%3A%5B0%2C0%2C6%2C0%2C0%2C0%5D%7D%2C%7B%22course%22%3A%7B%22courseCode%22%3A%22EK1191%22%2C%22title%22%3A%22M%C3%A4tteknik%22%2C%22credits%22%3A6%2C%22formattedCredits%22%3A%226%2C0%20hp%22%2C%22educationalLevel%22%3A%22Grundniv%C3%A5%22%2C%22electiveCondition%22%3A%22O%22%2C%22status%22%3A%7B%22code%22%3A%22S3%22%2C%22nameSv%22%3A%22Komplett%22%2C%22nameEn%22%3A%22Complete%22%7D%7D%2C%22applicationCode%22%3A%2251143%22%2C%22term%22%3A%2220252%22%2C%22creditsPerPeriod%22%3A%5B0%2C3%2C3%2C0%2C0%2C0%5D%7D%2C%7B%22course%22%3A%7B%22courseCode%22%3A%22EQ1270%22%2C%22title%22%3A%22Stokastiska%20signaler%20och%20system%22%2C%22credits%22%3A6%2C%22formattedCredits%22%3A%226%2C0%20hp%22%2C%22educationalLevel%22%3A%22Grundniv%C3%A5%22%2C%22electiveCondition%22%3A%22O%22%2C%22status%22%3A%7B%22code%22%3A%22S3%22%2C%22nameSv%22%3A%22Komplett%22%2C%22nameEn%22%3A%22Complete%22%7D%7D%2C%22applicationCode%22%3A%2251144%22%2C%22term%22%3A%2220252%22%2C%22creditsPerPeriod%22%3A%5B0%2C0%2C6%2C0%2C0%2C0%5D%7D%2C%7B%22course%22%3A%7B%22courseCode%22%3A%22IE1207%22%2C%22title%22%3A%22Analog%20Elektronik%22%2C%22credits%22%3A6%2C%22formattedCredits%22%3A%226%2C0%20hp%22%2C%22educationalLevel%22%3A%22Grundniv%C3%A5%22%2C%22electiveCondition%22%3A%22O%22%2C%22status%22%3A%7B%22code%22%3A%22S3%22%2C%22nameSv%22%3A%22Komplett%22%2C%22nameEn%22%3A%22Complete%22%7D%7D%2C%22applicationCode%22%3A%2251145%22%2C%22term%22%3A%2220252%22%2C%22creditsPerPeriod%22%3A%5B0%2C6%2C0%2C0%2C0%2C0%5D%7D%2C%7B%22course%22%3A%7B%22courseCode%22%3A%22EL1020%22%2C%22title%22%3A%22Reglerteknik%2C%20allm%C3%A4n%20kurs%22%2C%22credits%22%3A6%2C%22formattedCredits%22%3A%226%2C0%20hp%22%2C%22educationalLevel%22%3A%22Grundniv%C3%A5%22%2C%22electiveCondition%22%3A%22O%22%2C%22status%22%3A%7B%22code%22%3A%22S3%22%2C%22nameSv%22%3A%22Komplett%22%2C%22nameEn%22%3A%22Complete%22%7D%7D%2C%22applicationCode%22%3A%2251147%22%2C%22term%22%3A%2220252%22%2C%22creditsPerPeriod%22%3A%5B0%2C6%2C0%2C0%2C0%2C0%5D%7D%2C%7B%22course%22%3A%7B%22courseCode%22%3A%22EF112X%22%2C%22title%22%3A%22Examensarbete%20inom%20elektroteknik%2C%20grundniv%C3%A5%22%2C%22credits%22%3A15%2C%22formattedCredits%22%3A%2215%2C0%20hp%22%2C%22educationalLevel%22%3A%22Grundniv%C3%A5%22%2C%22electiveCondition%22%3A%22O%22%2C%22status%22%3A%7B%22code%22%3A%22S3%22%2C%22nameSv%22%3A%22Komplett%22%2C%22nameEn%22%3A%22Complete%22%7D%7D%2C%22applicationCode%22%3A%2260889%22%2C%22term%22%3A%2220261%22%2C%22creditsPerPeriod%22%3A%5B0%2C0%2C0%2C7.5%2C7.5%2C0%5D%7D%5D%2C%22VV%22%3A%5B%7B%22course%22%3A%7B%22courseCode%22%3A%22DD1320%22%2C%22title%22%3A%22Till%C3%A4mpad%20datalogi%22%2C%22credits%22%3A6%2C%22formattedCredits%22%3A%226%2C0%20hp%22%2C%22educationalLevel%22%3A%22Grundniv%C3%A5%22%2C%22electiveCondition%22%3A%22VV%22%2C%22status%22%3A%7B%22code%22%3A%22S3%22%2C%22nameSv%22%3A%22Komplett%22%2C%22nameEn%22%3A%22Complete%22%7D%7D%2C%22applicationCode%22%3A%2260104%22%2C%22term%22%3A%2220261%22%2C%22creditsPerPeriod%22%3A%5B0%2C0%2C0%2C6%2C0%2C0%5D%7D%2C%7B%22course%22%3A%7B%22courseCode%22%3A%22EP1100%22%2C%22title%22%3A%22Datakommunikation%20och%20datorn%C3%A4t%22%2C%22credits%22%3A7.5%2C%22formattedCredits%22%3A%227%2C5%20hp%22%2C%22educationalLevel%22%3A%22Grundniv%C3%A5%22%2C%22electiveCondition%22%3A%22VV%22%2C%22status%22%3A%7B%22code%22%3A%22S3%22%2C%22nameSv%22%3A%22Komplett%22%2C%22nameEn%22%3A%22Complete%22%7D%7D%2C%22applicationCode%22%3A%2260258%22%2C%22term%22%3A%2220261%22%2C%22creditsPerPeriod%22%3A%5B0%2C0%2C0%2C7.5%2C0%2C0%5D%7D%2C%7B%22course%22%3A%7B%22courseCode%22%3A%22DD1388%22%2C%22title%22%3A%22Programsystemkonstruktion%20med%20C%2B%2B%22%2C%22credits%22%3A7.5%2C%22formattedCredits%22%3A%227%2C5%20hp%22%2C%22educationalLevel%22%3A%22Grundniv%C3%A5%22%2C%22electiveCondition%22%3A%22VV%22%2C%22status%22%3A%7B%22code%22%3A%22S3%22%2C%22nameSv%22%3A%22Komplett%22%2C%22nameEn%22%3A%22Complete%22%7D%7D%2C%22applicationCode%22%3A%2260314%22%2C%22term%22%3A%2220261%22%2C%22creditsPerPeriod%22%3A%5B0%2C0%2C0%2C4%2C3.5%2C0%5D%7D%2C%7B%22course%22%3A%7B%22courseCode%22%3A%22SF1546%22%2C%22title%22%3A%22Numeriska%20metoder%2C%20grundkurs%22%2C%22credits%22%3A6%2C%22formattedCredits%22%3A%226%2C0%20hp%22%2C%22educationalLevel%22%3A%22Grundniv%C3%A5%22%2C%22electiveCondition%22%3A%22VV%22%2C%22status%22%3A%7B%22code%22%3A%22S3%22%2C%22nameSv%22%3A%22Komplett%22%2C%22nameEn%22%3A%22Complete%22%7D%7D%2C%22applicationCode%22%3A%2260335%22%2C%22term%22%3A%2220261%22%2C%22creditsPerPeriod%22%3A%5B0%2C0%2C0%2C4%2C2%2C0%5D%7D%2C%7B%22course%22%3A%7B%22courseCode%22%3A%22IL2240%22%2C%22title%22%3A%22Halvledarkomponenter%20f%C3%B6r%20integrerade%20kretsar%22%2C%22credits%22%3A7.5%2C%22formattedCredits%22%3A%227%2C5%20hp%22%2C%22educationalLevel%22%3A%22Avancerad%20niv%C3%A5%22%2C%22electiveCondition%22%3A%22VV%22%2C%22status%22%3A%7B%22code%22%3A%22S3%22%2C%22nameSv%22%3A%22Komplett%22%2C%22nameEn%22%3A%22Complete%22%7D%7D%2C%22applicationCode%22%3A%2260609%22%2C%22term%22%3A%2220261%22%2C%22creditsPerPeriod%22%3A%5B0%2C0%2C0%2C7.5%2C0%2C0%5D%7D%2C%7B%22course%22%3A%7B%22courseCode%22%3A%22SK1119%22%2C%22title%22%3A%22Termodynamik%20och%20statistisk%20fysik%22%2C%22credits%22%3A7.5%2C%22formattedCredits%22%3A%227%2C5%20hp%22%2C%22educationalLevel%22%3A%22Grundniv%C3%A5%22%2C%22electiveCondition%22%3A%22VV%22%2C%22status%22%3A%7B%22code%22%3A%22S3%22%2C%22nameSv%22%3A%22Komplett%22%2C%22nameEn%22%3A%22Complete%22%7D%7D%2C%22applicationCode%22%3A%2260781%22%2C%22term%22%3A%2220261%22%2C%22creditsPerPeriod%22%3A%5B0%2C0%2C0%2C0%2C7.5%2C0%5D%7D%2C%7B%22course%22%3A%7B%22courseCode%22%3A%22EI1222%22%2C%22title%22%3A%22Teoretisk%20elektroteknik%2C%20forts%C3%A4ttningskurs%22%2C%22credits%22%3A6%2C%22formattedCredits%22%3A%226%2C0%20hp%22%2C%22educationalLevel%22%3A%22Grundniv%C3%A5%22%2C%22electiveCondition%22%3A%22VV%22%2C%22status%22%3A%7B%22code%22%3A%22S3%22%2C%22nameSv%22%3A%22Komplett%22%2C%22nameEn%22%3A%22Complete%22%7D%7D%2C%22applicationCode%22%3A%2260880%22%2C%22term%22%3A%2220261%22%2C%22creditsPerPeriod%22%3A%5B0%2C0%2C0%2C0%2C6%2C0%5D%7D%2C%7B%22course%22%3A%7B%22courseCode%22%3A%22SF1679%22%2C%22title%22%3A%22Diskret%20matematik%22%2C%22credits%22%3A7.5%2C%22formattedCredits%22%3A%227%2C5%20hp%22%2C%22educationalLevel%22%3A%22Grundniv%C3%A5%22%2C%22electiveCondition%22%3A%22VV%22%2C%22status%22%3A%7B%22code%22%3A%22S3%22%2C%22nameSv%22%3A%22Komplett%22%2C%22nameEn%22%3A%22Complete%22%7D%7D%2C%22applicationCode%22%3A%2260882%22%2C%22term%22%3A%2220261%22%2C%22creditsPerPeriod%22%3A%5B0%2C0%2C0%2C7.5%2C0%2C0%5D%7D%2C%7B%22course%22%3A%7B%22courseCode%22%3A%22SF1691%22%2C%22title%22%3A%22Komplex%20analys%22%2C%22credits%22%3A7.5%2C%22formattedCredits%22%3A%227%2C5%20hp%22%2C%22educationalLevel%22%3A%22Grundniv%C3%A5%22%2C%22electiveCondition%22%3A%22VV%22%2C%22status%22%3A%7B%22code%22%3A%22S3%22%2C%22nameSv%22%3A%22Komplett%22%2C%22nameEn%22%3A%22Complete%22%7D%7D%2C%22applicationCode%22%3A%2260883%22%2C%22term%22%3A%2220261%22%2C%22creditsPerPeriod%22%3A%5B0%2C0%2C0%2C3.7%2C3.8%2C0%5D%7D%2C%7B%22course%22%3A%7B%22courseCode%22%3A%22SF1861%22%2C%22title%22%3A%22Optimeringsl%C3%A4ra%22%2C%22credits%22%3A6%2C%22formattedCredits%22%3A%226%2C0%20hp%22%2C%22educationalLevel%22%3A%22Grundniv%C3%A5%22%2C%22electiveCondition%22%3A%22VV%22%2C%22status%22%3A%7B%22code%22%3A%22S3%22%2C%22nameSv%22%3A%22Komplett%22%2C%22nameEn%22%3A%22Complete%22%7D%7D%2C%22applicationCode%22%3A%2260884%22%2C%22term%22%3A%2220261%22%2C%22creditsPerPeriod%22%3A%5B0%2C0%2C0%2C0%2C6%2C0%5D%7D%2C%7B%22course%22%3A%7B%22courseCode%22%3A%22SG1130%22%2C%22title%22%3A%22Mekanik%20I%22%2C%22credits%22%3A9%2C%22formattedCredits%22%3A%229%2C0%20hp%22%2C%22educationalLevel%22%3A%22Grundniv%C3%A5%22%2C%22electiveCondition%22%3A%22VV%22%2C%22status%22%3A%7B%22code%22%3A%22S3%22%2C%22nameSv%22%3A%22Komplett%22%2C%22nameEn%22%3A%22Complete%22%7D%7D%2C%22applicationCode%22%3A%2260886%22%2C%22term%22%3A%2220261%22%2C%22creditsPerPeriod%22%3A%5B0%2C0%2C0%2C4.5%2C4.5%2C0%5D%7D%2C%7B%22course%22%3A%7B%22courseCode%22%3A%22SI1200%22%2C%22title%22%3A%22Fysikens%20matematiska%20metoder%22%2C%22credits%22%3A4%2C%22formattedCredits%22%3A%224%2C0%20hp%22%2C%22educationalLevel%22%3A%22Grundniv%C3%A5%22%2C%22electiveCondition%22%3A%22VV%22%2C%22status%22%3A%7B%22code%22%3A%22S3%22%2C%22nameSv%22%3A%22Komplett%22%2C%22nameEn%22%3A%22Complete%22%7D%7D%2C%22applicationCode%22%3A%2260181%22%2C%22term%22%3A%2220261%22%2C%22creditsPerPeriod%22%3A%5B0%2C0%2C0%2C4%2C0%2C0%5D%7D%2C%7B%22course%22%3A%7B%22courseCode%22%3A%22MH1023%22%2C%22title%22%3A%22Praktiskt%20j%C3%A4mst%C3%A4lldhets-%20och%20m%C3%A5ngfaldsarbete%20i%20vetenskapliga%2C%20tekniska%20och%20industriella%20milj%C3%B6er%22%2C%22credits%22%3A6%2C%22formattedCredits%22%3A%226%2C0%20hp%22%2C%22educationalLevel%22%3A%22Grundniv%C3%A5%22%2C%22electiveCondition%22%3A%22VV%22%2C%22status%22%3A%7B%22code%22%3A%22S3%22%2C%22nameSv%22%3A%22Komplett%22%2C%22nameEn%22%3A%22Complete%22%7D%7D%2C%22applicationCode%22%3A%2261019%22%2C%22term%22%3A%2220261%22%2C%22creditsPerPeriod%22%3A%5B0%2C0%2C0%2C3%2C3%2C0%5D%7D%2C%7B%22course%22%3A%7B%22courseCode%22%3A%22SH1012%22%2C%22title%22%3A%22Modern%20fysik%22%2C%22credits%22%3A8%2C%22formattedCredits%22%3A%228%2C0%20hp%22%2C%22educationalLevel%22%3A%22Grundniv%C3%A5%22%2C%22electiveCondition%22%3A%22VV%22%2C%22status%22%3A%7B%22code%22%3A%22S3%22%2C%22nameSv%22%3A%22Komplett%22%2C%22nameEn%22%3A%22Complete%22%7D%7D%2C%22applicationCode%22%3A%2261083%22%2C%22term%22%3A%2220261%22%2C%22creditsPerPeriod%22%3A%5B0%2C0%2C0%2C2%2C6%2C0%5D%7D%5D%7D%2C%22supplementaryInformation%22%3A%22%3Cp%3EUnder%20de%20f%C3%B6rsta%20tre%20%C3%A5ren%20finns%20utrymme%20f%C3%B6r%20en%20valfri%20kurs.%3C%2Fp%3E%22%2C%22conditionallyElectiveCoursesInformation%22%3A%22%3Cp%3ETre%20villkorligt%20valfria%20kurser%20ska%20l%C3%A4sas%20i%20%C3%A5rskurs%202%20eller%203.%3C%2Fp%3E%22%2C%22isFirstSpec%22%3Afalse%2C%22hasInfo%22%3Atrue%2C%22freeTexts%22%3A%5B%5D%7D%5D%2C%22lengthInStudyYears%22%3A5%2C%22thisHostBaseUrl%22%3Anull%7D";</script>
+
+<!---->
+
+  <div id="app"></div>
+    </div>
+  </div>
+  <!--indexOff: all-->
+  <!-- add "scroll-to-top" button when scrolled down -->
+  <div id="back-to-top" role="link" aria-label="Till sidans topp"></div>
+  <footer class="kth-footer student-web">
+      <div class="kth-footer__content">
+              
+  
+  
+  
+  
+    <div class="columnSplitterWrapper" data-cid="1.1066523" lang="sv">
+      
+      <div class="columnSplitter  using4Columns ">
+        <div class="col c1">
+          
+  
+  
+  
+  
+    <div class="block list links" data-cid="1.1066524" lang="sv">
+      <h2>Studentwebben</h2>
+      
+      <ul>
+        <li><a href="/student/studier">Studier</a></li>
+        <li><a href="/student/stod">Stöd och vägledning</a></li>
+        <li><a href="/student/it">IT och digitala tjänster</a></li>
+        <li><a href="/student/kontakt">Kontakt</a></li>
+      </ul>
+    </div>
+  
+  
+  
+        </div>
+        <div class="col c2">
+          
+  
+  
+  
+  
+    <div class="block list links" data-cid="1.1066531" lang="sv">
+      <h2>Tjänster</h2>
+      
+      <ul>
+        <li><a href="/student/studier/schema">Schema</a></li>
+        <li><a href="https://canvas.kth.se/">Canvas</a></li>
+        <li><a href="http://webmail.kth.se">Webbmejl</a></li>
+        <li><a href="/student/it/studenttjanster/personligamenyn">Personliga menyn</a></li>
+        <li><a href="https://www.student.ladok.se/student/app/studentwebb/">Ladok för studenter</a></li>
+      </ul>
+    </div>
+  
+  
+  
+        </div>
+        <div class="col c3">
+          
+  
+  
+  
+  
+    <div class="block list links" data-cid="1.1066534" lang="sv">
+      <h2>Kontakt</h2>
+      
+      <ul>
+        <li><a href="/student/kontakt/kontaktuppgifter/kontakta-utbildningsprogram-1.1170401">Kontakta utbildningsprogram</a></li>
+        <li><a href="/student/kontakt/kontaktuppgifter/kontakta-kurs-1.1171899">Kontakta kurs</a></li>
+        <li><a href="/student/it/contact">IT-support</a></li>
+        <li><a href="/student/kontakt/campus/kth-entre">KTH Entré</a></li>
+        <li><a href="/student/kontakt/campus/kth-biblioteket-1.2479">KTH Biblioteket</a></li>
+      </ul>
+    </div>
+  
+  
+  
+        </div>
+        <div class="col c4">
+          
+  
+  
+  
+  
+    <article class="block teaser top white" data-cid="1.1083631" lang="sv">
+      
+      <div class="teaserBody   ">
+        
+        
+        <div class="lead">
+          
+          
+        
+          
+          <p><strong>KTH</strong><br> <em>100 44 Stockholm<br> +46 8 790 60 00<br>
+        
+      
+        
+          
+  
+  
+  
+  
+    <a class="block link" data-cid="1.1083633" lang="sv" href="mailto:info@kth.se">info@kth.se</a>
+  
+  
+  
+          
+        
+      
+        
+          
+          </em><br> &nbsp;</p>
+        
+      
+        </div>
+        
+      </div>
+    </article>
+  
+  
+  
+        </div>
+      </div>
+    </div>
+  
+  
+  
+      </div>
+  </footer>
+  <!--indexOn: all-->  <script src="/student/kurser/static/app.js?v=2.0.0-20260427.1_59b0"></script>
+</body>
+
+</html>

--- a/tests/fixtures/program_CFATE_20232_arskurs3.html
+++ b/tests/fixtures/program_CFATE_20232_arskurs3.html
@@ -1,0 +1,681 @@
+<!DOCTYPE html>
+<html lang="sv">
+
+<head>
+  <title>Civilingenjörsutbildning i farkostteknik (CFATE), Utbildningsplan kull HT2023, Årskurs 3 | KTH</title>
+  <meta charset="utf-8">
+  <meta http-equiv="X-UA-Compatible" content="IE=edge">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <meta name="description" content="">
+  <link rel="shortcut icon" id="favicon" href="/student/kurser/static/icon/favicon">
+
+
+  
+  
+  
+
+  <link href="/student/kurser/static/kth-style/css/kth-bootstrap.css?v=2.0.0-20260427.1_59b0" media="screen" rel="stylesheet">
+<link href="/student/kurser/assets/fonts.css?v=2.0.0-20260427.1_59b0" media="screen" rel="stylesheet">
+<link href="/student/kurser/static/app.css?v=2.0.0-20260427.1_59b0" media="screen" rel="stylesheet">
+
+    
+
+
+
+
+  <!-- Begin JavaScript contentId-1_1137647 -->
+  <script>var klaroConfig = {
+    testing: false,
+  acceptAll: true,
+  styling: {
+      theme: [],
+  },
+  htmlTexts: false,
+  groupByPurpose: false,
+  storageMethod: 'cookie',
+  cookieDomain: 'kth.se',
+  cookieExpiresAfterDays: 30,
+  hideDeclineAll: false,
+  translations: {
+      sv: {
+          service: {
+            disableAll: {
+              description: 'Använd detta reglage för att tillåta alla tjänster eller endast nödvändiga.',
+              title: 'Ändra för alla tjänster',
+            },
+          },
+          consentModal: {
+            description:
+              'Här kan du se och anpassa vilken information vi samlar om dig.',
+          },
+          privacyPolicy: {
+              name: 'kakor',
+              text: 'Läs mer om hur vi hanterar {privacyPolicy}.',
+          },
+          privacyPolicyUrl: 'https://www.kth.se/gemensamt/om-kakor-cookies-pa-kth-s-webbplats-1.844',
+          consentNotice: {
+              title: '',
+              testing: 'Observera att Klaro körs i testläge',
+              description: 'Denna webbplats använder tjänster som kan lagra information om dig och hur du använder denna webbplats. Vissa tjänster är nödvändiga för att webbplatsen ska fungera och andra är valbara.',
+              learnMore: 'Hantera valbara tjänster',
+          },
+          decline: 'Tillåt bara nödvändiga tjänster',
+          ok: 'Tillåt alla tjänster',
+          purposeItem: {
+              service: 'Tjänster'
+          },
+            contextualConsent:{
+                acceptAlways: 'Alltid',
+                acceptOnce: 'Ja',
+                description: 'Du har tidigare nekat visning av innehåll av typen "{title}". Vill du visa innehållet?',
+          }
+      },
+      en: {
+          service: {
+            disableAll: {
+              description: 'Use this slider to allow all cookies or only necessary.',
+              title: 'Change for all services',
+            },
+          },
+        consentModal: {
+            description:
+              'Here you can assess and customise the services we use on this website.',
+          },
+          privacyPolicy: {
+              name: 'cookies',
+              text: 'Find out more about our usage of {privacyPolicy}.',
+          },
+          privacyPolicyUrl: 'https://www.kth.se/en/gemensamt/om-kakor-cookies-pa-kth-s-webbplats-1.844',
+          consentNotice: {
+              title: '',
+              testing: 'Please note that Klaro is currently running in test mode',
+              description: 'This website uses services that may store information about you and how you use the website. Some services are necessary for the website to work, and others are optional.',
+              learnMore: 'Manage services',
+          },
+          decline: 'Accept only necessary services',
+          ok: 'Accept all services',
+          purposeItem: {
+              service: 'Services'
+          },
+            contextualConsent:{
+                acceptAlways: 'Always',
+                acceptOnce: 'Yes',
+                description: 'You have previously denied the display of content of the type "{title}". Do you want to show content?',
+          }
+      }
+  },
+  services: [
+      {
+          name: "required-consent",
+          default: true,
+          contextualConsentOnly: false,
+          required: true,
+          translations: {
+              zz: {
+                  title: 'Required Services',
+                  description: 'These services are necessary for the site to function and cannot be turned off. They are usually used when you utilise a function on the website that needs an answer, such as setting cookies, logging in, or filling in a form.'
+              },
+              sv: {
+                  title: 'Nödvändiga tjänster',
+                  description: 'Dessa tjänster är nödvändiga för att webbplatsen ska fungera och kan inte stängas av. De används främst när du nyttjar en funktion på webbplatsen som behöver ett svar, exempelvis ställer in kakor, loggar in eller fyller i formulär.'
+              },
+          },
+      },
+      {
+          name: "media-consent",
+          default: false,
+          translations: {
+              zz: {
+                  title: 'External media',
+                  description: 'Media on the site embedded from external providers like Youtube, Vimeo and Kaltura. When these are played, the providers may use cookies and local storage.'
+              },
+              sv: {
+                  title: 'Extern media',
+                  description: 'Inbäddad media från externa leverantörer som Youtube, Vimeo och Kaltura. När media spelas upp kan leverantörerna använda sig av kakor och lokal lagring.'
+              },
+          },
+      },
+      {
+        name: "service-consent",
+        default: false,
+        translations: {
+          zz: {
+            title: 'External Services',
+            description: 'Embedded services by external providers such as forms, maps, chat applications et c. When these are loaded, the providers may use cookies and local storage.'
+          },
+          sv: {
+            title: 'Externa tjänster',
+            description: 'Inbäddade tjänster från externa leverantörer såsom formulär, kartor, chat-funktion et c. När tjänsterna laddas in kan leverantörerna använda sig av kakor och lokal lagring.'
+          },
+        },
+      },
+      {
+          name: "analytics-consent",
+          default: false,
+          translations: {
+              zz: {
+                  title: 'Analytics and Tracking',
+                  description: 'The website uses Matomo to evaluate and improve the website content, experience and structure. The information collected is anonymised and only stored at KTH servers.'
+              },
+              sv: {
+                  title: 'Analys och spårning',
+                  description: 'Webbplatsen använder Matomo för att utvärdera och förbättra webbplatsens innehåll, upplevelse och struktur. Insamlandet av informationen anonymiseras och lagras enbart på KTH-servrar.'
+              },
+          },
+      },
+      {
+        name: "marketing-consent",
+        default: false,
+        translations: {
+            zz: {
+                title: 'Marketing',
+                description: 'The website contains pages that, via cookies, communicate with advertising services and social media.'
+            },
+            sv: {
+                title: 'Marknadsföring',
+                description: 'På webbplatsen förekommer sidor som via kakor kommunicerar med annonseringstjänster och sociala medier.'
+            },
+        },
+    }
+    
+  ]
+}</script>
+  
+  
+  <!-- End JavaScript contentId-1_1137647 -->
+
+
+
+    
+
+  
+  
+  
+  <script src="/student/kurser/static/kth-style/js/klaro-no-css.js?v=2.0.0-20260427.1_59b0"></script>
+<script src="/student/kurser/static/vendor.js?v=2.0.0-20260427.1_59b0"></script>
+<script src="/student/kurser/static/browserConfig?v=2.0.0-20260427.1_59b0"></script>
+<script src="/student/kurser/static/kth-style/js/backtotop.js?v=2.0.0-20260427.1_59b0"></script>
+
+  <script src="https://www.kth.se/social/toolbar/widget.js"></script>
+
+</head>
+
+<body>
+  <a class="skipToMainContent" href="#mainContent" tabindex="1">Hoppa till huvudinnehållet</a>
+  <!--indexOff: all-->
+  <header class="kth-header student-web">
+    <div class="kth-header__container">
+      <a href="/student" class="kth-logotype">
+        <figure>
+          <img class="blue" alt="Till KTH:s startsida" width="64" height="64" src="/student/kurser/assets/logotype/logotype-blue.svg">
+        </figure>
+      </a>      
+  
+  
+  
+  
+  
+    <nav class="kth-mega-menu" aria-label="Huvudmeny" data-ajax-path="/cm/1.1066510?l=sv&amp;contentIdPath=/2.75593/1.1066510/&amp;target=">
+      <ul>
+        
+          <li><button data-id="1.1066571" class="kth-menu-item dropdown">
+              <span>
+                Studier
+              </span>
+            </button>
+            <dialog class="kth-menu-panel">
+              <div class="kth-menu-panel__container">
+                <div class="kth-menu-panel__header">
+                  <div>
+                    <a href="/student/studier">
+                      <h2>
+                        Studier
+                      </h2>
+                    </a>
+                  </div>
+                  <button class="kth-icon-button close" title="Stäng" aria-label="Stäng">
+                    <span class="kth-visually-hidden">close</span>
+                  </button>
+                </div>
+                <div class="kth-menu-panel__content"></div>
+              </div>
+            </dialog>
+          </li>
+          <li><button data-id="1.1070324" class="kth-menu-item dropdown">
+              <span>
+                Stöd och vägledning
+              </span>
+            </button>
+            <dialog class="kth-menu-panel">
+              <div class="kth-menu-panel__container">
+                <div class="kth-menu-panel__header">
+                  <div>
+                    <a href="/student/stod">
+                      <h2>
+                        Stöd och vägledning
+                      </h2>
+                    </a>
+                  </div>
+                  <button class="kth-icon-button close" title="Stäng" aria-label="Stäng">
+                    <span class="kth-visually-hidden">close</span>
+                  </button>
+                </div>
+                <div class="kth-menu-panel__content"></div>
+              </div>
+            </dialog>
+          </li>
+          <li><button data-id="1.1178595" class="kth-menu-item dropdown">
+              <span>
+                IT och digitala tjänster
+              </span>
+            </button>
+            <dialog class="kth-menu-panel">
+              <div class="kth-menu-panel__container">
+                <div class="kth-menu-panel__header">
+                  <div>
+                    <a href="/student/it">
+                      <h2>
+                        IT och digitala tjänster
+                      </h2>
+                    </a>
+                  </div>
+                  <button class="kth-icon-button close" title="Stäng" aria-label="Stäng">
+                    <span class="kth-visually-hidden">close</span>
+                  </button>
+                </div>
+                <div class="kth-menu-panel__content"></div>
+              </div>
+            </dialog>
+          </li>
+          <li><button data-id="1.1178638" class="kth-menu-item dropdown">
+              <span>
+                Kontakt
+              </span>
+            </button>
+            <dialog class="kth-menu-panel">
+              <div class="kth-menu-panel__container">
+                <div class="kth-menu-panel__header">
+                  <div>
+                    <a href="/student/kontakt">
+                      <h2>
+                        Kontakt
+                      </h2>
+                    </a>
+                  </div>
+                  <button class="kth-icon-button close" title="Stäng" aria-label="Stäng">
+                    <span class="kth-visually-hidden">close</span>
+                  </button>
+                </div>
+                <div class="kth-menu-panel__content"></div>
+              </div>
+            </dialog>
+          </li>
+        
+      </ul>
+    </nav>
+  
+    <!-- Mobile menu -->
+    <nav class="kth-mega-menu--collapsable">
+      <dialog class="kth-mobile-menu">
+        <div class="kth-mobile-menu__navigation">
+          <button class="kth-icon-button close" title="Stäng" aria-label="Stäng">
+            <span class="kth-visually-hidden">Close</span>
+          </button>
+        </div>
+        <div class="kth-mobile-menu__content">
+          <ul class="kth-mobile-menu__items">
+            <li>
+              <button class="kth-mobile-menu__item" data-id="1.1066571">
+                <span>
+                  Studier
+                </span>
+              </button>
+              <dialog class="kth-menu-panel--modal">
+                <button class="kth-icon-button close" title="Stäng" aria-label="Stäng">
+                  <span class="kth-visually-hidden">Close</span>
+                </button>
+                <div class="kth-menu-panel__content"></div>
+              </dialog>
+            </li>
+            <li>
+              <button class="kth-mobile-menu__item" data-id="1.1070324">
+                <span>
+                  Stöd och vägledning
+                </span>
+              </button>
+              <dialog class="kth-menu-panel--modal">
+                <button class="kth-icon-button close" title="Stäng" aria-label="Stäng">
+                  <span class="kth-visually-hidden">Close</span>
+                </button>
+                <div class="kth-menu-panel__content"></div>
+              </dialog>
+            </li>
+            <li>
+              <button class="kth-mobile-menu__item" data-id="1.1178595">
+                <span>
+                  IT och digitala tjänster
+                </span>
+              </button>
+              <dialog class="kth-menu-panel--modal">
+                <button class="kth-icon-button close" title="Stäng" aria-label="Stäng">
+                  <span class="kth-visually-hidden">Close</span>
+                </button>
+                <div class="kth-menu-panel__content"></div>
+              </dialog>
+            </li>
+            <li>
+              <button class="kth-mobile-menu__item" data-id="1.1178638">
+                <span>
+                  Kontakt
+                </span>
+              </button>
+              <dialog class="kth-menu-panel--modal">
+                <button class="kth-icon-button close" title="Stäng" aria-label="Stäng">
+                  <span class="kth-visually-hidden">Close</span>
+                </button>
+                <div class="kth-menu-panel__content"></div>
+              </dialog>
+            </li>
+          </ul>
+        </div>
+      </dialog>
+      <dialog class="kth-mobile-menu details" data-id="1.1066571">
+        <div class="kth-mobile-menu__navigation">
+          <button class="kth-button back">Huvudmeny</button>
+          <button class="kth-icon-button close" title="Stäng" aria-label="Stäng">
+            <span class="kth-visually-hidden">Close</span>
+          </button>
+        </div>
+        <div class="kth-mobile-menu__header">
+          <a href="/student/studier">
+            <h2>
+              Studier
+            </h2>
+          </a>
+        </div>
+        <div class="kth-mobile-menu__content">
+          <div class="kth-mobile-menu__cortina-content"></div>
+        </div>
+      </dialog><dialog class="kth-mobile-menu details" data-id="1.1070324">
+        <div class="kth-mobile-menu__navigation">
+          <button class="kth-button back">Huvudmeny</button>
+          <button class="kth-icon-button close" title="Stäng" aria-label="Stäng">
+            <span class="kth-visually-hidden">Close</span>
+          </button>
+        </div>
+        <div class="kth-mobile-menu__header">
+          <a href="/student/stod">
+            <h2>
+              Stöd och vägledning
+            </h2>
+          </a>
+        </div>
+        <div class="kth-mobile-menu__content">
+          <div class="kth-mobile-menu__cortina-content"></div>
+        </div>
+      </dialog><dialog class="kth-mobile-menu details" data-id="1.1178595">
+        <div class="kth-mobile-menu__navigation">
+          <button class="kth-button back">Huvudmeny</button>
+          <button class="kth-icon-button close" title="Stäng" aria-label="Stäng">
+            <span class="kth-visually-hidden">Close</span>
+          </button>
+        </div>
+        <div class="kth-mobile-menu__header">
+          <a href="/student/it">
+            <h2>
+              IT och digitala tjänster
+            </h2>
+          </a>
+        </div>
+        <div class="kth-mobile-menu__content">
+          <div class="kth-mobile-menu__cortina-content"></div>
+        </div>
+      </dialog><dialog class="kth-mobile-menu details" data-id="1.1178638">
+        <div class="kth-mobile-menu__navigation">
+          <button class="kth-button back">Huvudmeny</button>
+          <button class="kth-icon-button close" title="Stäng" aria-label="Stäng">
+            <span class="kth-visually-hidden">Close</span>
+          </button>
+        </div>
+        <div class="kth-mobile-menu__header">
+          <a href="/student/kontakt">
+            <h2>
+              Kontakt
+            </h2>
+          </a>
+        </div>
+        <div class="kth-mobile-menu__content">
+          <div class="kth-mobile-menu__cortina-content"></div>
+        </div>
+      </dialog>
+    </nav>
+    <!-- Mobile menu -->
+  
+    
+    <script>/* eslint-disable no-unused-expressions, no-unused-vars, no-undef */"use strict";window.addEventListener("load",(()=>{function e(e){return document.querySelector(".kth-mega-menu[data-ajax-path]")?.getAttribute("data-ajax-path")+e}function t(){document.querySelectorAll("dialog").forEach((e=>e.close()))}function n(e){const n=e.querySelector(".kth-icon-button.close");e.addEventListener("keydown",(t=>{"Escape"===t.key&&e.close()})),n instanceof HTMLButtonElement&&n.addEventListener("click",(()=>{t()}))}function o(e,o){n(e),o.addEventListener("click",(n=>{n.preventDefault(),e.open?t():(t(),e.show())})),document.addEventListener("click",(n=>{!e.open||n.composedPath().includes(o)||n.composedPath().includes(e)||(n.preventDefault(),t())}))}function c(e,o,c){const i=e.querySelector(".kth-button.back");n(e),o.addEventListener("click",(n=>{n.preventDefault(),t(),e.showModal()})),i instanceof HTMLButtonElement&&i.addEventListener("click",(()=>{e.close(),c&&c.showModal()}))}var i,l;document.querySelectorAll(".kth-menu-item[data-id], .kth-menu-item--modal[data-id]").forEach((t=>{const n=t.nextElementSibling,o=n?.querySelector(".kth-menu-panel__content");if(!(t instanceof HTMLElement))return;if(!(n instanceof HTMLDialogElement))return;const c=t.dataset.id;let i;function l(){o instanceof HTMLElement&&(i||(i=fetch(e(c)).then((e=>e.text()))),i.then((e=>{o.innerHTML=e})))}t.addEventListener("mouseover",l),t.addEventListener("click",l)})),document.querySelectorAll(".kth-mobile-menu__item[data-id]").forEach((t=>{if(!(t instanceof HTMLElement))return;const n=t.dataset.id,o=document.querySelector(`.kth-mobile-menu[data-id='${n}']`),c=o?.querySelector(".kth-mobile-menu__cortina-content");if(!(o instanceof HTMLDialogElement))return;let i;t.addEventListener("click",(function(){c instanceof HTMLElement&&(i||(i=fetch(e(n)).then((e=>e.text()))),i.then((e=>{c.innerHTML=e})))}))})),function(e,n){if(e){for(const e of n){if(!(e instanceof HTMLElement))continue;const t=e.nextElementSibling;t instanceof HTMLDialogElement&&o(t,e)}e.addEventListener("focusout",(function(n){const o=n.relatedTarget;o&&o instanceof Node&&!e.contains(o)&&t()}))}}(document.querySelector(".kth-header"),document.querySelectorAll(".kth-mega-menu .kth-menu-item")),i=document.querySelector(".kth-menu-item.collapsable"),l=document.querySelector(".kth-mobile-menu"),i instanceof HTMLElement&&l instanceof HTMLDialogElement&&c(l,i),function(e,t){if(!t||t instanceof HTMLDialogElement)for(const n of e){if(!(n instanceof HTMLElement))continue;const e=n.getAttribute("data-id"),o=document.querySelector(`.kth-mobile-menu[data-id='${e}']`);if(!(o instanceof HTMLDialogElement))return;c(o,n,t)}}(document.querySelectorAll(".kth-mobile-menu__item"),document.querySelector(".kth-mobile-menu"))})),window.addEventListener("load",(()=>{const e={threshold:32,className:"collapsed"};function t(e,{threshold:t,className:n}){window.scrollY>t?e?.classList.add(n):e?.classList.remove(n)}!function(n,o=e){t(n,o),window.addEventListener("scroll",(()=>{t(n,o)}))}(document.querySelector(".kth-header"))}));</script>
+  
+  
+  
+      <ul class="kth-header__tools">
+        <li><button class="kth-menu-item search">
+      <span>Sök</span>
+  </button>
+  <dialog class="kth-menu-panel">
+      <div class="kth-menu-panel__container search">
+          <button class="kth-icon-button close">
+              <span class="kth-visually-hidden">Stäng</span>
+          </button>
+          <div class="kth-menu-panel__content">
+                  
+  
+  
+  
+  
+    <div class="block search mainWidget default-size" data-cid="1.1066521" lang="sv">
+      <div id="widget_yhnutasc" class="searchWidgetContainer"><div class="searchWidget"><div class="searchInputBar"><form class="searchInputForm" method="GET" role="search" action="https://www.kth.se/search"><div class="searchAutoCompleteField kth-search"><label for="widget_yhnutasc_search__Field">Sök på Studentwebben</label><input id="widget_yhnutasc_search__Field" name="q" autoComplete="off" type="text" maxLength="1024" value=""/><button type="submit"><span class="kth-visually-hidden">Sök</span></button></div><input type="hidden" name="urlFilter" value="https://www.kth.se/student"/><input type="hidden" name="entityFilter" value="kth-profile,kth-course,kth-place,kth-program,kth-system"/><input type="hidden" name="metaSystemFilter" value=""/><input type="hidden" name="documentFilter" value=""/><input type="hidden" name="filterLabel" value="Sök på Studentwebben"/><input type="hidden" name="l" value="sv"/><input type="hidden" name="noscript" class="noscriptInput" value=""/></form></div><div class="searchAlternativesWidget"><div class="searchAlternativesWidgetLinks"><a href="https://www.kth.se/search?l=sv">Sök på KTH:s webbplats</a><a href="https://intra.kth.se/search?l=sv">Sök på KTH Intranät</a></div></div></div></div>
+  
+  <script>
+    (() => {
+      const SCRIPT_PATH = 'https://www.kth.se/search/static/widget.js?v=2.0.0-20250606.1_9d7abae6'
+      const STYLE_PATH = 'https://www.kth.se/search/static/widget.css?v=2.0.0-20250606.1_9d7abae6'
+      const DATA_PATH = 'https://www.kth.se/search/widgetData.js?widgetId=widget_yhnutasc&filterLabel=S%C3%B6k%20p%C3%A5%20Studentwebben&placeholder=S%C3%B6k%20p%C3%A5%20KTH%3As%20webbplats&urlFilter=https%3A%2F%2Fwww.kth.se%2Fstudent&isFilterRemovable=false&entityFilter=kth-profile%2Ckth-course%2Ckth-place%2Ckth-program%2Ckth-system&l=sv&includeLinks=true'
+      const WIDGET_ID = 'widget_yhnutasc'
+      const scriptAnchor = document.currentScript
+  
+      const observer = new IntersectionObserver((entries, observer) => {
+  
+        if (entries[0].target?.checkVisibility?.()) {
+  
+          if (!window.searchWidgetIsLoaded) {
+  
+            const styleElement = document.createElement('link')
+            styleElement.href = STYLE_PATH
+            styleElement.media = "screen"
+            styleElement.rel = "stylesheet"
+            styleElement.async = 1
+            scriptAnchor.after(styleElement)
+  
+            const scriptElement = document.createElement('script')
+            scriptElement.src = SCRIPT_PATH
+            scriptElement.async = 1
+            scriptAnchor.after(scriptElement)
+          }
+  
+          const dataElement = document.createElement('script')
+          dataElement.src = DATA_PATH
+          dataElement.async = 1
+          scriptAnchor.after(dataElement)
+  
+          window.searchWidgetIsLoaded = true
+          observer.disconnect()
+        }
+      }).observe(document.getElementById(WIDGET_ID))
+    })()
+  </script>
+      
+      <script>/* eslint-disable no-unused-expressions, no-unused-vars, no-undef */"use strict";!function(){function e(){document.querySelectorAll("dialog").forEach((e=>e.close()))}window.addEventListener("load",(function(){document.querySelectorAll(".block.search").forEach((t=>{t.parentElement.className.includes("kth-menu-panel__content")&&function(t,n){if(!(n instanceof HTMLElement))return;const c=n.nextElementSibling;if(!(c instanceof HTMLDialogElement))return;c.addEventListener("keydown",(t=>{"Escape"===t.key&&e()}));const o=c.querySelector(".close");o instanceof HTMLButtonElement&&o.addEventListener("click",(()=>{e()})),n.addEventListener("click",(n=>{n.preventDefault(),c.open?e():(e(),c.show(),function(e){const t=e.querySelector("template");if(null===t)return;const n=t.content;t.replaceWith(n)}(t),function(e){const t=e.querySelector(".searchAutoCompleteField")?.querySelector("input");t&&t.focus()}(c))})),document.addEventListener("click",(t=>{!c.open||t.composedPath().includes(n)||t.composedPath().includes(c)||(t.preventDefault(),e())}))}(t,document.querySelector(".kth-menu-item.search"))}))}))}();</script>
+    </div>
+  
+  
+  
+          </div>
+      </div>
+  </dialog></li>
+        <li><a class="kth-menu-item language" hreflang="en-US" href="?l=en">English</a></li>
+      </ul>
+      <button class="kth-menu-item menu collapsable">
+        <span>Meny</span>
+      </button>
+    </div>
+  </header>
+  <div class="kth-content articleNavigation">
+    <div class="row justify-content-between">
+      
+    <nav id="breadcrumbs" aria-label="Brödsmulor" class="kth-breadcrumbs">
+      <ol class="kth-breadcrumbs__list">
+        <li><a href="/student">Studentwebben</a></li><li><a href="/student/studier">Studier</a></li><li><a href="/student/kurser/kurser-inom-program">Kurs- och programkatalogen</a></li><li><a href="/student/kurser/program/CFATE">Civilingenjörsutbildning i farkostteknik</a></li>
+      </ol>
+    </nav>
+   
+    </div>
+  </div>
+  <!--indexOn: all-->  <div class="kth-content">
+    <div class="row">
+        <script>window.__compressedApplicationStore__ = "%7B%22browserConfig%22%3A%7B%22proxyPrefixPath%22%3A%7B%22uri%22%3A%22%2Fstudent%2Fkurser%22%2C%22searchPage%22%3A%22%2Fstudent%2Fkurser%2Fsokkurs%22%2C%22searchResult%22%3A%22%2Fstudent%2Fkurser%2Fsokkurs%2Fresultat%22%2C%22courseSearchInternApi%22%3A%22%2Fstudent%2Fkurser%2Fintern-api%2Fsok%22%2C%22department%22%3A%22%2Fstudent%2Fkurser%2Forg%22%2C%22programme%22%3A%22%2Fstudent%2Fkurser%2Fprogram%22%2C%22programmesList%22%3A%22%2Fstudent%2Fkurser%2Fkurser-inom-program%22%2C%22schoolsList%22%3A%22%2Fstudent%2Fkurser%2Fprogram%22%2C%22studyHandbook%22%3A%22%2Fstudent%2Fprogram%2Fshb%22%2C%22thirdCycleCourseSearch%22%3A%22%2Futbildning%2Fforskarutbildning%2Fkurser%2Fsok%22%2C%22thirdCycleCourseSearchResult%22%3A%22%2Futbildning%2Fforskarutbildning%2Fkurser%2Fsok%2Fresultat%22%2C%22thirdCycleSchoolsAndDepartments%22%3A%22%2Futbildning%2Fforskarutbildning%2Fkurser%2Favdelning%22%2C%22thirdCycleCoursesPerDepartment%22%3A%22%2Futbildning%2Fforskarutbildning%2Fkurser%2Forg%22%2C%22programmeSyllabusPDF%22%3A%22%2Fstudent%2Fkurser%2Fintern-api%2FPDFRenderFunction%22%7D%2C%22redirectProxyPath%22%3A%7B%22studentRoot%22%3A%22%2Fstudent%2Fkurser%22%2C%22thirdCycleRoot%22%3A%22%2Futbildning%2Fforskarutbildning%2Fkurser%22%2C%22coursesPerDepartment%22%3A%22%2Fstudent%2Fkurser%2Fkurser-per-avdelning%22%2C%22departmentCourses%22%3A%22%2Fstudent%2Fkurser%2Favdelning%2F%3AdepartmentCode%2Fkurser%2F%22%7D%2C%22markHtmlFromKopps%22%3Afalse%2C%22markHtmlFromLadok%22%3Afalse%2C%22env%22%3A%22prod%22%7D%2C%22statusCode%22%3A200%2C%22language%22%3A%22sv%22%2C%22languageIndex%22%3A1%2C%22programmeCode%22%3A%22CFATE%22%2C%22programmeName%22%3A%22Civilingenj%C3%B6rsutbildning%20i%20farkostteknik%22%2C%22owningSchoolCode%22%3A%22SCI%2FSkolan%20f%C3%B6r%20teknikvetenskap%22%2C%22term%22%3A%2220232%22%2C%22studyYear%22%3A%223%22%2C%22curriculums%22%3A%5B%7B%22studyYears%22%3A%5B%7B%22yearNumber%22%3A1%2C%22courses%22%3A%22%3Ch3%20id%3D%5C%22gemensammakurser%5C%22%3EGemensamma%20kurser%3C%2Fh3%3E%5Cn%3Ch4%20id%3D%5C%22obligatoriskakurser%5C%22%3EObligatoriska%20kurser%3C%2Fh4%3E%5Cn%3Ctable%3E%5Cn%3Cthead%3E%5Cn%3Ctr%3E%5Cn%3Cth%3EKurskod%3C%2Fth%3E%5Cn%3Cth%3EKursnamn%3C%2Fth%3E%5Cn%3Cth%3EOmfattning%3C%2Fth%3E%5Cn%3Cth%3EUtbildningsniv%C3%A5%3C%2Fth%3E%5Cn%3C%2Ftr%3E%5Cn%3C%2Fthead%3E%5Cn%3Ctbody%3E%5Cn%3Ctr%3E%5Cn%3Ctd%3EDD1331%3C%2Ftd%3E%5Cn%3Ctd%3EGrundl%C3%A4ggande%20programmering%3C%2Ftd%3E%5Cn%3Ctd%3E5%20hp%3C%2Ftd%3E%5Cn%3Ctd%3EGrundniv%C3%A5%3C%2Ftd%3E%5Cn%3C%2Ftr%3E%5Cn%3Ctr%3E%5Cn%3Ctd%3ESD1002%3C%2Ftd%3E%5Cn%3Ctd%3EFarkostteknik%3C%2Ftd%3E%5Cn%3Ctd%3E7%20hp%3C%2Ftd%3E%5Cn%3Ctd%3EGrundniv%C3%A5%3C%2Ftd%3E%5Cn%3C%2Ftr%3E%5Cn%3Ctr%3E%5Cn%3Ctd%3ESF1626%3C%2Ftd%3E%5Cn%3Ctd%3EFlervariabelanalys%3C%2Ftd%3E%5Cn%3Ctd%3E7.5%20hp%3C%2Ftd%3E%5Cn%3Ctd%3EGrundniv%C3%A5%3C%2Ftd%3E%5Cn%3C%2Ftr%3E%5Cn%3Ctr%3E%5Cn%3Ctd%3ESF1668%3C%2Ftd%3E%5Cn%3Ctd%3EMatematisk%20och%20numerisk%20analys%20I%3C%2Ftd%3E%5Cn%3Ctd%3E10%20hp%3C%2Ftd%3E%5Cn%3Ctd%3EGrundniv%C3%A5%3C%2Ftd%3E%5Cn%3C%2Ftr%3E%5Cn%3Ctr%3E%5Cn%3Ctd%3ESF1694%3C%2Ftd%3E%5Cn%3Ctd%3ETill%C3%A4mpad%20linj%C3%A4r%20algebra%3C%2Ftd%3E%5Cn%3Ctd%3E10.5%20hp%3C%2Ftd%3E%5Cn%3Ctd%3EGrundniv%C3%A5%3C%2Ftd%3E%5Cn%3C%2Ftr%3E%5Cn%3Ctr%3E%5Cn%3Ctd%3ESG1132%3C%2Ftd%3E%5Cn%3Ctd%3EMekanik%20I%20med%20projekt%3C%2Ftd%3E%5Cn%3Ctd%3E11%20hp%3C%2Ftd%3E%5Cn%3Ctd%3EGrundniv%C3%A5%3C%2Ftd%3E%5Cn%3C%2Ftr%3E%5Cn%3Ctr%3E%5Cn%3Ctd%3ESK1112%3C%2Ftd%3E%5Cn%3Ctd%3EFysik%20I%3C%2Ftd%3E%5Cn%3Ctd%3E9%20hp%3C%2Ftd%3E%5Cn%3Ctd%3EGrundniv%C3%A5%3C%2Ftd%3E%5Cn%3C%2Ftr%3E%5Cn%3C%2Ftbody%3E%5Cn%3C%2Ftable%3E%5Cn%3Ch4%20id%3D%5C%22valfriakurser%5C%22%3EValfria%20kurser%3C%2Fh4%3E%5Cn%3Ctable%3E%5Cn%3Cthead%3E%5Cn%3Ctr%3E%5Cn%3Cth%3EKurskod%3C%2Fth%3E%5Cn%3Cth%3EKursnamn%3C%2Fth%3E%5Cn%3Cth%3EOmfattning%3C%2Fth%3E%5Cn%3Cth%3EUtbildningsniv%C3%A5%3C%2Fth%3E%5Cn%3C%2Ftr%3E%5Cn%3C%2Fthead%3E%5Cn%3Ctbody%3E%5Cn%3Ctr%3E%5Cn%3Ctd%3EDD1301%3C%2Ftd%3E%5Cn%3Ctd%3EDatorintroduktion%3C%2Ftd%3E%5Cn%3Ctd%3E1.5%20hp%3C%2Ftd%3E%5Cn%3Ctd%3EGrundniv%C3%A5%3C%2Ftd%3E%5Cn%3C%2Ftr%3E%5Cn%3C%2Ftbody%3E%5Cn%3C%2Ftable%3E%22%2C%22freeTexts%22%3A%5B%5D%7D%2C%7B%22yearNumber%22%3A2%2C%22courses%22%3A%22%3Ch3%20id%3D%5C%22gemensammakurser%5C%22%3EGemensamma%20kurser%3C%2Fh3%3E%5Cn%3Ch4%20id%3D%5C%22obligatoriskakurser%5C%22%3EObligatoriska%20kurser%3C%2Fh4%3E%5Cn%3Ctable%3E%5Cn%3Cthead%3E%5Cn%3Ctr%3E%5Cn%3Cth%3EKurskod%3C%2Fth%3E%5Cn%3Cth%3EKursnamn%3C%2Fth%3E%5Cn%3Cth%3EOmfattning%3C%2Fth%3E%5Cn%3Cth%3EUtbildningsniv%C3%A5%3C%2Fth%3E%5Cn%3C%2Ftr%3E%5Cn%3C%2Fthead%3E%5Cn%3Ctbody%3E%5Cn%3Ctr%3E%5Cn%3Ctd%3EMF1024%3C%2Ftd%3E%5Cn%3Ctd%3EProduktutveckling%3C%2Ftd%3E%5Cn%3Ctd%3E11%20hp%3C%2Ftd%3E%5Cn%3Ctd%3EGrundniv%C3%A5%3C%2Ftd%3E%5Cn%3C%2Ftr%3E%5Cn%3Ctr%3E%5Cn%3Ctd%3ESD1120%3C%2Ftd%3E%5Cn%3Ctd%3ELjud%20och%20vibrationer%3C%2Ftd%3E%5Cn%3Ctd%3E9%20hp%3C%2Ftd%3E%5Cn%3Ctd%3EGrundniv%C3%A5%3C%2Ftd%3E%5Cn%3C%2Ftr%3E%5Cn%3Ctr%3E%5Cn%3Ctd%3ESE1010%3C%2Ftd%3E%5Cn%3Ctd%3EH%C3%A5llfasthetsl%C3%A4ra%2C%20grundkurs%20med%20projekt%3C%2Ftd%3E%5Cn%3Ctd%3E12%20hp%3C%2Ftd%3E%5Cn%3Ctd%3EGrundniv%C3%A5%3C%2Ftd%3E%5Cn%3C%2Ftr%3E%5Cn%3Ctr%3E%5Cn%3Ctd%3ESF1682%3C%2Ftd%3E%5Cn%3Ctd%3EAnalytiska%20och%20numeriska%20metoder%20f%C3%B6r%20differentialekvationer%3C%2Ftd%3E%5Cn%3Ctd%3E11%20hp%3C%2Ftd%3E%5Cn%3Ctd%3EGrundniv%C3%A5%3C%2Ftd%3E%5Cn%3C%2Ftr%3E%5Cn%3Ctr%3E%5Cn%3Ctd%3ESG1140%3C%2Ftd%3E%5Cn%3Ctd%3EMekanik%20II%3C%2Ftd%3E%5Cn%3Ctd%3E6%20hp%3C%2Ftd%3E%5Cn%3Ctd%3EGrundniv%C3%A5%3C%2Ftd%3E%5Cn%3C%2Ftr%3E%5Cn%3Ctr%3E%5Cn%3Ctd%3ESG1216%3C%2Ftd%3E%5Cn%3Ctd%3ETermodynamik%3C%2Ftd%3E%5Cn%3Ctd%3E6%20hp%3C%2Ftd%3E%5Cn%3Ctd%3EGrundniv%C3%A5%3C%2Ftd%3E%5Cn%3C%2Ftr%3E%5Cn%3Ctr%3E%5Cn%3Ctd%3ESG1217%3C%2Ftd%3E%5Cn%3Ctd%3EStr%C3%B6mningsmekanik%2C%20grundkurs%3C%2Ftd%3E%5Cn%3Ctd%3E6%20hp%3C%2Ftd%3E%5Cn%3Ctd%3EGrundniv%C3%A5%3C%2Ftd%3E%5Cn%3C%2Ftr%3E%5Cn%3C%2Ftbody%3E%5Cn%3C%2Ftable%3E%22%2C%22freeTexts%22%3A%5B%5D%7D%2C%7B%22yearNumber%22%3A3%2C%22courses%22%3A%5B%7B%22utbildningsinstansUid%22%3A%2235cf364c-9eba-11eb-b121-4a7c58ae420f%22%2C%22uid%22%3A%22cd4af35a-bb9f-11ef-9553-beecfac44351%22%2C%22tillfalleskod%22%3A%2250485%22%2C%22status%22%3A%7B%22code%22%3A%22S3%22%2C%22nameSv%22%3A%22Komplett%22%2C%22nameEn%22%3A%22Complete%22%7D%2C%22utbildningstyp%22%3A%7B%22id%22%3A%2222%22%2C%22code%22%3A%222007GKURS%22%2C%22name%22%3A%22Kurs%2C%20grundniv%C3%A5%22%2C%22nameOther%22%3A%22Course%2C%20First-cycle%22%2C%22creditsUnit%22%3A%7B%22code%22%3A%22HP%22%2C%22sv%22%3A%22H%C3%B6gskolepo%C3%A4ng%22%2C%22en%22%3A%22Credits%22%7D%2C%22level%22%3A%7B%22code%22%3A%221%22%2C%22name%22%3A%22Grundniv%C3%A5%22%7D%7D%2C%22omfattning%22%3A%7B%22number%22%3A6%2C%22formattedWithUnit%22%3A%226%2C0%20hp%22%7D%2C%22startperiod%22%3A%7B%22code%22%3A%22HT2025%22%2C%22startDay%22%3A%222025-08-25%22%2C%22lastDay%22%3A%222026-01-12%22%2C%22inDigits%22%3A%2220252%22%7D%2C%22Tillfallesperioder%22%3A%5B%7B%22ForstaRegistreringsdatum%22%3A%222025-10-23%22%2C%22ForstaUndervisningsdatum%22%3A%222025-10-27%22%2C%22Lasperiodsfordelning%22%3A%5B%7B%22Lasperiodskod%22%3A%22P2%22%2C%22Omfattningsvarde%22%3A6%2C%22link%22%3A%5B%5D%7D%5D%2C%22Omfattningsvarde%22%3A6%2C%22SistaRegistreringsdatum%22%3A%222025-11-03%22%2C%22SistaUndervisningsdatum%22%3A%222026-01-12%22%7D%5D%2C%22kod%22%3A%22EL1010%22%2C%22benamning%22%3A%22Reglerteknik%2C%20allm%C3%A4n%20kurs%22%2C%22Valvillkor%22%3A%22O%22%2C%22type%22%3A%22instance%22%7D%2C%7B%22utbildningsinstansUid%22%3A%222811fdec-5d08-11e9-b67f-a77d6cb34fef%22%2C%22uid%22%3A%22f327814b-b888-11ef-9553-beecfac44351%22%2C%22tillfalleskod%22%3A%2250329%22%2C%22status%22%3A%7B%22code%22%3A%22S3%22%2C%22nameSv%22%3A%22Komplett%22%2C%22nameEn%22%3A%22Complete%22%7D%2C%22utbildningstyp%22%3A%7B%22id%22%3A%2222%22%2C%22code%22%3A%222007GKURS%22%2C%22name%22%3A%22Kurs%2C%20grundniv%C3%A5%22%2C%22nameOther%22%3A%22Course%2C%20First-cycle%22%2C%22creditsUnit%22%3A%7B%22code%22%3A%22HP%22%2C%22sv%22%3A%22H%C3%B6gskolepo%C3%A4ng%22%2C%22en%22%3A%22Credits%22%7D%2C%22level%22%3A%7B%22code%22%3A%221%22%2C%22name%22%3A%22Grundniv%C3%A5%22%7D%7D%2C%22omfattning%22%3A%7B%22number%22%3A6%2C%22formattedWithUnit%22%3A%226%2C0%20hp%22%7D%2C%22startperiod%22%3A%7B%22code%22%3A%22HT2025%22%2C%22startDay%22%3A%222025-08-25%22%2C%22lastDay%22%3A%222026-01-12%22%2C%22inDigits%22%3A%2220252%22%7D%2C%22Tillfallesperioder%22%3A%5B%7B%22ForstaRegistreringsdatum%22%3A%222025-08-21%22%2C%22ForstaUndervisningsdatum%22%3A%222025-08-25%22%2C%22Lasperiodsfordelning%22%3A%5B%7B%22Lasperiodskod%22%3A%22P1%22%2C%22Omfattningsvarde%22%3A6%2C%22link%22%3A%5B%5D%7D%5D%2C%22Omfattningsvarde%22%3A6%2C%22SistaRegistreringsdatum%22%3A%222025-09-01%22%2C%22SistaUndervisningsdatum%22%3A%222025-10-24%22%7D%5D%2C%22kod%22%3A%22MF1017%22%2C%22benamning%22%3A%22Elektroteknik%22%2C%22Valvillkor%22%3A%22O%22%2C%22type%22%3A%22instance%22%7D%2C%7B%22utbildningsinstansUid%22%3A%227c11c735-73d8-11e8-b4e0-063f9afb40e3%22%2C%22uid%22%3A%22a5ae4629-bbae-11ef-9553-beecfac44351%22%2C%22tillfalleskod%22%3A%2251600%22%2C%22status%22%3A%7B%22code%22%3A%22S3%22%2C%22nameSv%22%3A%22Komplett%22%2C%22nameEn%22%3A%22Complete%22%7D%2C%22utbildningstyp%22%3A%7B%22id%22%3A%2224%22%2C%22code%22%3A%222007AKURS%22%2C%22name%22%3A%22Kurs%2C%20avancerad%20niv%C3%A5%22%2C%22nameOther%22%3A%22Course%2C%20Second-cycle%22%2C%22creditsUnit%22%3A%7B%22code%22%3A%22HP%22%2C%22sv%22%3A%22H%C3%B6gskolepo%C3%A4ng%22%2C%22en%22%3A%22Credits%22%7D%2C%22level%22%3A%7B%22code%22%3A%222%22%2C%22name%22%3A%22Avancerad%20niv%C3%A5%22%7D%7D%2C%22omfattning%22%3A%7B%22number%22%3A6%2C%22formattedWithUnit%22%3A%226%2C0%20hp%22%7D%2C%22startperiod%22%3A%7B%22code%22%3A%22HT2025%22%2C%22startDay%22%3A%222025-08-25%22%2C%22lastDay%22%3A%222026-01-12%22%2C%22inDigits%22%3A%2220252%22%7D%2C%22Tillfallesperioder%22%3A%5B%7B%22ForstaRegistreringsdatum%22%3A%222025-10-23%22%2C%22ForstaUndervisningsdatum%22%3A%222025-10-27%22%2C%22Lasperiodsfordelning%22%3A%5B%7B%22Lasperiodskod%22%3A%22P2%22%2C%22Omfattningsvarde%22%3A6%2C%22link%22%3A%5B%5D%7D%5D%2C%22Omfattningsvarde%22%3A6%2C%22SistaRegistreringsdatum%22%3A%222025-11-03%22%2C%22SistaUndervisningsdatum%22%3A%222026-01-12%22%7D%5D%2C%22kod%22%3A%22SD2125%22%2C%22benamning%22%3A%22Signaler%20och%20mekaniska%20system%22%2C%22Valvillkor%22%3A%22O%22%2C%22type%22%3A%22instance%22%7D%2C%7B%22utbildningsinstansUid%22%3A%228045d3b8-73d8-11e8-b4e0-063f9afb40e3%22%2C%22uid%22%3A%221a8948bb-ce68-11ef-9bca-bbbddaff469b%22%2C%22tillfalleskod%22%3A%2250468%22%2C%22status%22%3A%7B%22code%22%3A%22S3%22%2C%22nameSv%22%3A%22Komplett%22%2C%22nameEn%22%3A%22Complete%22%7D%2C%22utbildningstyp%22%3A%7B%22id%22%3A%2222%22%2C%22code%22%3A%222007GKURS%22%2C%22name%22%3A%22Kurs%2C%20grundniv%C3%A5%22%2C%22nameOther%22%3A%22Course%2C%20First-cycle%22%2C%22creditsUnit%22%3A%7B%22code%22%3A%22HP%22%2C%22sv%22%3A%22H%C3%B6gskolepo%C3%A4ng%22%2C%22en%22%3A%22Credits%22%7D%2C%22level%22%3A%7B%22code%22%3A%221%22%2C%22name%22%3A%22Grundniv%C3%A5%22%7D%7D%2C%22omfattning%22%3A%7B%22number%22%3A6%2C%22formattedWithUnit%22%3A%226%2C0%20hp%22%7D%2C%22startperiod%22%3A%7B%22code%22%3A%22HT2025%22%2C%22startDay%22%3A%222025-08-25%22%2C%22lastDay%22%3A%222026-01-12%22%2C%22inDigits%22%3A%2220252%22%7D%2C%22Tillfallesperioder%22%3A%5B%7B%22ForstaRegistreringsdatum%22%3A%222025-08-21%22%2C%22ForstaUndervisningsdatum%22%3A%222025-08-25%22%2C%22Lasperiodsfordelning%22%3A%5B%7B%22Lasperiodskod%22%3A%22P1%22%2C%22Omfattningsvarde%22%3A6%2C%22link%22%3A%5B%5D%7D%5D%2C%22Omfattningsvarde%22%3A6%2C%22SistaRegistreringsdatum%22%3A%222025-09-01%22%2C%22SistaUndervisningsdatum%22%3A%222025-10-24%22%7D%5D%2C%22kod%22%3A%22SF1914%22%2C%22benamning%22%3A%22Sannolikhetsteori%20och%20statistik%22%2C%22Valvillkor%22%3A%22O%22%2C%22type%22%3A%22instance%22%7D%2C%7B%22utbildningsinstansUid%22%3A%22b48a52a5-dd0c-11e8-bb7a-19f8cd1a470e%22%2C%22uid%22%3A%226728b9be-ce5c-11ef-9bca-bbbddaff469b%22%2C%22tillfalleskod%22%3A%2260889%22%2C%22status%22%3A%7B%22code%22%3A%22S3%22%2C%22nameSv%22%3A%22Komplett%22%2C%22nameEn%22%3A%22Complete%22%7D%2C%22utbildningstyp%22%3A%7B%22id%22%3A%2222%22%2C%22code%22%3A%222007GKURS%22%2C%22name%22%3A%22Kurs%2C%20grundniv%C3%A5%22%2C%22nameOther%22%3A%22Course%2C%20First-cycle%22%2C%22creditsUnit%22%3A%7B%22code%22%3A%22HP%22%2C%22sv%22%3A%22H%C3%B6gskolepo%C3%A4ng%22%2C%22en%22%3A%22Credits%22%7D%2C%22level%22%3A%7B%22code%22%3A%221%22%2C%22name%22%3A%22Grundniv%C3%A5%22%7D%7D%2C%22omfattning%22%3A%7B%22number%22%3A15%2C%22formattedWithUnit%22%3A%2215%2C0%20hp%22%7D%2C%22startperiod%22%3A%7B%22code%22%3A%22VT2026%22%2C%22startDay%22%3A%222026-01-13%22%2C%22lastDay%22%3A%222026-06-01%22%2C%22inDigits%22%3A%2220261%22%7D%2C%22Tillfallesperioder%22%3A%5B%7B%22ForstaRegistreringsdatum%22%3A%222026-01-08%22%2C%22ForstaUndervisningsdatum%22%3A%222026-01-13%22%2C%22Lasperiodsfordelning%22%3A%5B%7B%22Lasperiodskod%22%3A%22P4%22%2C%22Omfattningsvarde%22%3A7.5%2C%22link%22%3A%5B%5D%7D%2C%7B%22Lasperiodskod%22%3A%22P3%22%2C%22Omfattningsvarde%22%3A7.5%2C%22link%22%3A%5B%5D%7D%5D%2C%22Omfattningsvarde%22%3A15%2C%22SistaRegistreringsdatum%22%3A%222026-01-19%22%2C%22SistaUndervisningsdatum%22%3A%222026-06-01%22%7D%5D%2C%22kod%22%3A%22EF112X%22%2C%22benamning%22%3A%22Examensarbete%20inom%20elektroteknik%2C%20grundniv%C3%A5%22%2C%22Valvillkor%22%3A%22VV%22%2C%22type%22%3A%22instance%22%7D%2C%7B%22utbildningsinstansUid%22%3A%22edcaf516-f0ec-11e9-9646-c1b6f8c04be9%22%2C%22uid%22%3A%22b5f7630d-cccf-11ef-9e07-d56117ae456b%22%2C%22tillfalleskod%22%3A%2260217%22%2C%22status%22%3A%7B%22code%22%3A%22S3%22%2C%22nameSv%22%3A%22Komplett%22%2C%22nameEn%22%3A%22Complete%22%7D%2C%22utbildningstyp%22%3A%7B%22id%22%3A%2224%22%2C%22code%22%3A%222007AKURS%22%2C%22name%22%3A%22Kurs%2C%20avancerad%20niv%C3%A5%22%2C%22nameOther%22%3A%22Course%2C%20Second-cycle%22%2C%22creditsUnit%22%3A%7B%22code%22%3A%22HP%22%2C%22sv%22%3A%22H%C3%B6gskolepo%C3%A4ng%22%2C%22en%22%3A%22Credits%22%7D%2C%22level%22%3A%7B%22code%22%3A%222%22%2C%22name%22%3A%22Avancerad%20niv%C3%A5%22%7D%7D%2C%22omfattning%22%3A%7B%22number%22%3A6%2C%22formattedWithUnit%22%3A%226%2C0%20hp%22%7D%2C%22startperiod%22%3A%7B%22code%22%3A%22VT2026%22%2C%22startDay%22%3A%222026-01-13%22%2C%22lastDay%22%3A%222026-06-01%22%2C%22inDigits%22%3A%2220261%22%7D%2C%22Tillfallesperioder%22%3A%5B%7B%22ForstaRegistreringsdatum%22%3A%222026-03-12%22%2C%22ForstaUndervisningsdatum%22%3A%222026-03-16%22%2C%22Lasperiodsfordelning%22%3A%5B%7B%22Lasperiodskod%22%3A%22P4%22%2C%22Omfattningsvarde%22%3A6%2C%22link%22%3A%5B%5D%7D%5D%2C%22Omfattningsvarde%22%3A6%2C%22SistaRegistreringsdatum%22%3A%222026-03-23%22%2C%22SistaUndervisningsdatum%22%3A%222026-06-01%22%7D%5D%2C%22kod%22%3A%22ME2163%22%2C%22benamning%22%3A%22Ledarskap%20och%20organisering%20i%20olika%20milj%C3%B6er%22%2C%22Valvillkor%22%3A%22VV%22%2C%22type%22%3A%22instance%22%7D%2C%7B%22utbildningsinstansUid%22%3A%2239295141-b577-11f0-aa27-85c3b3d64a85%22%2C%22uid%22%3A%22a6d6499d-b88f-11ef-9553-beecfac44351%22%2C%22tillfalleskod%22%3A%2260552%22%2C%22status%22%3A%7B%22code%22%3A%22S3%22%2C%22nameSv%22%3A%22Komplett%22%2C%22nameEn%22%3A%22Complete%22%7D%2C%22utbildningstyp%22%3A%7B%22id%22%3A%2222%22%2C%22code%22%3A%222007GKURS%22%2C%22name%22%3A%22Kurs%2C%20grundniv%C3%A5%22%2C%22nameOther%22%3A%22Course%2C%20First-cycle%22%2C%22creditsUnit%22%3A%7B%22code%22%3A%22HP%22%2C%22sv%22%3A%22H%C3%B6gskolepo%C3%A4ng%22%2C%22en%22%3A%22Credits%22%7D%2C%22level%22%3A%7B%22code%22%3A%221%22%2C%22name%22%3A%22Grundniv%C3%A5%22%7D%7D%2C%22omfattning%22%3A%7B%22number%22%3A15%2C%22formattedWithUnit%22%3A%2215%2C0%20hp%22%7D%2C%22startperiod%22%3A%7B%22code%22%3A%22VT2026%22%2C%22startDay%22%3A%222026-01-13%22%2C%22lastDay%22%3A%222026-06-01%22%2C%22inDigits%22%3A%2220261%22%7D%2C%22Tillfallesperioder%22%3A%5B%7B%22ForstaRegistreringsdatum%22%3A%222026-01-08%22%2C%22ForstaUndervisningsdatum%22%3A%222026-01-13%22%2C%22Lasperiodsfordelning%22%3A%5B%7B%22Lasperiodskod%22%3A%22P4%22%2C%22Omfattningsvarde%22%3A7.5%2C%22link%22%3A%5B%5D%7D%2C%7B%22Lasperiodskod%22%3A%22P3%22%2C%22Omfattningsvarde%22%3A7.5%2C%22link%22%3A%5B%5D%7D%5D%2C%22Omfattningsvarde%22%3A15%2C%22SistaRegistreringsdatum%22%3A%222026-01-19%22%2C%22SistaUndervisningsdatum%22%3A%222026-06-01%22%7D%5D%2C%22kod%22%3A%22MF130X%22%2C%22benamning%22%3A%22Examensarbete%20inom%20maskinkonstruktion%2C%20grundniv%C3%A5%22%2C%22Valvillkor%22%3A%22VV%22%2C%22type%22%3A%22instance%22%7D%2C%7B%22utbildningsinstansUid%22%3A%226bca254c-73d8-11e8-b4e0-063f9afb40e3%22%2C%22uid%22%3A%22b3a1e3b9-b88f-11ef-9553-beecfac44351%22%2C%22tillfalleskod%22%3A%2260553%22%2C%22status%22%3A%7B%22code%22%3A%22S3%22%2C%22nameSv%22%3A%22Komplett%22%2C%22nameEn%22%3A%22Complete%22%7D%2C%22utbildningstyp%22%3A%7B%22id%22%3A%2222%22%2C%22code%22%3A%222007GKURS%22%2C%22name%22%3A%22Kurs%2C%20grundniv%C3%A5%22%2C%22nameOther%22%3A%22Course%2C%20First-cycle%22%2C%22creditsUnit%22%3A%7B%22code%22%3A%22HP%22%2C%22sv%22%3A%22H%C3%B6gskolepo%C3%A4ng%22%2C%22en%22%3A%22Credits%22%7D%2C%22level%22%3A%7B%22code%22%3A%221%22%2C%22name%22%3A%22Grundniv%C3%A5%22%7D%7D%2C%22omfattning%22%3A%7B%22number%22%3A15%2C%22formattedWithUnit%22%3A%2215%2C0%20hp%22%7D%2C%22startperiod%22%3A%7B%22code%22%3A%22VT2026%22%2C%22startDay%22%3A%222026-01-13%22%2C%22lastDay%22%3A%222026-06-01%22%2C%22inDigits%22%3A%2220261%22%7D%2C%22Tillfallesperioder%22%3A%5B%7B%22ForstaRegistreringsdatum%22%3A%222026-01-08%22%2C%22ForstaUndervisningsdatum%22%3A%222026-01-13%22%2C%22Lasperiodsfordelning%22%3A%5B%7B%22Lasperiodskod%22%3A%22P4%22%2C%22Omfattningsvarde%22%3A7.5%2C%22link%22%3A%5B%5D%7D%2C%7B%22Lasperiodskod%22%3A%22P3%22%2C%22Omfattningsvarde%22%3A7.5%2C%22link%22%3A%5B%5D%7D%5D%2C%22Omfattningsvarde%22%3A15%2C%22SistaRegistreringsdatum%22%3A%222026-01-19%22%2C%22SistaUndervisningsdatum%22%3A%222026-06-01%22%7D%5D%2C%22kod%22%3A%22MF131X%22%2C%22benamning%22%3A%22Examensarbete%20inom%20integrerad%20produktutveckling%2C%20grundniv%C3%A5%22%2C%22Valvillkor%22%3A%22VV%22%2C%22type%22%3A%22instance%22%7D%2C%7B%22utbildningsinstansUid%22%3A%226bca254d-73d8-11e8-b4e0-063f9afb40e3%22%2C%22uid%22%3A%22d9e5ba75-b88f-11ef-9553-beecfac44351%22%2C%22tillfalleskod%22%3A%2260567%22%2C%22status%22%3A%7B%22code%22%3A%22S3%22%2C%22nameSv%22%3A%22Komplett%22%2C%22nameEn%22%3A%22Complete%22%7D%2C%22utbildningstyp%22%3A%7B%22id%22%3A%2222%22%2C%22code%22%3A%222007GKURS%22%2C%22name%22%3A%22Kurs%2C%20grundniv%C3%A5%22%2C%22nameOther%22%3A%22Course%2C%20First-cycle%22%2C%22creditsUnit%22%3A%7B%22code%22%3A%22HP%22%2C%22sv%22%3A%22H%C3%B6gskolepo%C3%A4ng%22%2C%22en%22%3A%22Credits%22%7D%2C%22level%22%3A%7B%22code%22%3A%221%22%2C%22name%22%3A%22Grundniv%C3%A5%22%7D%7D%2C%22omfattning%22%3A%7B%22number%22%3A15%2C%22formattedWithUnit%22%3A%2215%2C0%20hp%22%7D%2C%22startperiod%22%3A%7B%22code%22%3A%22VT2026%22%2C%22startDay%22%3A%222026-01-13%22%2C%22lastDay%22%3A%222026-06-01%22%2C%22inDigits%22%3A%2220261%22%7D%2C%22Tillfallesperioder%22%3A%5B%7B%22ForstaRegistreringsdatum%22%3A%222026-01-08%22%2C%22ForstaUndervisningsdatum%22%3A%222026-01-13%22%2C%22Lasperiodsfordelning%22%3A%5B%7B%22Lasperiodskod%22%3A%22P4%22%2C%22Omfattningsvarde%22%3A7.5%2C%22link%22%3A%5B%5D%7D%2C%7B%22Lasperiodskod%22%3A%22P3%22%2C%22Omfattningsvarde%22%3A7.5%2C%22link%22%3A%5B%5D%7D%5D%2C%22Omfattningsvarde%22%3A15%2C%22SistaRegistreringsdatum%22%3A%222026-01-19%22%2C%22SistaUndervisningsdatum%22%3A%222026-06-01%22%7D%5D%2C%22kod%22%3A%22MF133X%22%2C%22benamning%22%3A%22Examensarbete%20inom%20mekatronik%2C%20grundniv%C3%A5%22%2C%22Valvillkor%22%3A%22VV%22%2C%22type%22%3A%22instance%22%7D%2C%7B%22utbildningsinstansUid%22%3A%2274b7c24b-73d8-11e8-b4e0-063f9afb40e3%22%2C%22uid%22%3A%22ef4a518c-bb8e-11ef-9553-beecfac44351%22%2C%22tillfalleskod%22%3A%2260993%22%2C%22status%22%3A%7B%22code%22%3A%22S3%22%2C%22nameSv%22%3A%22Komplett%22%2C%22nameEn%22%3A%22Complete%22%7D%2C%22utbildningstyp%22%3A%7B%22id%22%3A%2222%22%2C%22code%22%3A%222007GKURS%22%2C%22name%22%3A%22Kurs%2C%20grundniv%C3%A5%22%2C%22nameOther%22%3A%22Course%2C%20First-cycle%22%2C%22creditsUnit%22%3A%7B%22code%22%3A%22HP%22%2C%22sv%22%3A%22H%C3%B6gskolepo%C3%A4ng%22%2C%22en%22%3A%22Credits%22%7D%2C%22level%22%3A%7B%22code%22%3A%221%22%2C%22name%22%3A%22Grundniv%C3%A5%22%7D%7D%2C%22omfattning%22%3A%7B%22number%22%3A15%2C%22formattedWithUnit%22%3A%2215%2C0%20hp%22%7D%2C%22startperiod%22%3A%7B%22code%22%3A%22VT2026%22%2C%22startDay%22%3A%222026-01-13%22%2C%22lastDay%22%3A%222026-06-01%22%2C%22inDigits%22%3A%2220261%22%7D%2C%22Tillfallesperioder%22%3A%5B%7B%22ForstaRegistreringsdatum%22%3A%222026-01-08%22%2C%22ForstaUndervisningsdatum%22%3A%222026-01-13%22%2C%22Lasperiodsfordelning%22%3A%5B%7B%22Lasperiodskod%22%3A%22P4%22%2C%22Omfattningsvarde%22%3A7.5%2C%22link%22%3A%5B%5D%7D%2C%7B%22Lasperiodskod%22%3A%22P3%22%2C%22Omfattningsvarde%22%3A7.5%2C%22link%22%3A%5B%5D%7D%5D%2C%22Omfattningsvarde%22%3A15%2C%22SistaRegistreringsdatum%22%3A%222026-01-19%22%2C%22SistaUndervisningsdatum%22%3A%222026-06-01%22%7D%5D%2C%22kod%22%3A%22MJ146X%22%2C%22benamning%22%3A%22Examensarbete%20inom%20h%C3%A5llbar%20energiteknik%2C%20grundniv%C3%A5%22%2C%22Valvillkor%22%3A%22VV%22%2C%22type%22%3A%22instance%22%7D%2C%7B%22utbildningsinstansUid%22%3A%228b930de6-96a2-11ea-a1f9-cb69981448b1%22%2C%22uid%22%3A%22c78e245e-b2e9-11ef-9c22-4dfcae5d4bc4%22%2C%22tillfalleskod%22%3A%2260368%22%2C%22status%22%3A%7B%22code%22%3A%22S3%22%2C%22nameSv%22%3A%22Komplett%22%2C%22nameEn%22%3A%22Complete%22%7D%2C%22utbildningstyp%22%3A%7B%22id%22%3A%2222%22%2C%22code%22%3A%222007GKURS%22%2C%22name%22%3A%22Kurs%2C%20grundniv%C3%A5%22%2C%22nameOther%22%3A%22Course%2C%20First-cycle%22%2C%22creditsUnit%22%3A%7B%22code%22%3A%22HP%22%2C%22sv%22%3A%22H%C3%B6gskolepo%C3%A4ng%22%2C%22en%22%3A%22Credits%22%7D%2C%22level%22%3A%7B%22code%22%3A%221%22%2C%22name%22%3A%22Grundniv%C3%A5%22%7D%7D%2C%22omfattning%22%3A%7B%22number%22%3A15%2C%22formattedWithUnit%22%3A%2215%2C0%20hp%22%7D%2C%22startperiod%22%3A%7B%22code%22%3A%22VT2026%22%2C%22startDay%22%3A%222026-01-13%22%2C%22lastDay%22%3A%222026-06-01%22%2C%22inDigits%22%3A%2220261%22%7D%2C%22Tillfallesperioder%22%3A%5B%7B%22ForstaRegistreringsdatum%22%3A%222026-01-08%22%2C%22ForstaUndervisningsdatum%22%3A%222026-01-13%22%2C%22Lasperiodsfordelning%22%3A%5B%7B%22Lasperiodskod%22%3A%22P4%22%2C%22Omfattningsvarde%22%3A7.5%2C%22link%22%3A%5B%5D%7D%2C%7B%22Lasperiodskod%22%3A%22P3%22%2C%22Omfattningsvarde%22%3A7.5%2C%22link%22%3A%5B%5D%7D%5D%2C%22Omfattningsvarde%22%3A15%2C%22SistaRegistreringsdatum%22%3A%222026-01-19%22%2C%22SistaUndervisningsdatum%22%3A%222026-06-01%22%7D%5D%2C%22kod%22%3A%22SA115X%22%2C%22benamning%22%3A%22Examensarbete%20inom%20farkostteknik%2C%20grundniv%C3%A5%22%2C%22Valvillkor%22%3A%22VV%22%2C%22type%22%3A%22instance%22%7D%2C%7B%22utbildningsinstansUid%22%3A%228410be34-73d8-11e8-b4e0-063f9afb40e3%22%2C%22uid%22%3A%2247f95929-bbab-11ef-9553-beecfac44351%22%2C%22tillfalleskod%22%3A%2260157%22%2C%22status%22%3A%7B%22code%22%3A%22S3%22%2C%22nameSv%22%3A%22Komplett%22%2C%22nameEn%22%3A%22Complete%22%7D%2C%22utbildningstyp%22%3A%7B%22id%22%3A%2222%22%2C%22code%22%3A%222007GKURS%22%2C%22name%22%3A%22Kurs%2C%20grundniv%C3%A5%22%2C%22nameOther%22%3A%22Course%2C%20First-cycle%22%2C%22creditsUnit%22%3A%7B%22code%22%3A%22HP%22%2C%22sv%22%3A%22H%C3%B6gskolepo%C3%A4ng%22%2C%22en%22%3A%22Credits%22%7D%2C%22level%22%3A%7B%22code%22%3A%221%22%2C%22name%22%3A%22Grundniv%C3%A5%22%7D%7D%2C%22omfattning%22%3A%7B%22number%22%3A6%2C%22formattedWithUnit%22%3A%226%2C0%20hp%22%7D%2C%22startperiod%22%3A%7B%22code%22%3A%22VT2026%22%2C%22startDay%22%3A%222026-01-13%22%2C%22lastDay%22%3A%222026-06-01%22%2C%22inDigits%22%3A%2220261%22%7D%2C%22Tillfallesperioder%22%3A%5B%7B%22ForstaRegistreringsdatum%22%3A%222026-03-12%22%2C%22ForstaUndervisningsdatum%22%3A%222026-03-16%22%2C%22Lasperiodsfordelning%22%3A%5B%7B%22Lasperiodskod%22%3A%22P4%22%2C%22Omfattningsvarde%22%3A6%2C%22link%22%3A%5B%5D%7D%5D%2C%22Omfattningsvarde%22%3A6%2C%22SistaRegistreringsdatum%22%3A%222026-03-23%22%2C%22SistaUndervisningsdatum%22%3A%222026-06-01%22%7D%5D%2C%22kod%22%3A%22SI1155%22%2C%22benamning%22%3A%22Teoretisk%20fysik%22%2C%22Valvillkor%22%3A%22VV%22%2C%22type%22%3A%22instance%22%7D%2C%7B%22utbildningsinstansUid%22%3A%227d972e0c-73d8-11e8-b4e0-063f9afb40e3%22%2C%22uid%22%3A%226388b604-beb0-11ef-9c9e-74b5caef4769%22%2C%22tillfalleskod%22%3A%2260358%22%2C%22status%22%3A%7B%22code%22%3A%22S3%22%2C%22nameSv%22%3A%22Komplett%22%2C%22nameEn%22%3A%22Complete%22%7D%2C%22utbildningstyp%22%3A%7B%22id%22%3A%2222%22%2C%22code%22%3A%222007GKURS%22%2C%22name%22%3A%22Kurs%2C%20grundniv%C3%A5%22%2C%22nameOther%22%3A%22Course%2C%20First-cycle%22%2C%22creditsUnit%22%3A%7B%22code%22%3A%22HP%22%2C%22sv%22%3A%22H%C3%B6gskolepo%C3%A4ng%22%2C%22en%22%3A%22Credits%22%7D%2C%22level%22%3A%7B%22code%22%3A%221%22%2C%22name%22%3A%22Grundniv%C3%A5%22%7D%7D%2C%22omfattning%22%3A%7B%22number%22%3A6%2C%22formattedWithUnit%22%3A%226%2C0%20hp%22%7D%2C%22startperiod%22%3A%7B%22code%22%3A%22VT2026%22%2C%22startDay%22%3A%222026-01-13%22%2C%22lastDay%22%3A%222026-06-01%22%2C%22inDigits%22%3A%2220261%22%7D%2C%22Tillfallesperioder%22%3A%5B%7B%22ForstaRegistreringsdatum%22%3A%222026-01-08%22%2C%22ForstaUndervisningsdatum%22%3A%222026-01-13%22%2C%22Lasperiodsfordelning%22%3A%5B%7B%22Lasperiodskod%22%3A%22P3%22%2C%22Omfattningsvarde%22%3A6%2C%22link%22%3A%5B%5D%7D%5D%2C%22Omfattningsvarde%22%3A6%2C%22SistaRegistreringsdatum%22%3A%222026-01-19%22%2C%22SistaUndervisningsdatum%22%3A%222026-03-13%22%7D%5D%2C%22kod%22%3A%22SE1025%22%2C%22benamning%22%3A%22FEM%20f%C3%B6r%20ingenj%C3%B6rstill%C3%A4mpningar%22%2C%22Valvillkor%22%3A%22O%22%2C%22type%22%3A%22instance%22%7D%2C%7B%22utbildningsinstansUid%22%3A%228010e0d4-73d8-11e8-b4e0-063f9afb40e3%22%2C%22uid%22%3A%22fa9003b2-ce67-11ef-9bca-bbbddaff469b%22%2C%22tillfalleskod%22%3A%2260884%22%2C%22status%22%3A%7B%22code%22%3A%22S3%22%2C%22nameSv%22%3A%22Komplett%22%2C%22nameEn%22%3A%22Complete%22%7D%2C%22utbildningstyp%22%3A%7B%22id%22%3A%2222%22%2C%22code%22%3A%222007GKURS%22%2C%22name%22%3A%22Kurs%2C%20grundniv%C3%A5%22%2C%22nameOther%22%3A%22Course%2C%20First-cycle%22%2C%22creditsUnit%22%3A%7B%22code%22%3A%22HP%22%2C%22sv%22%3A%22H%C3%B6gskolepo%C3%A4ng%22%2C%22en%22%3A%22Credits%22%7D%2C%22level%22%3A%7B%22code%22%3A%221%22%2C%22name%22%3A%22Grundniv%C3%A5%22%7D%7D%2C%22omfattning%22%3A%7B%22number%22%3A6%2C%22formattedWithUnit%22%3A%226%2C0%20hp%22%7D%2C%22startperiod%22%3A%7B%22code%22%3A%22VT2026%22%2C%22startDay%22%3A%222026-01-13%22%2C%22lastDay%22%3A%222026-06-01%22%2C%22inDigits%22%3A%2220261%22%7D%2C%22Tillfallesperioder%22%3A%5B%7B%22ForstaRegistreringsdatum%22%3A%222026-03-12%22%2C%22ForstaUndervisningsdatum%22%3A%222026-03-16%22%2C%22Lasperiodsfordelning%22%3A%5B%7B%22Lasperiodskod%22%3A%22P4%22%2C%22Omfattningsvarde%22%3A6%2C%22link%22%3A%5B%5D%7D%5D%2C%22Omfattningsvarde%22%3A6%2C%22SistaRegistreringsdatum%22%3A%222026-03-23%22%2C%22SistaUndervisningsdatum%22%3A%222026-06-01%22%7D%5D%2C%22kod%22%3A%22SF1861%22%2C%22benamning%22%3A%22Optimeringsl%C3%A4ra%22%2C%22Valvillkor%22%3A%22O%22%2C%22type%22%3A%22instance%22%7D%2C%7B%22utbildningsinstansUid%22%3A%226187815e-9ebd-11eb-b121-4a7c58ae420f%22%2C%22uid%22%3A%225f10a575-b3ba-11ef-9bd4-11b99f1f4d85%22%2C%22tillfalleskod%22%3A%2250425%22%2C%22status%22%3A%7B%22code%22%3A%22S3%22%2C%22nameSv%22%3A%22Komplett%22%2C%22nameEn%22%3A%22Complete%22%7D%2C%22utbildningstyp%22%3A%7B%22id%22%3A%2222%22%2C%22code%22%3A%222007GKURS%22%2C%22name%22%3A%22Kurs%2C%20grundniv%C3%A5%22%2C%22nameOther%22%3A%22Course%2C%20First-cycle%22%2C%22creditsUnit%22%3A%7B%22code%22%3A%22HP%22%2C%22sv%22%3A%22H%C3%B6gskolepo%C3%A4ng%22%2C%22en%22%3A%22Credits%22%7D%2C%22level%22%3A%7B%22code%22%3A%221%22%2C%22name%22%3A%22Grundniv%C3%A5%22%7D%7D%2C%22omfattning%22%3A%7B%22number%22%3A6%2C%22formattedWithUnit%22%3A%226%2C0%20hp%22%7D%2C%22startperiod%22%3A%7B%22code%22%3A%22HT2025%22%2C%22startDay%22%3A%222025-08-25%22%2C%22lastDay%22%3A%222026-01-12%22%2C%22inDigits%22%3A%2220252%22%7D%2C%22Tillfallesperioder%22%3A%5B%7B%22ForstaRegistreringsdatum%22%3A%222025-08-21%22%2C%22ForstaUndervisningsdatum%22%3A%222025-08-25%22%2C%22Lasperiodsfordelning%22%3A%5B%7B%22Lasperiodskod%22%3A%22P2%22%2C%22Omfattningsvarde%22%3A1%2C%22link%22%3A%5B%5D%7D%2C%7B%22Lasperiodskod%22%3A%22P1%22%2C%22Omfattningsvarde%22%3A5%2C%22link%22%3A%5B%5D%7D%5D%2C%22Omfattningsvarde%22%3A6%2C%22SistaRegistreringsdatum%22%3A%222025-09-01%22%2C%22SistaUndervisningsdatum%22%3A%222026-01-12%22%7D%5D%2C%22kod%22%3A%22DD1320%22%2C%22benamning%22%3A%22Till%C3%A4mpad%20datalogi%22%2C%22Valvillkor%22%3A%22VV%22%2C%22type%22%3A%22instance%22%7D%2C%7B%22utbildningsinstansUid%22%3A%225e38f5dd-6042-11e9-b67f-a77d6cb34fef%22%2C%22uid%22%3A%22e2a70a9a-bb8f-11ef-9553-beecfac44351%22%2C%22tillfalleskod%22%3A%2250852%22%2C%22status%22%3A%7B%22code%22%3A%22S3%22%2C%22nameSv%22%3A%22Komplett%22%2C%22nameEn%22%3A%22Complete%22%7D%2C%22utbildningstyp%22%3A%7B%22id%22%3A%2222%22%2C%22code%22%3A%222007GKURS%22%2C%22name%22%3A%22Kurs%2C%20grundniv%C3%A5%22%2C%22nameOther%22%3A%22Course%2C%20First-cycle%22%2C%22creditsUnit%22%3A%7B%22code%22%3A%22HP%22%2C%22sv%22%3A%22H%C3%B6gskolepo%C3%A4ng%22%2C%22en%22%3A%22Credits%22%7D%2C%22level%22%3A%7B%22code%22%3A%221%22%2C%22name%22%3A%22Grundniv%C3%A5%22%7D%7D%2C%22omfattning%22%3A%7B%22number%22%3A6%2C%22formattedWithUnit%22%3A%226%2C0%20hp%22%7D%2C%22startperiod%22%3A%7B%22code%22%3A%22HT2025%22%2C%22startDay%22%3A%222025-08-25%22%2C%22lastDay%22%3A%222026-01-12%22%2C%22inDigits%22%3A%2220252%22%7D%2C%22Tillfallesperioder%22%3A%5B%7B%22ForstaRegistreringsdatum%22%3A%222025-10-23%22%2C%22ForstaUndervisningsdatum%22%3A%222025-10-27%22%2C%22Lasperiodsfordelning%22%3A%5B%7B%22Lasperiodskod%22%3A%22P2%22%2C%22Omfattningsvarde%22%3A6%2C%22link%22%3A%5B%5D%7D%5D%2C%22Omfattningsvarde%22%3A6%2C%22SistaRegistreringsdatum%22%3A%222025-11-03%22%2C%22SistaUndervisningsdatum%22%3A%222026-01-12%22%7D%5D%2C%22kod%22%3A%22MJ1401%22%2C%22benamning%22%3A%22V%C3%A4rme%C3%B6verf%C3%B6ring%22%2C%22Valvillkor%22%3A%22VV%22%2C%22type%22%3A%22instance%22%7D%2C%7B%22utbildningsinstansUid%22%3A%2282c467d4-73d8-11e8-b4e0-063f9afb40e3%22%2C%22uid%22%3A%229ade5891-bba7-11ef-9553-beecfac44351%22%2C%22tillfalleskod%22%3A%2251382%22%2C%22status%22%3A%7B%22code%22%3A%22S3%22%2C%22nameSv%22%3A%22Komplett%22%2C%22nameEn%22%3A%22Complete%22%7D%2C%22utbildningstyp%22%3A%7B%22id%22%3A%2222%22%2C%22code%22%3A%222007GKURS%22%2C%22name%22%3A%22Kurs%2C%20grundniv%C3%A5%22%2C%22nameOther%22%3A%22Course%2C%20First-cycle%22%2C%22creditsUnit%22%3A%7B%22code%22%3A%22HP%22%2C%22sv%22%3A%22H%C3%B6gskolepo%C3%A4ng%22%2C%22en%22%3A%22Credits%22%7D%2C%22level%22%3A%7B%22code%22%3A%221%22%2C%22name%22%3A%22Grundniv%C3%A5%22%7D%7D%2C%22omfattning%22%3A%7B%22number%22%3A4%2C%22formattedWithUnit%22%3A%224%2C0%20hp%22%7D%2C%22startperiod%22%3A%7B%22code%22%3A%22HT2025%22%2C%22startDay%22%3A%222025-08-25%22%2C%22lastDay%22%3A%222026-01-12%22%2C%22inDigits%22%3A%2220252%22%7D%2C%22Tillfallesperioder%22%3A%5B%7B%22ForstaRegistreringsdatum%22%3A%222025-10-23%22%2C%22ForstaUndervisningsdatum%22%3A%222025-10-27%22%2C%22Lasperiodsfordelning%22%3A%5B%7B%22Lasperiodskod%22%3A%22P2%22%2C%22Omfattningsvarde%22%3A4%2C%22link%22%3A%5B%5D%7D%5D%2C%22Omfattningsvarde%22%3A4%2C%22SistaRegistreringsdatum%22%3A%222025-11-03%22%2C%22SistaUndervisningsdatum%22%3A%222026-01-12%22%7D%5D%2C%22kod%22%3A%22SH1014%22%2C%22benamning%22%3A%22Modern%20fysik%22%2C%22Valvillkor%22%3A%22VV%22%2C%22type%22%3A%22instance%22%7D%2C%7B%22utbildningsinstansUid%22%3A%2284079666-73d8-11e8-b4e0-063f9afb40e3%22%2C%22uid%22%3A%220deb231b-bbab-11ef-9553-beecfac44351%22%2C%22tillfalleskod%22%3A%2250258%22%2C%22status%22%3A%7B%22code%22%3A%22S3%22%2C%22nameSv%22%3A%22Komplett%22%2C%22nameEn%22%3A%22Complete%22%7D%2C%22utbildningstyp%22%3A%7B%22id%22%3A%2222%22%2C%22code%22%3A%222007GKURS%22%2C%22name%22%3A%22Kurs%2C%20grundniv%C3%A5%22%2C%22nameOther%22%3A%22Course%2C%20First-cycle%22%2C%22creditsUnit%22%3A%7B%22code%22%3A%22HP%22%2C%22sv%22%3A%22H%C3%B6gskolepo%C3%A4ng%22%2C%22en%22%3A%22Credits%22%7D%2C%22level%22%3A%7B%22code%22%3A%221%22%2C%22name%22%3A%22Grundniv%C3%A5%22%7D%7D%2C%22omfattning%22%3A%7B%22number%22%3A4%2C%22formattedWithUnit%22%3A%224%2C0%20hp%22%7D%2C%22startperiod%22%3A%7B%22code%22%3A%22HT2025%22%2C%22startDay%22%3A%222025-08-25%22%2C%22lastDay%22%3A%222026-01-12%22%2C%22inDigits%22%3A%2220252%22%7D%2C%22Tillfallesperioder%22%3A%5B%7B%22ForstaRegistreringsdatum%22%3A%222025-08-21%22%2C%22ForstaUndervisningsdatum%22%3A%222025-08-25%22%2C%22Lasperiodsfordelning%22%3A%5B%7B%22Lasperiodskod%22%3A%22P1%22%2C%22Omfattningsvarde%22%3A4%2C%22link%22%3A%5B%5D%7D%5D%2C%22Omfattningsvarde%22%3A4%2C%22SistaRegistreringsdatum%22%3A%222025-09-01%22%2C%22SistaUndervisningsdatum%22%3A%222025-10-24%22%7D%5D%2C%22kod%22%3A%22SI1146%22%2C%22benamning%22%3A%22Vektoranalys%22%2C%22Valvillkor%22%3A%22VV%22%2C%22type%22%3A%22instance%22%7D%2C%7B%22utbildningsinstansUid%22%3A%222d4a5ec2-eab6-11ee-b995-37dc0139489a%22%2C%22uid%22%3A%22b46217a3-bc69-11ef-9553-beecfac44351%22%2C%22tillfalleskod%22%3A%2250316%22%2C%22status%22%3A%7B%22code%22%3A%22S3%22%2C%22nameSv%22%3A%22Komplett%22%2C%22nameEn%22%3A%22Complete%22%7D%2C%22utbildningstyp%22%3A%7B%22id%22%3A%2222%22%2C%22code%22%3A%222007GKURS%22%2C%22name%22%3A%22Kurs%2C%20grundniv%C3%A5%22%2C%22nameOther%22%3A%22Course%2C%20First-cycle%22%2C%22creditsUnit%22%3A%7B%22code%22%3A%22HP%22%2C%22sv%22%3A%22H%C3%B6gskolepo%C3%A4ng%22%2C%22en%22%3A%22Credits%22%7D%2C%22level%22%3A%7B%22code%22%3A%221%22%2C%22name%22%3A%22Grundniv%C3%A5%22%7D%7D%2C%22omfattning%22%3A%7B%22number%22%3A6%2C%22formattedWithUnit%22%3A%226%2C0%20hp%22%7D%2C%22startperiod%22%3A%7B%22code%22%3A%22HT2025%22%2C%22startDay%22%3A%222025-08-25%22%2C%22lastDay%22%3A%222026-01-12%22%2C%22inDigits%22%3A%2220252%22%7D%2C%22Tillfallesperioder%22%3A%5B%7B%22ForstaRegistreringsdatum%22%3A%222025-08-21%22%2C%22ForstaUndervisningsdatum%22%3A%222025-08-25%22%2C%22Lasperiodsfordelning%22%3A%5B%7B%22Lasperiodskod%22%3A%22P1%22%2C%22Omfattningsvarde%22%3A6%2C%22link%22%3A%5B%5D%7D%5D%2C%22Omfattningsvarde%22%3A6%2C%22SistaRegistreringsdatum%22%3A%222025-09-01%22%2C%22SistaUndervisningsdatum%22%3A%222025-10-24%22%7D%5D%2C%22kod%22%3A%22ME1003%22%2C%22benamning%22%3A%22Industriell%20ekonomi%2C%20grundkurs%22%2C%22Valvillkor%22%3A%22VV%22%2C%22type%22%3A%22instance%22%7D%5D%2C%22freeTexts%22%3A%5B%5D%2C%22supplementaryInfo%22%3A%22%3Cp%3E%3Cstrong%3EUtbildningens%20tv%C3%A5%20sista%20%C3%A5r%20l%C3%A4ses%20inom%20ramen%20f%C3%B6r%20ett%20masterprogram.%3C%2Fstrong%3E%3C%2Fp%3E%5Cn%3Cp%3EF%C3%B6r%20information%20om%20kurser%20i%20%C3%A5k%204-5%2C%20se%26nbsp%3Bmasterprogrammen%20i%20-%20prelimin%C3%A4r%3A%3C%2Fp%3E%5Cn%3Cp%3EFlyg-%20och%20rymdteknik%2C%20Fordonsteknik%2C%20H%C3%A5llbar%20energiteknik%2C%20Industriell%20ekonomi%2C%20Maskinkonstruktion%2C%20Integrerad%20produktdesign%26nbsp%3B(endast%20sp%C3%A5r%20Innovationsledning%20och%20produktutveckling)%2C%26nbsp%3BK%C3%A4rnenergiteknik%2C%20Marina%20system%2C%20Teknisk%20mekanik%2C%20Teknisk%20fysik%2C%20Till%C3%A4mpad%20matematik%20och%20ber%C3%A4kningsmatematik%2C%20Mekatronik.%3C%2Fp%3E%22%2C%22conditionallyElectiveCoursesInfo%22%3A%22%3Cp%3EBeh%C3%B6righetsgivande%20kurser%20till%20masterprogram%3C%2Fp%3E%5Cn%3Cp%3EH%C3%A5llbar%20energiteknik%20(TSUEM)%3C%2Fp%3E%5Cn%3Cp%3EKurs%20som%20kr%C3%A4vs%3A%20MJ1401%3C%2Fp%3E%5Cn%3Cp%3ETeknisk%20fysik%20(TTFYM)%3A%3C%2Fp%3E%5Cn%3Cp%3EKurser%20som%20kr%C3%A4vs%3A%20SI1146%20och%20SH1014%3C%2Fp%3E%5Cn%3Cp%3ESamt%20SI1155%20f%C3%B6r%20tre%20av%20sp%C3%A5ren%3A%20TFYA%2C%20TFYB%20och%20TFYG%3C%2Fp%3E%5Cn%3Cp%3EIndustriell%20ekonomi%20(TINEM)%3C%2Fp%3E%5Cn%3Cp%3EKursen%20som%20kr%C3%A4vs%3A%20ME1003%20och%20ME2163%3C%2Fp%3E%5Cn%3Cp%3EK%C3%A4rnenergiteknik%20(TNEEM)%3C%2Fp%3E%5Cn%3Cp%3EKurs%20som%20kr%C3%A4vs%3A%20SH1012%3C%2Fp%3E%5Cn%3Cp%3EMekatronik%20(TMEKM)%3C%2Fp%3E%5Cn%3Cp%3EKurs%20som%20kr%C3%A4vs%3A%20DD1320%3C%2Fp%3E%5Cn%3Cp%3ESystemteknik%20och%20robotik%20(TSCRM)%3C%2Fp%3E%5Cn%3Cp%3EKurs%20som%20kr%C3%A4vs%3A%20DD1320%3C%2Fp%3E%5Cn%3Cp%3EMaskinkonstruktion%20(TMSKM)%3C%2Fp%3E%22%7D%2C%7B%22yearNumber%22%3A4%2C%22courses%22%3A%5B%5D%2C%22freeTexts%22%3A%5B%5D%2C%22supplementaryInfo%22%3A%22%3Cp%3E%3Cstrong%3EUtbildningens%20tv%C3%A5%20sista%20%C3%A5r%20l%C3%A4ses%20inom%20ramen%20f%C3%B6r%20ett%20masterprogram.%3C%2Fstrong%3E%3C%2Fp%3E%5Cn%3Cp%3EF%C3%B6r%20kurser%20inom%20%C3%A5rskurs%204%2C%20se%20l%C3%A4s%C3%A5rsplan%20f%C3%B6r%20%C3%A5rskurs%201%20inom%20det%20masterprogram%20du%20har%20valt.%3C%2Fp%3E%5Cn%3Cp%3EValbara%20masterprogram%20som%20leder%20till%20civilingenj%C3%B6rsexamen%20i%20Farkostteknik%20%C3%A4r%20(prelinim%C3%A4r)%3A%3C%2Fp%3E%5Cn%3Cul%3E%5Cn%3Cli%3EFlyg-%20och%20rymdteknik%3C%2Fli%3E%5Cn%3Cli%3EFordonsteknik%3C%2Fli%3E%5Cn%3Cli%3EH%C3%A5llbar%20energiteknik%3C%2Fli%3E%5Cn%3Cli%3EIndustriell%20ekonomi%3C%2Fli%3E%5Cn%3Cli%3EMaskinkonstruktion%3C%2Fli%3E%5Cn%3Cli%3EIntegrerad%20produktdesign%26nbsp%3B%3C%2Fli%3E%5Cn%3Cli%3EK%C3%A4rnenergiteknik%3C%2Fli%3E%5Cn%3Cli%3EMarina%20system%3C%2Fli%3E%5Cn%3Cli%3ESystemteknik%20och%20robotik%3C%2Fli%3E%5Cn%3Cli%3ETeknisk%20fysik%3C%2Fli%3E%5Cn%3Cli%3ETeknisk%20mekanik%3C%2Fli%3E%5Cn%3Cli%3ETill%C3%A4mpad%20matematik%20och%20ber%C3%A4kningsmatematik.%3C%2Fli%3E%5Cn%3Cli%3EMekatronik%3C%2Fli%3E%5Cn%3C%2Ful%3E%22%7D%2C%7B%22yearNumber%22%3A5%2C%22courses%22%3A%5B%5D%2C%22freeTexts%22%3A%5B%5D%2C%22supplementaryInfo%22%3A%22%3Cp%3E%3Cstrong%3EUtbildningens%20tv%C3%A5%20sista%20%C3%A5r%20l%C3%A4ses%20inom%20ramen%20f%C3%B6r%20ett%20masterprogram.%3C%2Fstrong%3E%3C%2Fp%3E%5Cn%3Cp%3EF%C3%B6r%20kurser%20inom%20%C3%A5rskurs%205%2C%20se%20l%C3%A4s%C3%A5rsplan%20f%C3%B6r%20%C3%A5rskurs%202%20inom%20det%20masterprogram%20du%20har%20valt.%3C%2Fp%3E%5Cn%3Cp%3EValbara%20masterprogram%20som%20leder%20till%20civilingenj%C3%B6rsexamen%20i%20Farkostteknik%20%C3%A4r%20(prelinim%C3%A4r)%3A%3C%2Fp%3E%5Cn%3Cul%3E%5Cn%3Cli%3EFlyg-%20och%20rymdteknik%3C%2Fli%3E%5Cn%3Cli%3EFordonsteknik%3C%2Fli%3E%5Cn%3Cli%3EH%C3%A5llbar%20energiteknik%3C%2Fli%3E%5Cn%3Cli%3EIndustriell%20ekonomi%3C%2Fli%3E%5Cn%3Cli%3EMaskinkonstruktion%3C%2Fli%3E%5Cn%3Cli%3EIntegrerad%20produktdesign%26nbsp%3B%3C%2Fli%3E%5Cn%3Cli%3EK%C3%A4rnenergiteknik%3C%2Fli%3E%5Cn%3Cli%3EMarina%20system%3C%2Fli%3E%5Cn%3Cli%3ESystemteknik%20och%20robotik%3C%2Fli%3E%5Cn%3Cli%3ETeknisk%20fysik%3C%2Fli%3E%5Cn%3Cli%3ETeknisk%20mekanik%3C%2Fli%3E%5Cn%3Cli%3ETill%C3%A4mpad%20matematik%20och%20ber%C3%A4kningsmatematik.%3C%2Fli%3E%5Cn%3C%2Ful%3E%22%7D%5D%7D%5D%2C%22errorType%22%3A%7B%22MISSING_ADMISSION%22%3A%22missing_admission%22%7D%2C%22error%22%3Anull%2C%22curriculumInfos%22%3A%5B%7B%22code%22%3A%22%22%2C%22specializationName%22%3Anull%2C%22isCommon%22%3Atrue%2C%22participations%22%3A%7B%22O%22%3A%5B%7B%22course%22%3A%7B%22courseCode%22%3A%22EL1010%22%2C%22title%22%3A%22Reglerteknik%2C%20allm%C3%A4n%20kurs%22%2C%22credits%22%3A6%2C%22formattedCredits%22%3A%226%2C0%20hp%22%2C%22educationalLevel%22%3A%22Grundniv%C3%A5%22%2C%22electiveCondition%22%3A%22O%22%2C%22status%22%3A%7B%22code%22%3A%22S3%22%2C%22nameSv%22%3A%22Komplett%22%2C%22nameEn%22%3A%22Complete%22%7D%7D%2C%22applicationCode%22%3A%2250485%22%2C%22term%22%3A%2220252%22%2C%22creditsPerPeriod%22%3A%5B0%2C0%2C6%2C0%2C0%2C0%5D%7D%2C%7B%22course%22%3A%7B%22courseCode%22%3A%22MF1017%22%2C%22title%22%3A%22Elektroteknik%22%2C%22credits%22%3A6%2C%22formattedCredits%22%3A%226%2C0%20hp%22%2C%22educationalLevel%22%3A%22Grundniv%C3%A5%22%2C%22electiveCondition%22%3A%22O%22%2C%22status%22%3A%7B%22code%22%3A%22S3%22%2C%22nameSv%22%3A%22Komplett%22%2C%22nameEn%22%3A%22Complete%22%7D%7D%2C%22applicationCode%22%3A%2250329%22%2C%22term%22%3A%2220252%22%2C%22creditsPerPeriod%22%3A%5B0%2C6%2C0%2C0%2C0%2C0%5D%7D%2C%7B%22course%22%3A%7B%22courseCode%22%3A%22SD2125%22%2C%22title%22%3A%22Signaler%20och%20mekaniska%20system%22%2C%22credits%22%3A6%2C%22formattedCredits%22%3A%226%2C0%20hp%22%2C%22educationalLevel%22%3A%22Avancerad%20niv%C3%A5%22%2C%22electiveCondition%22%3A%22O%22%2C%22status%22%3A%7B%22code%22%3A%22S3%22%2C%22nameSv%22%3A%22Komplett%22%2C%22nameEn%22%3A%22Complete%22%7D%7D%2C%22applicationCode%22%3A%2251600%22%2C%22term%22%3A%2220252%22%2C%22creditsPerPeriod%22%3A%5B0%2C0%2C6%2C0%2C0%2C0%5D%7D%2C%7B%22course%22%3A%7B%22courseCode%22%3A%22SF1914%22%2C%22title%22%3A%22Sannolikhetsteori%20och%20statistik%22%2C%22credits%22%3A6%2C%22formattedCredits%22%3A%226%2C0%20hp%22%2C%22educationalLevel%22%3A%22Grundniv%C3%A5%22%2C%22electiveCondition%22%3A%22O%22%2C%22status%22%3A%7B%22code%22%3A%22S3%22%2C%22nameSv%22%3A%22Komplett%22%2C%22nameEn%22%3A%22Complete%22%7D%7D%2C%22applicationCode%22%3A%2250468%22%2C%22term%22%3A%2220252%22%2C%22creditsPerPeriod%22%3A%5B0%2C6%2C0%2C0%2C0%2C0%5D%7D%2C%7B%22course%22%3A%7B%22courseCode%22%3A%22SE1025%22%2C%22title%22%3A%22FEM%20f%C3%B6r%20ingenj%C3%B6rstill%C3%A4mpningar%22%2C%22credits%22%3A6%2C%22formattedCredits%22%3A%226%2C0%20hp%22%2C%22educationalLevel%22%3A%22Grundniv%C3%A5%22%2C%22electiveCondition%22%3A%22O%22%2C%22status%22%3A%7B%22code%22%3A%22S3%22%2C%22nameSv%22%3A%22Komplett%22%2C%22nameEn%22%3A%22Complete%22%7D%7D%2C%22applicationCode%22%3A%2260358%22%2C%22term%22%3A%2220261%22%2C%22creditsPerPeriod%22%3A%5B0%2C0%2C0%2C6%2C0%2C0%5D%7D%2C%7B%22course%22%3A%7B%22courseCode%22%3A%22SF1861%22%2C%22title%22%3A%22Optimeringsl%C3%A4ra%22%2C%22credits%22%3A6%2C%22formattedCredits%22%3A%226%2C0%20hp%22%2C%22educationalLevel%22%3A%22Grundniv%C3%A5%22%2C%22electiveCondition%22%3A%22O%22%2C%22status%22%3A%7B%22code%22%3A%22S3%22%2C%22nameSv%22%3A%22Komplett%22%2C%22nameEn%22%3A%22Complete%22%7D%7D%2C%22applicationCode%22%3A%2260884%22%2C%22term%22%3A%2220261%22%2C%22creditsPerPeriod%22%3A%5B0%2C0%2C0%2C0%2C6%2C0%5D%7D%5D%2C%22VV%22%3A%5B%7B%22course%22%3A%7B%22courseCode%22%3A%22DD1320%22%2C%22title%22%3A%22Till%C3%A4mpad%20datalogi%22%2C%22credits%22%3A6%2C%22formattedCredits%22%3A%226%2C0%20hp%22%2C%22educationalLevel%22%3A%22Grundniv%C3%A5%22%2C%22electiveCondition%22%3A%22VV%22%2C%22status%22%3A%7B%22code%22%3A%22S3%22%2C%22nameSv%22%3A%22Komplett%22%2C%22nameEn%22%3A%22Complete%22%7D%7D%2C%22applicationCode%22%3A%2250425%22%2C%22term%22%3A%2220252%22%2C%22creditsPerPeriod%22%3A%5B0%2C5%2C1%2C0%2C0%2C0%5D%7D%2C%7B%22course%22%3A%7B%22courseCode%22%3A%22MJ1401%22%2C%22title%22%3A%22V%C3%A4rme%C3%B6verf%C3%B6ring%22%2C%22credits%22%3A6%2C%22formattedCredits%22%3A%226%2C0%20hp%22%2C%22educationalLevel%22%3A%22Grundniv%C3%A5%22%2C%22electiveCondition%22%3A%22VV%22%2C%22status%22%3A%7B%22code%22%3A%22S3%22%2C%22nameSv%22%3A%22Komplett%22%2C%22nameEn%22%3A%22Complete%22%7D%7D%2C%22applicationCode%22%3A%2250852%22%2C%22term%22%3A%2220252%22%2C%22creditsPerPeriod%22%3A%5B0%2C0%2C6%2C0%2C0%2C0%5D%7D%2C%7B%22course%22%3A%7B%22courseCode%22%3A%22SH1014%22%2C%22title%22%3A%22Modern%20fysik%22%2C%22credits%22%3A4%2C%22formattedCredits%22%3A%224%2C0%20hp%22%2C%22educationalLevel%22%3A%22Grundniv%C3%A5%22%2C%22electiveCondition%22%3A%22VV%22%2C%22status%22%3A%7B%22code%22%3A%22S3%22%2C%22nameSv%22%3A%22Komplett%22%2C%22nameEn%22%3A%22Complete%22%7D%7D%2C%22applicationCode%22%3A%2251382%22%2C%22term%22%3A%2220252%22%2C%22creditsPerPeriod%22%3A%5B0%2C0%2C4%2C0%2C0%2C0%5D%7D%2C%7B%22course%22%3A%7B%22courseCode%22%3A%22SI1146%22%2C%22title%22%3A%22Vektoranalys%22%2C%22credits%22%3A4%2C%22formattedCredits%22%3A%224%2C0%20hp%22%2C%22educationalLevel%22%3A%22Grundniv%C3%A5%22%2C%22electiveCondition%22%3A%22VV%22%2C%22status%22%3A%7B%22code%22%3A%22S3%22%2C%22nameSv%22%3A%22Komplett%22%2C%22nameEn%22%3A%22Complete%22%7D%7D%2C%22applicationCode%22%3A%2250258%22%2C%22term%22%3A%2220252%22%2C%22creditsPerPeriod%22%3A%5B0%2C4%2C0%2C0%2C0%2C0%5D%7D%2C%7B%22course%22%3A%7B%22courseCode%22%3A%22ME1003%22%2C%22title%22%3A%22Industriell%20ekonomi%2C%20grundkurs%22%2C%22credits%22%3A6%2C%22formattedCredits%22%3A%226%2C0%20hp%22%2C%22educationalLevel%22%3A%22Grundniv%C3%A5%22%2C%22electiveCondition%22%3A%22VV%22%2C%22status%22%3A%7B%22code%22%3A%22S3%22%2C%22nameSv%22%3A%22Komplett%22%2C%22nameEn%22%3A%22Complete%22%7D%7D%2C%22applicationCode%22%3A%2250316%22%2C%22term%22%3A%2220252%22%2C%22creditsPerPeriod%22%3A%5B0%2C6%2C0%2C0%2C0%2C0%5D%7D%2C%7B%22course%22%3A%7B%22courseCode%22%3A%22EF112X%22%2C%22title%22%3A%22Examensarbete%20inom%20elektroteknik%2C%20grundniv%C3%A5%22%2C%22credits%22%3A15%2C%22formattedCredits%22%3A%2215%2C0%20hp%22%2C%22educationalLevel%22%3A%22Grundniv%C3%A5%22%2C%22electiveCondition%22%3A%22VV%22%2C%22status%22%3A%7B%22code%22%3A%22S3%22%2C%22nameSv%22%3A%22Komplett%22%2C%22nameEn%22%3A%22Complete%22%7D%7D%2C%22applicationCode%22%3A%2260889%22%2C%22term%22%3A%2220261%22%2C%22creditsPerPeriod%22%3A%5B0%2C0%2C0%2C7.5%2C7.5%2C0%5D%7D%2C%7B%22course%22%3A%7B%22courseCode%22%3A%22ME2163%22%2C%22title%22%3A%22Ledarskap%20och%20organisering%20i%20olika%20milj%C3%B6er%22%2C%22credits%22%3A6%2C%22formattedCredits%22%3A%226%2C0%20hp%22%2C%22educationalLevel%22%3A%22Avancerad%20niv%C3%A5%22%2C%22electiveCondition%22%3A%22VV%22%2C%22status%22%3A%7B%22code%22%3A%22S3%22%2C%22nameSv%22%3A%22Komplett%22%2C%22nameEn%22%3A%22Complete%22%7D%7D%2C%22applicationCode%22%3A%2260217%22%2C%22term%22%3A%2220261%22%2C%22creditsPerPeriod%22%3A%5B0%2C0%2C0%2C0%2C6%2C0%5D%7D%2C%7B%22course%22%3A%7B%22courseCode%22%3A%22MF130X%22%2C%22title%22%3A%22Examensarbete%20inom%20maskinkonstruktion%2C%20grundniv%C3%A5%22%2C%22credits%22%3A15%2C%22formattedCredits%22%3A%2215%2C0%20hp%22%2C%22educationalLevel%22%3A%22Grundniv%C3%A5%22%2C%22electiveCondition%22%3A%22VV%22%2C%22status%22%3A%7B%22code%22%3A%22S3%22%2C%22nameSv%22%3A%22Komplett%22%2C%22nameEn%22%3A%22Complete%22%7D%7D%2C%22applicationCode%22%3A%2260552%22%2C%22term%22%3A%2220261%22%2C%22creditsPerPeriod%22%3A%5B0%2C0%2C0%2C7.5%2C7.5%2C0%5D%7D%2C%7B%22course%22%3A%7B%22courseCode%22%3A%22MF131X%22%2C%22title%22%3A%22Examensarbete%20inom%20integrerad%20produktutveckling%2C%20grundniv%C3%A5%22%2C%22credits%22%3A15%2C%22formattedCredits%22%3A%2215%2C0%20hp%22%2C%22educationalLevel%22%3A%22Grundniv%C3%A5%22%2C%22electiveCondition%22%3A%22VV%22%2C%22status%22%3A%7B%22code%22%3A%22S3%22%2C%22nameSv%22%3A%22Komplett%22%2C%22nameEn%22%3A%22Complete%22%7D%7D%2C%22applicationCode%22%3A%2260553%22%2C%22term%22%3A%2220261%22%2C%22creditsPerPeriod%22%3A%5B0%2C0%2C0%2C7.5%2C7.5%2C0%5D%7D%2C%7B%22course%22%3A%7B%22courseCode%22%3A%22MF133X%22%2C%22title%22%3A%22Examensarbete%20inom%20mekatronik%2C%20grundniv%C3%A5%22%2C%22credits%22%3A15%2C%22formattedCredits%22%3A%2215%2C0%20hp%22%2C%22educationalLevel%22%3A%22Grundniv%C3%A5%22%2C%22electiveCondition%22%3A%22VV%22%2C%22status%22%3A%7B%22code%22%3A%22S3%22%2C%22nameSv%22%3A%22Komplett%22%2C%22nameEn%22%3A%22Complete%22%7D%7D%2C%22applicationCode%22%3A%2260567%22%2C%22term%22%3A%2220261%22%2C%22creditsPerPeriod%22%3A%5B0%2C0%2C0%2C7.5%2C7.5%2C0%5D%7D%2C%7B%22course%22%3A%7B%22courseCode%22%3A%22MJ146X%22%2C%22title%22%3A%22Examensarbete%20inom%20h%C3%A5llbar%20energiteknik%2C%20grundniv%C3%A5%22%2C%22credits%22%3A15%2C%22formattedCredits%22%3A%2215%2C0%20hp%22%2C%22educationalLevel%22%3A%22Grundniv%C3%A5%22%2C%22electiveCondition%22%3A%22VV%22%2C%22status%22%3A%7B%22code%22%3A%22S3%22%2C%22nameSv%22%3A%22Komplett%22%2C%22nameEn%22%3A%22Complete%22%7D%7D%2C%22applicationCode%22%3A%2260993%22%2C%22term%22%3A%2220261%22%2C%22creditsPerPeriod%22%3A%5B0%2C0%2C0%2C7.5%2C7.5%2C0%5D%7D%2C%7B%22course%22%3A%7B%22courseCode%22%3A%22SA115X%22%2C%22title%22%3A%22Examensarbete%20inom%20farkostteknik%2C%20grundniv%C3%A5%22%2C%22credits%22%3A15%2C%22formattedCredits%22%3A%2215%2C0%20hp%22%2C%22educationalLevel%22%3A%22Grundniv%C3%A5%22%2C%22electiveCondition%22%3A%22VV%22%2C%22status%22%3A%7B%22code%22%3A%22S3%22%2C%22nameSv%22%3A%22Komplett%22%2C%22nameEn%22%3A%22Complete%22%7D%7D%2C%22applicationCode%22%3A%2260368%22%2C%22term%22%3A%2220261%22%2C%22creditsPerPeriod%22%3A%5B0%2C0%2C0%2C7.5%2C7.5%2C0%5D%7D%2C%7B%22course%22%3A%7B%22courseCode%22%3A%22SI1155%22%2C%22title%22%3A%22Teoretisk%20fysik%22%2C%22credits%22%3A6%2C%22formattedCredits%22%3A%226%2C0%20hp%22%2C%22educationalLevel%22%3A%22Grundniv%C3%A5%22%2C%22electiveCondition%22%3A%22VV%22%2C%22status%22%3A%7B%22code%22%3A%22S3%22%2C%22nameSv%22%3A%22Komplett%22%2C%22nameEn%22%3A%22Complete%22%7D%7D%2C%22applicationCode%22%3A%2260157%22%2C%22term%22%3A%2220261%22%2C%22creditsPerPeriod%22%3A%5B0%2C0%2C0%2C0%2C6%2C0%5D%7D%5D%7D%2C%22supplementaryInformation%22%3A%22%3Cp%3E%3Cstrong%3EUtbildningens%20tv%C3%A5%20sista%20%C3%A5r%20l%C3%A4ses%20inom%20ramen%20f%C3%B6r%20ett%20masterprogram.%3C%2Fstrong%3E%3C%2Fp%3E%5Cn%3Cp%3EF%C3%B6r%20information%20om%20kurser%20i%20%C3%A5k%204-5%2C%20se%26nbsp%3Bmasterprogrammen%20i%20-%20prelimin%C3%A4r%3A%3C%2Fp%3E%5Cn%3Cp%3EFlyg-%20och%20rymdteknik%2C%20Fordonsteknik%2C%20H%C3%A5llbar%20energiteknik%2C%20Industriell%20ekonomi%2C%20Maskinkonstruktion%2C%20Integrerad%20produktdesign%26nbsp%3B(endast%20sp%C3%A5r%20Innovationsledning%20och%20produktutveckling)%2C%26nbsp%3BK%C3%A4rnenergiteknik%2C%20Marina%20system%2C%20Teknisk%20mekanik%2C%20Teknisk%20fysik%2C%20Till%C3%A4mpad%20matematik%20och%20ber%C3%A4kningsmatematik%2C%20Mekatronik.%3C%2Fp%3E%22%2C%22conditionallyElectiveCoursesInformation%22%3A%22%3Cp%3EBeh%C3%B6righetsgivande%20kurser%20till%20masterprogram%3C%2Fp%3E%5Cn%3Cp%3EH%C3%A5llbar%20energiteknik%20(TSUEM)%3C%2Fp%3E%5Cn%3Cp%3EKurs%20som%20kr%C3%A4vs%3A%20MJ1401%3C%2Fp%3E%5Cn%3Cp%3ETeknisk%20fysik%20(TTFYM)%3A%3C%2Fp%3E%5Cn%3Cp%3EKurser%20som%20kr%C3%A4vs%3A%20SI1146%20och%20SH1014%3C%2Fp%3E%5Cn%3Cp%3ESamt%20SI1155%20f%C3%B6r%20tre%20av%20sp%C3%A5ren%3A%20TFYA%2C%20TFYB%20och%20TFYG%3C%2Fp%3E%5Cn%3Cp%3EIndustriell%20ekonomi%20(TINEM)%3C%2Fp%3E%5Cn%3Cp%3EKursen%20som%20kr%C3%A4vs%3A%20ME1003%20och%20ME2163%3C%2Fp%3E%5Cn%3Cp%3EK%C3%A4rnenergiteknik%20(TNEEM)%3C%2Fp%3E%5Cn%3Cp%3EKurs%20som%20kr%C3%A4vs%3A%20SH1012%3C%2Fp%3E%5Cn%3Cp%3EMekatronik%20(TMEKM)%3C%2Fp%3E%5Cn%3Cp%3EKurs%20som%20kr%C3%A4vs%3A%20DD1320%3C%2Fp%3E%5Cn%3Cp%3ESystemteknik%20och%20robotik%20(TSCRM)%3C%2Fp%3E%5Cn%3Cp%3EKurs%20som%20kr%C3%A4vs%3A%20DD1320%3C%2Fp%3E%5Cn%3Cp%3EMaskinkonstruktion%20(TMSKM)%3C%2Fp%3E%22%2C%22isFirstSpec%22%3Afalse%2C%22hasInfo%22%3Atrue%2C%22freeTexts%22%3A%5B%5D%7D%5D%2C%22lengthInStudyYears%22%3A5%2C%22thisHostBaseUrl%22%3Anull%7D";</script>
+
+<!---->
+
+  <div id="app"></div>
+    </div>
+  </div>
+  <!--indexOff: all-->
+  <!-- add "scroll-to-top" button when scrolled down -->
+  <div id="back-to-top" role="link" aria-label="Till sidans topp"></div>
+  <footer class="kth-footer student-web">
+      <div class="kth-footer__content">
+              
+  
+  
+  
+  
+    <div class="columnSplitterWrapper" data-cid="1.1066523" lang="sv">
+      
+      <div class="columnSplitter  using4Columns ">
+        <div class="col c1">
+          
+  
+  
+  
+  
+    <div class="block list links" data-cid="1.1066524" lang="sv">
+      <h2>Studentwebben</h2>
+      
+      <ul>
+        <li><a href="/student/studier">Studier</a></li>
+        <li><a href="/student/stod">Stöd och vägledning</a></li>
+        <li><a href="/student/it">IT och digitala tjänster</a></li>
+        <li><a href="/student/kontakt">Kontakt</a></li>
+      </ul>
+    </div>
+  
+  
+  
+        </div>
+        <div class="col c2">
+          
+  
+  
+  
+  
+    <div class="block list links" data-cid="1.1066531" lang="sv">
+      <h2>Tjänster</h2>
+      
+      <ul>
+        <li><a href="/student/studier/schema">Schema</a></li>
+        <li><a href="https://canvas.kth.se/">Canvas</a></li>
+        <li><a href="http://webmail.kth.se">Webbmejl</a></li>
+        <li><a href="/student/it/studenttjanster/personligamenyn">Personliga menyn</a></li>
+        <li><a href="https://www.student.ladok.se/student/app/studentwebb/">Ladok för studenter</a></li>
+      </ul>
+    </div>
+  
+  
+  
+        </div>
+        <div class="col c3">
+          
+  
+  
+  
+  
+    <div class="block list links" data-cid="1.1066534" lang="sv">
+      <h2>Kontakt</h2>
+      
+      <ul>
+        <li><a href="/student/kontakt/kontaktuppgifter/kontakta-utbildningsprogram-1.1170401">Kontakta utbildningsprogram</a></li>
+        <li><a href="/student/kontakt/kontaktuppgifter/kontakta-kurs-1.1171899">Kontakta kurs</a></li>
+        <li><a href="/student/it/contact">IT-support</a></li>
+        <li><a href="/student/kontakt/campus/kth-entre">KTH Entré</a></li>
+        <li><a href="/student/kontakt/campus/kth-biblioteket-1.2479">KTH Biblioteket</a></li>
+      </ul>
+    </div>
+  
+  
+  
+        </div>
+        <div class="col c4">
+          
+  
+  
+  
+  
+    <article class="block teaser top white" data-cid="1.1083631" lang="sv">
+      
+      <div class="teaserBody   ">
+        
+        
+        <div class="lead">
+          
+          
+        
+          
+          <p><strong>KTH</strong><br> <em>100 44 Stockholm<br> +46 8 790 60 00<br>
+        
+      
+        
+          
+  
+  
+  
+  
+    <a class="block link" data-cid="1.1083633" lang="sv" href="mailto:info@kth.se">info@kth.se</a>
+  
+  
+  
+          
+        
+      
+        
+          
+          </em><br> &nbsp;</p>
+        
+      
+        </div>
+        
+      </div>
+    </article>
+  
+  
+  
+        </div>
+      </div>
+    </div>
+  
+  
+  
+      </div>
+  </footer>
+  <!--indexOn: all-->  <script src="/student/kurser/static/app.js?v=2.0.0-20260427.1_59b0"></script>
+</body>
+
+</html>

--- a/tests/fixtures/program_CTFYS_20232_arskurs3.html
+++ b/tests/fixtures/program_CTFYS_20232_arskurs3.html
@@ -1,0 +1,681 @@
+<!DOCTYPE html>
+<html lang="sv">
+
+<head>
+  <title>Civilingenjörsutbildning i teknisk fysik (CTFYS), Utbildningsplan kull HT2023, Årskurs 3 | KTH</title>
+  <meta charset="utf-8">
+  <meta http-equiv="X-UA-Compatible" content="IE=edge">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <meta name="description" content="">
+  <link rel="shortcut icon" id="favicon" href="/student/kurser/static/icon/favicon">
+
+
+  
+  
+  
+
+  <link href="/student/kurser/static/kth-style/css/kth-bootstrap.css?v=2.0.0-20260427.1_59b0" media="screen" rel="stylesheet">
+<link href="/student/kurser/assets/fonts.css?v=2.0.0-20260427.1_59b0" media="screen" rel="stylesheet">
+<link href="/student/kurser/static/app.css?v=2.0.0-20260427.1_59b0" media="screen" rel="stylesheet">
+
+    
+
+
+
+
+  <!-- Begin JavaScript contentId-1_1137647 -->
+  <script>var klaroConfig = {
+    testing: false,
+  acceptAll: true,
+  styling: {
+      theme: [],
+  },
+  htmlTexts: false,
+  groupByPurpose: false,
+  storageMethod: 'cookie',
+  cookieDomain: 'kth.se',
+  cookieExpiresAfterDays: 30,
+  hideDeclineAll: false,
+  translations: {
+      sv: {
+          service: {
+            disableAll: {
+              description: 'Använd detta reglage för att tillåta alla tjänster eller endast nödvändiga.',
+              title: 'Ändra för alla tjänster',
+            },
+          },
+          consentModal: {
+            description:
+              'Här kan du se och anpassa vilken information vi samlar om dig.',
+          },
+          privacyPolicy: {
+              name: 'kakor',
+              text: 'Läs mer om hur vi hanterar {privacyPolicy}.',
+          },
+          privacyPolicyUrl: 'https://www.kth.se/gemensamt/om-kakor-cookies-pa-kth-s-webbplats-1.844',
+          consentNotice: {
+              title: '',
+              testing: 'Observera att Klaro körs i testläge',
+              description: 'Denna webbplats använder tjänster som kan lagra information om dig och hur du använder denna webbplats. Vissa tjänster är nödvändiga för att webbplatsen ska fungera och andra är valbara.',
+              learnMore: 'Hantera valbara tjänster',
+          },
+          decline: 'Tillåt bara nödvändiga tjänster',
+          ok: 'Tillåt alla tjänster',
+          purposeItem: {
+              service: 'Tjänster'
+          },
+            contextualConsent:{
+                acceptAlways: 'Alltid',
+                acceptOnce: 'Ja',
+                description: 'Du har tidigare nekat visning av innehåll av typen "{title}". Vill du visa innehållet?',
+          }
+      },
+      en: {
+          service: {
+            disableAll: {
+              description: 'Use this slider to allow all cookies or only necessary.',
+              title: 'Change for all services',
+            },
+          },
+        consentModal: {
+            description:
+              'Here you can assess and customise the services we use on this website.',
+          },
+          privacyPolicy: {
+              name: 'cookies',
+              text: 'Find out more about our usage of {privacyPolicy}.',
+          },
+          privacyPolicyUrl: 'https://www.kth.se/en/gemensamt/om-kakor-cookies-pa-kth-s-webbplats-1.844',
+          consentNotice: {
+              title: '',
+              testing: 'Please note that Klaro is currently running in test mode',
+              description: 'This website uses services that may store information about you and how you use the website. Some services are necessary for the website to work, and others are optional.',
+              learnMore: 'Manage services',
+          },
+          decline: 'Accept only necessary services',
+          ok: 'Accept all services',
+          purposeItem: {
+              service: 'Services'
+          },
+            contextualConsent:{
+                acceptAlways: 'Always',
+                acceptOnce: 'Yes',
+                description: 'You have previously denied the display of content of the type "{title}". Do you want to show content?',
+          }
+      }
+  },
+  services: [
+      {
+          name: "required-consent",
+          default: true,
+          contextualConsentOnly: false,
+          required: true,
+          translations: {
+              zz: {
+                  title: 'Required Services',
+                  description: 'These services are necessary for the site to function and cannot be turned off. They are usually used when you utilise a function on the website that needs an answer, such as setting cookies, logging in, or filling in a form.'
+              },
+              sv: {
+                  title: 'Nödvändiga tjänster',
+                  description: 'Dessa tjänster är nödvändiga för att webbplatsen ska fungera och kan inte stängas av. De används främst när du nyttjar en funktion på webbplatsen som behöver ett svar, exempelvis ställer in kakor, loggar in eller fyller i formulär.'
+              },
+          },
+      },
+      {
+          name: "media-consent",
+          default: false,
+          translations: {
+              zz: {
+                  title: 'External media',
+                  description: 'Media on the site embedded from external providers like Youtube, Vimeo and Kaltura. When these are played, the providers may use cookies and local storage.'
+              },
+              sv: {
+                  title: 'Extern media',
+                  description: 'Inbäddad media från externa leverantörer som Youtube, Vimeo och Kaltura. När media spelas upp kan leverantörerna använda sig av kakor och lokal lagring.'
+              },
+          },
+      },
+      {
+        name: "service-consent",
+        default: false,
+        translations: {
+          zz: {
+            title: 'External Services',
+            description: 'Embedded services by external providers such as forms, maps, chat applications et c. When these are loaded, the providers may use cookies and local storage.'
+          },
+          sv: {
+            title: 'Externa tjänster',
+            description: 'Inbäddade tjänster från externa leverantörer såsom formulär, kartor, chat-funktion et c. När tjänsterna laddas in kan leverantörerna använda sig av kakor och lokal lagring.'
+          },
+        },
+      },
+      {
+          name: "analytics-consent",
+          default: false,
+          translations: {
+              zz: {
+                  title: 'Analytics and Tracking',
+                  description: 'The website uses Matomo to evaluate and improve the website content, experience and structure. The information collected is anonymised and only stored at KTH servers.'
+              },
+              sv: {
+                  title: 'Analys och spårning',
+                  description: 'Webbplatsen använder Matomo för att utvärdera och förbättra webbplatsens innehåll, upplevelse och struktur. Insamlandet av informationen anonymiseras och lagras enbart på KTH-servrar.'
+              },
+          },
+      },
+      {
+        name: "marketing-consent",
+        default: false,
+        translations: {
+            zz: {
+                title: 'Marketing',
+                description: 'The website contains pages that, via cookies, communicate with advertising services and social media.'
+            },
+            sv: {
+                title: 'Marknadsföring',
+                description: 'På webbplatsen förekommer sidor som via kakor kommunicerar med annonseringstjänster och sociala medier.'
+            },
+        },
+    }
+    
+  ]
+}</script>
+  
+  
+  <!-- End JavaScript contentId-1_1137647 -->
+
+
+
+    
+
+  
+  
+  
+  <script src="/student/kurser/static/kth-style/js/klaro-no-css.js?v=2.0.0-20260427.1_59b0"></script>
+<script src="/student/kurser/static/vendor.js?v=2.0.0-20260427.1_59b0"></script>
+<script src="/student/kurser/static/browserConfig?v=2.0.0-20260427.1_59b0"></script>
+<script src="/student/kurser/static/kth-style/js/backtotop.js?v=2.0.0-20260427.1_59b0"></script>
+
+  <script src="https://www.kth.se/social/toolbar/widget.js"></script>
+
+</head>
+
+<body>
+  <a class="skipToMainContent" href="#mainContent" tabindex="1">Hoppa till huvudinnehållet</a>
+  <!--indexOff: all-->
+  <header class="kth-header student-web">
+    <div class="kth-header__container">
+      <a href="/student" class="kth-logotype">
+        <figure>
+          <img class="blue" alt="Till KTH:s startsida" width="64" height="64" src="/student/kurser/assets/logotype/logotype-blue.svg">
+        </figure>
+      </a>      
+  
+  
+  
+  
+  
+    <nav class="kth-mega-menu" aria-label="Huvudmeny" data-ajax-path="/cm/1.1066510?l=sv&amp;contentIdPath=/2.75593/1.1066510/&amp;target=">
+      <ul>
+        
+          <li><button data-id="1.1066571" class="kth-menu-item dropdown">
+              <span>
+                Studier
+              </span>
+            </button>
+            <dialog class="kth-menu-panel">
+              <div class="kth-menu-panel__container">
+                <div class="kth-menu-panel__header">
+                  <div>
+                    <a href="/student/studier">
+                      <h2>
+                        Studier
+                      </h2>
+                    </a>
+                  </div>
+                  <button class="kth-icon-button close" title="Stäng" aria-label="Stäng">
+                    <span class="kth-visually-hidden">close</span>
+                  </button>
+                </div>
+                <div class="kth-menu-panel__content"></div>
+              </div>
+            </dialog>
+          </li>
+          <li><button data-id="1.1070324" class="kth-menu-item dropdown">
+              <span>
+                Stöd och vägledning
+              </span>
+            </button>
+            <dialog class="kth-menu-panel">
+              <div class="kth-menu-panel__container">
+                <div class="kth-menu-panel__header">
+                  <div>
+                    <a href="/student/stod">
+                      <h2>
+                        Stöd och vägledning
+                      </h2>
+                    </a>
+                  </div>
+                  <button class="kth-icon-button close" title="Stäng" aria-label="Stäng">
+                    <span class="kth-visually-hidden">close</span>
+                  </button>
+                </div>
+                <div class="kth-menu-panel__content"></div>
+              </div>
+            </dialog>
+          </li>
+          <li><button data-id="1.1178595" class="kth-menu-item dropdown">
+              <span>
+                IT och digitala tjänster
+              </span>
+            </button>
+            <dialog class="kth-menu-panel">
+              <div class="kth-menu-panel__container">
+                <div class="kth-menu-panel__header">
+                  <div>
+                    <a href="/student/it">
+                      <h2>
+                        IT och digitala tjänster
+                      </h2>
+                    </a>
+                  </div>
+                  <button class="kth-icon-button close" title="Stäng" aria-label="Stäng">
+                    <span class="kth-visually-hidden">close</span>
+                  </button>
+                </div>
+                <div class="kth-menu-panel__content"></div>
+              </div>
+            </dialog>
+          </li>
+          <li><button data-id="1.1178638" class="kth-menu-item dropdown">
+              <span>
+                Kontakt
+              </span>
+            </button>
+            <dialog class="kth-menu-panel">
+              <div class="kth-menu-panel__container">
+                <div class="kth-menu-panel__header">
+                  <div>
+                    <a href="/student/kontakt">
+                      <h2>
+                        Kontakt
+                      </h2>
+                    </a>
+                  </div>
+                  <button class="kth-icon-button close" title="Stäng" aria-label="Stäng">
+                    <span class="kth-visually-hidden">close</span>
+                  </button>
+                </div>
+                <div class="kth-menu-panel__content"></div>
+              </div>
+            </dialog>
+          </li>
+        
+      </ul>
+    </nav>
+  
+    <!-- Mobile menu -->
+    <nav class="kth-mega-menu--collapsable">
+      <dialog class="kth-mobile-menu">
+        <div class="kth-mobile-menu__navigation">
+          <button class="kth-icon-button close" title="Stäng" aria-label="Stäng">
+            <span class="kth-visually-hidden">Close</span>
+          </button>
+        </div>
+        <div class="kth-mobile-menu__content">
+          <ul class="kth-mobile-menu__items">
+            <li>
+              <button class="kth-mobile-menu__item" data-id="1.1066571">
+                <span>
+                  Studier
+                </span>
+              </button>
+              <dialog class="kth-menu-panel--modal">
+                <button class="kth-icon-button close" title="Stäng" aria-label="Stäng">
+                  <span class="kth-visually-hidden">Close</span>
+                </button>
+                <div class="kth-menu-panel__content"></div>
+              </dialog>
+            </li>
+            <li>
+              <button class="kth-mobile-menu__item" data-id="1.1070324">
+                <span>
+                  Stöd och vägledning
+                </span>
+              </button>
+              <dialog class="kth-menu-panel--modal">
+                <button class="kth-icon-button close" title="Stäng" aria-label="Stäng">
+                  <span class="kth-visually-hidden">Close</span>
+                </button>
+                <div class="kth-menu-panel__content"></div>
+              </dialog>
+            </li>
+            <li>
+              <button class="kth-mobile-menu__item" data-id="1.1178595">
+                <span>
+                  IT och digitala tjänster
+                </span>
+              </button>
+              <dialog class="kth-menu-panel--modal">
+                <button class="kth-icon-button close" title="Stäng" aria-label="Stäng">
+                  <span class="kth-visually-hidden">Close</span>
+                </button>
+                <div class="kth-menu-panel__content"></div>
+              </dialog>
+            </li>
+            <li>
+              <button class="kth-mobile-menu__item" data-id="1.1178638">
+                <span>
+                  Kontakt
+                </span>
+              </button>
+              <dialog class="kth-menu-panel--modal">
+                <button class="kth-icon-button close" title="Stäng" aria-label="Stäng">
+                  <span class="kth-visually-hidden">Close</span>
+                </button>
+                <div class="kth-menu-panel__content"></div>
+              </dialog>
+            </li>
+          </ul>
+        </div>
+      </dialog>
+      <dialog class="kth-mobile-menu details" data-id="1.1066571">
+        <div class="kth-mobile-menu__navigation">
+          <button class="kth-button back">Huvudmeny</button>
+          <button class="kth-icon-button close" title="Stäng" aria-label="Stäng">
+            <span class="kth-visually-hidden">Close</span>
+          </button>
+        </div>
+        <div class="kth-mobile-menu__header">
+          <a href="/student/studier">
+            <h2>
+              Studier
+            </h2>
+          </a>
+        </div>
+        <div class="kth-mobile-menu__content">
+          <div class="kth-mobile-menu__cortina-content"></div>
+        </div>
+      </dialog><dialog class="kth-mobile-menu details" data-id="1.1070324">
+        <div class="kth-mobile-menu__navigation">
+          <button class="kth-button back">Huvudmeny</button>
+          <button class="kth-icon-button close" title="Stäng" aria-label="Stäng">
+            <span class="kth-visually-hidden">Close</span>
+          </button>
+        </div>
+        <div class="kth-mobile-menu__header">
+          <a href="/student/stod">
+            <h2>
+              Stöd och vägledning
+            </h2>
+          </a>
+        </div>
+        <div class="kth-mobile-menu__content">
+          <div class="kth-mobile-menu__cortina-content"></div>
+        </div>
+      </dialog><dialog class="kth-mobile-menu details" data-id="1.1178595">
+        <div class="kth-mobile-menu__navigation">
+          <button class="kth-button back">Huvudmeny</button>
+          <button class="kth-icon-button close" title="Stäng" aria-label="Stäng">
+            <span class="kth-visually-hidden">Close</span>
+          </button>
+        </div>
+        <div class="kth-mobile-menu__header">
+          <a href="/student/it">
+            <h2>
+              IT och digitala tjänster
+            </h2>
+          </a>
+        </div>
+        <div class="kth-mobile-menu__content">
+          <div class="kth-mobile-menu__cortina-content"></div>
+        </div>
+      </dialog><dialog class="kth-mobile-menu details" data-id="1.1178638">
+        <div class="kth-mobile-menu__navigation">
+          <button class="kth-button back">Huvudmeny</button>
+          <button class="kth-icon-button close" title="Stäng" aria-label="Stäng">
+            <span class="kth-visually-hidden">Close</span>
+          </button>
+        </div>
+        <div class="kth-mobile-menu__header">
+          <a href="/student/kontakt">
+            <h2>
+              Kontakt
+            </h2>
+          </a>
+        </div>
+        <div class="kth-mobile-menu__content">
+          <div class="kth-mobile-menu__cortina-content"></div>
+        </div>
+      </dialog>
+    </nav>
+    <!-- Mobile menu -->
+  
+    
+    <script>/* eslint-disable no-unused-expressions, no-unused-vars, no-undef */"use strict";window.addEventListener("load",(()=>{function e(e){return document.querySelector(".kth-mega-menu[data-ajax-path]")?.getAttribute("data-ajax-path")+e}function t(){document.querySelectorAll("dialog").forEach((e=>e.close()))}function n(e){const n=e.querySelector(".kth-icon-button.close");e.addEventListener("keydown",(t=>{"Escape"===t.key&&e.close()})),n instanceof HTMLButtonElement&&n.addEventListener("click",(()=>{t()}))}function o(e,o){n(e),o.addEventListener("click",(n=>{n.preventDefault(),e.open?t():(t(),e.show())})),document.addEventListener("click",(n=>{!e.open||n.composedPath().includes(o)||n.composedPath().includes(e)||(n.preventDefault(),t())}))}function c(e,o,c){const i=e.querySelector(".kth-button.back");n(e),o.addEventListener("click",(n=>{n.preventDefault(),t(),e.showModal()})),i instanceof HTMLButtonElement&&i.addEventListener("click",(()=>{e.close(),c&&c.showModal()}))}var i,l;document.querySelectorAll(".kth-menu-item[data-id], .kth-menu-item--modal[data-id]").forEach((t=>{const n=t.nextElementSibling,o=n?.querySelector(".kth-menu-panel__content");if(!(t instanceof HTMLElement))return;if(!(n instanceof HTMLDialogElement))return;const c=t.dataset.id;let i;function l(){o instanceof HTMLElement&&(i||(i=fetch(e(c)).then((e=>e.text()))),i.then((e=>{o.innerHTML=e})))}t.addEventListener("mouseover",l),t.addEventListener("click",l)})),document.querySelectorAll(".kth-mobile-menu__item[data-id]").forEach((t=>{if(!(t instanceof HTMLElement))return;const n=t.dataset.id,o=document.querySelector(`.kth-mobile-menu[data-id='${n}']`),c=o?.querySelector(".kth-mobile-menu__cortina-content");if(!(o instanceof HTMLDialogElement))return;let i;t.addEventListener("click",(function(){c instanceof HTMLElement&&(i||(i=fetch(e(n)).then((e=>e.text()))),i.then((e=>{c.innerHTML=e})))}))})),function(e,n){if(e){for(const e of n){if(!(e instanceof HTMLElement))continue;const t=e.nextElementSibling;t instanceof HTMLDialogElement&&o(t,e)}e.addEventListener("focusout",(function(n){const o=n.relatedTarget;o&&o instanceof Node&&!e.contains(o)&&t()}))}}(document.querySelector(".kth-header"),document.querySelectorAll(".kth-mega-menu .kth-menu-item")),i=document.querySelector(".kth-menu-item.collapsable"),l=document.querySelector(".kth-mobile-menu"),i instanceof HTMLElement&&l instanceof HTMLDialogElement&&c(l,i),function(e,t){if(!t||t instanceof HTMLDialogElement)for(const n of e){if(!(n instanceof HTMLElement))continue;const e=n.getAttribute("data-id"),o=document.querySelector(`.kth-mobile-menu[data-id='${e}']`);if(!(o instanceof HTMLDialogElement))return;c(o,n,t)}}(document.querySelectorAll(".kth-mobile-menu__item"),document.querySelector(".kth-mobile-menu"))})),window.addEventListener("load",(()=>{const e={threshold:32,className:"collapsed"};function t(e,{threshold:t,className:n}){window.scrollY>t?e?.classList.add(n):e?.classList.remove(n)}!function(n,o=e){t(n,o),window.addEventListener("scroll",(()=>{t(n,o)}))}(document.querySelector(".kth-header"))}));</script>
+  
+  
+  
+      <ul class="kth-header__tools">
+        <li><button class="kth-menu-item search">
+      <span>Sök</span>
+  </button>
+  <dialog class="kth-menu-panel">
+      <div class="kth-menu-panel__container search">
+          <button class="kth-icon-button close">
+              <span class="kth-visually-hidden">Stäng</span>
+          </button>
+          <div class="kth-menu-panel__content">
+                  
+  
+  
+  
+  
+    <div class="block search mainWidget default-size" data-cid="1.1066521" lang="sv">
+      <div id="widget_yhnutasc" class="searchWidgetContainer"><div class="searchWidget"><div class="searchInputBar"><form class="searchInputForm" method="GET" role="search" action="https://www.kth.se/search"><div class="searchAutoCompleteField kth-search"><label for="widget_yhnutasc_search__Field">Sök på Studentwebben</label><input id="widget_yhnutasc_search__Field" name="q" autoComplete="off" type="text" maxLength="1024" value=""/><button type="submit"><span class="kth-visually-hidden">Sök</span></button></div><input type="hidden" name="urlFilter" value="https://www.kth.se/student"/><input type="hidden" name="entityFilter" value="kth-profile,kth-course,kth-place,kth-program,kth-system"/><input type="hidden" name="metaSystemFilter" value=""/><input type="hidden" name="documentFilter" value=""/><input type="hidden" name="filterLabel" value="Sök på Studentwebben"/><input type="hidden" name="l" value="sv"/><input type="hidden" name="noscript" class="noscriptInput" value=""/></form></div><div class="searchAlternativesWidget"><div class="searchAlternativesWidgetLinks"><a href="https://www.kth.se/search?l=sv">Sök på KTH:s webbplats</a><a href="https://intra.kth.se/search?l=sv">Sök på KTH Intranät</a></div></div></div></div>
+  
+  <script>
+    (() => {
+      const SCRIPT_PATH = 'https://www.kth.se/search/static/widget.js?v=2.0.0-20250606.1_9d7abae6'
+      const STYLE_PATH = 'https://www.kth.se/search/static/widget.css?v=2.0.0-20250606.1_9d7abae6'
+      const DATA_PATH = 'https://www.kth.se/search/widgetData.js?widgetId=widget_yhnutasc&filterLabel=S%C3%B6k%20p%C3%A5%20Studentwebben&placeholder=S%C3%B6k%20p%C3%A5%20KTH%3As%20webbplats&urlFilter=https%3A%2F%2Fwww.kth.se%2Fstudent&isFilterRemovable=false&entityFilter=kth-profile%2Ckth-course%2Ckth-place%2Ckth-program%2Ckth-system&l=sv&includeLinks=true'
+      const WIDGET_ID = 'widget_yhnutasc'
+      const scriptAnchor = document.currentScript
+  
+      const observer = new IntersectionObserver((entries, observer) => {
+  
+        if (entries[0].target?.checkVisibility?.()) {
+  
+          if (!window.searchWidgetIsLoaded) {
+  
+            const styleElement = document.createElement('link')
+            styleElement.href = STYLE_PATH
+            styleElement.media = "screen"
+            styleElement.rel = "stylesheet"
+            styleElement.async = 1
+            scriptAnchor.after(styleElement)
+  
+            const scriptElement = document.createElement('script')
+            scriptElement.src = SCRIPT_PATH
+            scriptElement.async = 1
+            scriptAnchor.after(scriptElement)
+          }
+  
+          const dataElement = document.createElement('script')
+          dataElement.src = DATA_PATH
+          dataElement.async = 1
+          scriptAnchor.after(dataElement)
+  
+          window.searchWidgetIsLoaded = true
+          observer.disconnect()
+        }
+      }).observe(document.getElementById(WIDGET_ID))
+    })()
+  </script>
+      
+      <script>/* eslint-disable no-unused-expressions, no-unused-vars, no-undef */"use strict";!function(){function e(){document.querySelectorAll("dialog").forEach((e=>e.close()))}window.addEventListener("load",(function(){document.querySelectorAll(".block.search").forEach((t=>{t.parentElement.className.includes("kth-menu-panel__content")&&function(t,n){if(!(n instanceof HTMLElement))return;const c=n.nextElementSibling;if(!(c instanceof HTMLDialogElement))return;c.addEventListener("keydown",(t=>{"Escape"===t.key&&e()}));const o=c.querySelector(".close");o instanceof HTMLButtonElement&&o.addEventListener("click",(()=>{e()})),n.addEventListener("click",(n=>{n.preventDefault(),c.open?e():(e(),c.show(),function(e){const t=e.querySelector("template");if(null===t)return;const n=t.content;t.replaceWith(n)}(t),function(e){const t=e.querySelector(".searchAutoCompleteField")?.querySelector("input");t&&t.focus()}(c))})),document.addEventListener("click",(t=>{!c.open||t.composedPath().includes(n)||t.composedPath().includes(c)||(t.preventDefault(),e())}))}(t,document.querySelector(".kth-menu-item.search"))}))}))}();</script>
+    </div>
+  
+  
+  
+          </div>
+      </div>
+  </dialog></li>
+        <li><a class="kth-menu-item language" hreflang="en-US" href="?l=en">English</a></li>
+      </ul>
+      <button class="kth-menu-item menu collapsable">
+        <span>Meny</span>
+      </button>
+    </div>
+  </header>
+  <div class="kth-content articleNavigation">
+    <div class="row justify-content-between">
+      
+    <nav id="breadcrumbs" aria-label="Brödsmulor" class="kth-breadcrumbs">
+      <ol class="kth-breadcrumbs__list">
+        <li><a href="/student">Studentwebben</a></li><li><a href="/student/studier">Studier</a></li><li><a href="/student/kurser/kurser-inom-program">Kurs- och programkatalogen</a></li><li><a href="/student/kurser/program/CTFYS">Civilingenjörsutbildning i teknisk fysik</a></li>
+      </ol>
+    </nav>
+   
+    </div>
+  </div>
+  <!--indexOn: all-->  <div class="kth-content">
+    <div class="row">
+        <script>window.__compressedApplicationStore__ = "%7B%22browserConfig%22%3A%7B%22proxyPrefixPath%22%3A%7B%22uri%22%3A%22%2Fstudent%2Fkurser%22%2C%22searchPage%22%3A%22%2Fstudent%2Fkurser%2Fsokkurs%22%2C%22searchResult%22%3A%22%2Fstudent%2Fkurser%2Fsokkurs%2Fresultat%22%2C%22courseSearchInternApi%22%3A%22%2Fstudent%2Fkurser%2Fintern-api%2Fsok%22%2C%22department%22%3A%22%2Fstudent%2Fkurser%2Forg%22%2C%22programme%22%3A%22%2Fstudent%2Fkurser%2Fprogram%22%2C%22programmesList%22%3A%22%2Fstudent%2Fkurser%2Fkurser-inom-program%22%2C%22schoolsList%22%3A%22%2Fstudent%2Fkurser%2Fprogram%22%2C%22studyHandbook%22%3A%22%2Fstudent%2Fprogram%2Fshb%22%2C%22thirdCycleCourseSearch%22%3A%22%2Futbildning%2Fforskarutbildning%2Fkurser%2Fsok%22%2C%22thirdCycleCourseSearchResult%22%3A%22%2Futbildning%2Fforskarutbildning%2Fkurser%2Fsok%2Fresultat%22%2C%22thirdCycleSchoolsAndDepartments%22%3A%22%2Futbildning%2Fforskarutbildning%2Fkurser%2Favdelning%22%2C%22thirdCycleCoursesPerDepartment%22%3A%22%2Futbildning%2Fforskarutbildning%2Fkurser%2Forg%22%2C%22programmeSyllabusPDF%22%3A%22%2Fstudent%2Fkurser%2Fintern-api%2FPDFRenderFunction%22%7D%2C%22redirectProxyPath%22%3A%7B%22studentRoot%22%3A%22%2Fstudent%2Fkurser%22%2C%22thirdCycleRoot%22%3A%22%2Futbildning%2Fforskarutbildning%2Fkurser%22%2C%22coursesPerDepartment%22%3A%22%2Fstudent%2Fkurser%2Fkurser-per-avdelning%22%2C%22departmentCourses%22%3A%22%2Fstudent%2Fkurser%2Favdelning%2F%3AdepartmentCode%2Fkurser%2F%22%7D%2C%22markHtmlFromKopps%22%3Afalse%2C%22markHtmlFromLadok%22%3Afalse%2C%22env%22%3A%22prod%22%7D%2C%22statusCode%22%3A200%2C%22language%22%3A%22sv%22%2C%22languageIndex%22%3A1%2C%22programmeCode%22%3A%22CTFYS%22%2C%22programmeName%22%3A%22Civilingenj%C3%B6rsutbildning%20i%20teknisk%20fysik%22%2C%22owningSchoolCode%22%3A%22SCI%2FSkolan%20f%C3%B6r%20teknikvetenskap%22%2C%22term%22%3A%2220232%22%2C%22studyYear%22%3A%223%22%2C%22curriculums%22%3A%5B%7B%22studyYears%22%3A%5B%7B%22yearNumber%22%3A1%2C%22courses%22%3A%22%3Ch3%20id%3D%5C%22gemensammakurser%5C%22%3EGemensamma%20kurser%3C%2Fh3%3E%5Cn%3Ch4%20id%3D%5C%22obligatoriskakurser%5C%22%3EObligatoriska%20kurser%3C%2Fh4%3E%5Cn%3Ctable%3E%5Cn%3Cthead%3E%5Cn%3Ctr%3E%5Cn%3Cth%3EKurskod%3C%2Fth%3E%5Cn%3Cth%3EKursnamn%3C%2Fth%3E%5Cn%3Cth%3EOmfattning%3C%2Fth%3E%5Cn%3Cth%3EUtbildningsniv%C3%A5%3C%2Fth%3E%5Cn%3C%2Ftr%3E%5Cn%3C%2Fthead%3E%5Cn%3Ctbody%3E%5Cn%3Ctr%3E%5Cn%3Ctd%3EDD1331%3C%2Ftd%3E%5Cn%3Ctd%3EGrundl%C3%A4ggande%20programmering%3C%2Ftd%3E%5Cn%3Ctd%3E5%20hp%3C%2Ftd%3E%5Cn%3Ctd%3EGrundniv%C3%A5%3C%2Ftd%3E%5Cn%3C%2Ftr%3E%5Cn%3Ctr%3E%5Cn%3Ctd%3ESF1672%3C%2Ftd%3E%5Cn%3Ctd%3ELinj%C3%A4r%20algebra%3C%2Ftd%3E%5Cn%3Ctd%3E7.5%20hp%3C%2Ftd%3E%5Cn%3Ctd%3EGrundniv%C3%A5%3C%2Ftd%3E%5Cn%3C%2Ftr%3E%5Cn%3Ctr%3E%5Cn%3Ctd%3ESF1673%3C%2Ftd%3E%5Cn%3Ctd%3EAnalys%20i%20en%20variabel%3C%2Ftd%3E%5Cn%3Ctd%3E7.5%20hp%3C%2Ftd%3E%5Cn%3Ctd%3EGrundniv%C3%A5%3C%2Ftd%3E%5Cn%3C%2Ftr%3E%5Cn%3Ctr%3E%5Cn%3Ctd%3ESF1674%3C%2Ftd%3E%5Cn%3Ctd%3EFlervariabelanalys%3C%2Ftd%3E%5Cn%3Ctd%3E7.5%20hp%3C%2Ftd%3E%5Cn%3Ctd%3EGrundniv%C3%A5%3C%2Ftd%3E%5Cn%3C%2Ftr%3E%5Cn%3Ctr%3E%5Cn%3Ctd%3ESF1922%3C%2Ftd%3E%5Cn%3Ctd%3ESannolikhetsteori%20och%20statistik%3C%2Ftd%3E%5Cn%3Ctd%3E6%20hp%3C%2Ftd%3E%5Cn%3Ctd%3EGrundniv%C3%A5%3C%2Ftd%3E%5Cn%3C%2Ftr%3E%5Cn%3Ctr%3E%5Cn%3Ctd%3ESG1112%3C%2Ftd%3E%5Cn%3Ctd%3EMekanik%20I%3C%2Ftd%3E%5Cn%3Ctd%3E9%20hp%3C%2Ftd%3E%5Cn%3Ctd%3EGrundniv%C3%A5%3C%2Ftd%3E%5Cn%3C%2Ftr%3E%5Cn%3Ctr%3E%5Cn%3Ctd%3ESI1121%3C%2Ftd%3E%5Cn%3Ctd%3ETermodynamik%3C%2Ftd%3E%5Cn%3Ctd%3E6%20hp%3C%2Ftd%3E%5Cn%3Ctd%3EGrundniv%C3%A5%3C%2Ftd%3E%5Cn%3C%2Ftr%3E%5Cn%3Ctr%3E%5Cn%3Ctd%3ESK1104%3C%2Ftd%3E%5Cn%3Ctd%3EKlassisk%20fysik%3C%2Ftd%3E%5Cn%3Ctd%3E7.5%20hp%3C%2Ftd%3E%5Cn%3Ctd%3EGrundniv%C3%A5%3C%2Ftd%3E%5Cn%3C%2Ftr%3E%5Cn%3Ctr%3E%5Cn%3Ctd%3ESK1105%3C%2Ftd%3E%5Cn%3Ctd%3EExperimentell%20fysik%3C%2Ftd%3E%5Cn%3Ctd%3E4%20hp%3C%2Ftd%3E%5Cn%3Ctd%3EGrundniv%C3%A5%3C%2Ftd%3E%5Cn%3C%2Ftr%3E%5Cn%3C%2Ftbody%3E%5Cn%3C%2Ftable%3E%5Cn%3Ch4%20id%3D%5C%22valfriakurser%5C%22%3EValfria%20kurser%3C%2Fh4%3E%5Cn%3Ctable%3E%5Cn%3Cthead%3E%5Cn%3Ctr%3E%5Cn%3Cth%3EKurskod%3C%2Fth%3E%5Cn%3Cth%3EKursnamn%3C%2Fth%3E%5Cn%3Cth%3EOmfattning%3C%2Fth%3E%5Cn%3Cth%3EUtbildningsniv%C3%A5%3C%2Fth%3E%5Cn%3C%2Ftr%3E%5Cn%3C%2Fthead%3E%5Cn%3Ctbody%3E%5Cn%3Ctr%3E%5Cn%3Ctd%3EDD1301%3C%2Ftd%3E%5Cn%3Ctd%3EDatorintroduktion%3C%2Ftd%3E%5Cn%3Ctd%3E1.5%20hp%3C%2Ftd%3E%5Cn%3Ctd%3EGrundniv%C3%A5%3C%2Ftd%3E%5Cn%3C%2Ftr%3E%5Cn%3C%2Ftbody%3E%5Cn%3C%2Ftable%3E%22%2C%22freeTexts%22%3A%5B%5D%7D%2C%7B%22yearNumber%22%3A2%2C%22courses%22%3A%22%3Ch3%20id%3D%5C%22gemensammakurser%5C%22%3EGemensamma%20kurser%3C%2Fh3%3E%5Cn%3Ch4%20id%3D%5C%22obligatoriskakurser%5C%22%3EObligatoriska%20kurser%3C%2Fh4%3E%5Cn%3Ctable%3E%5Cn%3Cthead%3E%5Cn%3Ctr%3E%5Cn%3Cth%3EKurskod%3C%2Fth%3E%5Cn%3Cth%3EKursnamn%3C%2Fth%3E%5Cn%3Cth%3EOmfattning%3C%2Fth%3E%5Cn%3Cth%3EUtbildningsniv%C3%A5%3C%2Fth%3E%5Cn%3C%2Ftr%3E%5Cn%3C%2Fthead%3E%5Cn%3Ctbody%3E%5Cn%3Ctr%3E%5Cn%3Ctd%3EDD1327%3C%2Ftd%3E%5Cn%3Ctd%3EGrundl%C3%A4ggande%20datalogi%3C%2Ftd%3E%5Cn%3Ctd%3E6%20hp%3C%2Ftd%3E%5Cn%3Ctd%3EGrundniv%C3%A5%3C%2Ftd%3E%5Cn%3C%2Ftr%3E%5Cn%3Ctr%3E%5Cn%3Ctd%3ESE1055%3C%2Ftd%3E%5Cn%3Ctd%3EH%C3%A5llfasthetsl%C3%A4ra%2C%20grundkurs%20med%20energimetoder%3C%2Ftd%3E%5Cn%3Ctd%3E9%20hp%3C%2Ftd%3E%5Cn%3Ctd%3EGrundniv%C3%A5%3C%2Ftd%3E%5Cn%3C%2Ftr%3E%5Cn%3Ctr%3E%5Cn%3Ctd%3ESF1544%3C%2Ftd%3E%5Cn%3Ctd%3ENumeriska%20metoder%2C%20grundkurs%20IV%3C%2Ftd%3E%5Cn%3Ctd%3E6%20hp%3C%2Ftd%3E%5Cn%3Ctd%3EGrundniv%C3%A5%3C%2Ftd%3E%5Cn%3C%2Ftr%3E%5Cn%3Ctr%3E%5Cn%3Ctd%3ESF1681%3C%2Ftd%3E%5Cn%3Ctd%3ELinj%C3%A4r%20algebra%2C%20forts%C3%A4ttningskurs%3C%2Ftd%3E%5Cn%3Ctd%3E6%20hp%3C%2Ftd%3E%5Cn%3Ctd%3EGrundniv%C3%A5%3C%2Ftd%3E%5Cn%3C%2Ftr%3E%5Cn%3Ctr%3E%5Cn%3Ctd%3ESF1683%3C%2Ftd%3E%5Cn%3Ctd%3EDifferentialekvationer%20och%20transformmetoder%3C%2Ftd%3E%5Cn%3Ctd%3E9%20hp%3C%2Ftd%3E%5Cn%3Ctd%3EGrundniv%C3%A5%3C%2Ftd%3E%5Cn%3C%2Ftr%3E%5Cn%3Ctr%3E%5Cn%3Ctd%3ESG1113%3C%2Ftd%3E%5Cn%3Ctd%3EMekanik%2C%20forts%C3%A4ttningskurs%3C%2Ftd%3E%5Cn%3Ctd%3E6%20hp%3C%2Ftd%3E%5Cn%3Ctd%3EGrundniv%C3%A5%3C%2Ftd%3E%5Cn%3C%2Ftr%3E%5Cn%3Ctr%3E%5Cn%3Ctd%3ESH1014%3C%2Ftd%3E%5Cn%3Ctd%3EModern%20fysik%3C%2Ftd%3E%5Cn%3Ctd%3E4%20hp%3C%2Ftd%3E%5Cn%3Ctd%3EGrundniv%C3%A5%3C%2Ftd%3E%5Cn%3C%2Ftr%3E%5Cn%3Ctr%3E%5Cn%3Ctd%3ESI1146%3C%2Ftd%3E%5Cn%3Ctd%3EVektoranalys%3C%2Ftd%3E%5Cn%3Ctd%3E4%20hp%3C%2Ftd%3E%5Cn%3Ctd%3EGrundniv%C3%A5%3C%2Ftd%3E%5Cn%3C%2Ftr%3E%5Cn%3Ctr%3E%5Cn%3Ctd%3ESI1155%3C%2Ftd%3E%5Cn%3Ctd%3ETeoretisk%20fysik%3C%2Ftd%3E%5Cn%3Ctd%3E6%20hp%3C%2Ftd%3E%5Cn%3Ctd%3EGrundniv%C3%A5%3C%2Ftd%3E%5Cn%3C%2Ftr%3E%5Cn%3Ctr%3E%5Cn%3Ctd%3ESI1200%3C%2Ftd%3E%5Cn%3Ctd%3EFysikens%20matematiska%20metoder%3C%2Ftd%3E%5Cn%3Ctd%3E4%20hp%3C%2Ftd%3E%5Cn%3Ctd%3EGrundniv%C3%A5%3C%2Ftd%3E%5Cn%3C%2Ftr%3E%5Cn%3C%2Ftbody%3E%5Cn%3C%2Ftable%3E%5Cn%3Ch4%20id%3D%5C%22kompletterandeinformation%5C%22%3EKompletterande%20information%3C%2Fh4%3E%5Cn%3Cp%3EProgrammet%20f%C3%B6r%C3%A4ndras%20f%C3%B6r%20studenter%20som%20b%C3%B6rjar%20%C3%A5rskurs%201%20h%C3%B6sten%202016.%20F%C3%B6r%C3%A4ndringen%20forts%C3%A4tter%20i%20%C3%A5rskurs%202%20och%203.%20Inr%C3%A4ttande%20av%20kurser%20p%C3%A5g%C3%A5r.%3C%2Fp%3E%22%2C%22freeTexts%22%3A%5B%5D%2C%22supplementaryInfo%22%3A%22%3Cp%3EProgrammet%20f%C3%B6r%C3%A4ndras%20f%C3%B6r%20studenter%20som%20b%C3%B6rjar%20%C3%A5rskurs%201%20h%C3%B6sten%202016.%20F%C3%B6r%C3%A4ndringen%20forts%C3%A4tter%20i%20%C3%A5rskurs%202%20och%203.%20Inr%C3%A4ttande%20av%20kurser%20p%C3%A5g%C3%A5r.%3C%2Fp%3E%22%7D%2C%7B%22yearNumber%22%3A3%2C%22courses%22%3A%5B%7B%22utbildningsinstansUid%22%3A%22b8f28855-ef29-11e8-ba11-7cc77ecb4a78%22%2C%22uid%22%3A%227026c596-b6cb-11ef-9553-beecfac44351%22%2C%22tillfalleskod%22%3A%2251986%22%2C%22status%22%3A%7B%22code%22%3A%22S3%22%2C%22nameSv%22%3A%22Komplett%22%2C%22nameEn%22%3A%22Complete%22%7D%2C%22utbildningstyp%22%3A%7B%22id%22%3A%2222%22%2C%22code%22%3A%222007GKURS%22%2C%22name%22%3A%22Kurs%2C%20grundniv%C3%A5%22%2C%22nameOther%22%3A%22Course%2C%20First-cycle%22%2C%22creditsUnit%22%3A%7B%22code%22%3A%22HP%22%2C%22sv%22%3A%22H%C3%B6gskolepo%C3%A4ng%22%2C%22en%22%3A%22Credits%22%7D%2C%22level%22%3A%7B%22code%22%3A%221%22%2C%22name%22%3A%22Grundniv%C3%A5%22%7D%7D%2C%22omfattning%22%3A%7B%22number%22%3A9%2C%22formattedWithUnit%22%3A%229%2C0%20hp%22%7D%2C%22startperiod%22%3A%7B%22code%22%3A%22HT2025%22%2C%22startDay%22%3A%222025-08-25%22%2C%22lastDay%22%3A%222026-01-12%22%2C%22inDigits%22%3A%2220252%22%7D%2C%22Tillfallesperioder%22%3A%5B%7B%22ForstaRegistreringsdatum%22%3A%222025-08-21%22%2C%22ForstaUndervisningsdatum%22%3A%222025-08-25%22%2C%22Lasperiodsfordelning%22%3A%5B%7B%22Lasperiodskod%22%3A%22P2%22%2C%22Omfattningsvarde%22%3A3%2C%22link%22%3A%5B%5D%7D%2C%7B%22Lasperiodskod%22%3A%22P1%22%2C%22Omfattningsvarde%22%3A6%2C%22link%22%3A%5B%5D%7D%5D%2C%22Omfattningsvarde%22%3A9%2C%22SistaRegistreringsdatum%22%3A%222025-09-01%22%2C%22SistaUndervisningsdatum%22%3A%222026-01-12%22%7D%5D%2C%22kod%22%3A%22EI1320%22%2C%22benamning%22%3A%22Teoretisk%20elektroteknik%22%2C%22Valvillkor%22%3A%22O%22%2C%22type%22%3A%22instance%22%7D%2C%7B%22utbildningsinstansUid%22%3A%2247f95ef1-9ebb-11eb-b121-4a7c58ae420f%22%2C%22uid%22%3A%22275151e3-bb85-11ef-9553-beecfac44351%22%2C%22tillfalleskod%22%3A%2251987%22%2C%22status%22%3A%7B%22code%22%3A%22S3%22%2C%22nameSv%22%3A%22Komplett%22%2C%22nameEn%22%3A%22Complete%22%7D%2C%22utbildningstyp%22%3A%7B%22id%22%3A%2222%22%2C%22code%22%3A%222007GKURS%22%2C%22name%22%3A%22Kurs%2C%20grundniv%C3%A5%22%2C%22nameOther%22%3A%22Course%2C%20First-cycle%22%2C%22creditsUnit%22%3A%7B%22code%22%3A%22HP%22%2C%22sv%22%3A%22H%C3%B6gskolepo%C3%A4ng%22%2C%22en%22%3A%22Credits%22%7D%2C%22level%22%3A%7B%22code%22%3A%221%22%2C%22name%22%3A%22Grundniv%C3%A5%22%7D%7D%2C%22omfattning%22%3A%7B%22number%22%3A6%2C%22formattedWithUnit%22%3A%226%2C0%20hp%22%7D%2C%22startperiod%22%3A%7B%22code%22%3A%22HT2025%22%2C%22startDay%22%3A%222025-08-25%22%2C%22lastDay%22%3A%222026-01-12%22%2C%22inDigits%22%3A%2220252%22%7D%2C%22Tillfallesperioder%22%3A%5B%7B%22ForstaRegistreringsdatum%22%3A%222025-08-21%22%2C%22ForstaUndervisningsdatum%22%3A%222025-08-25%22%2C%22Lasperiodsfordelning%22%3A%5B%7B%22Lasperiodskod%22%3A%22P1%22%2C%22Omfattningsvarde%22%3A6%2C%22link%22%3A%5B%5D%7D%5D%2C%22Omfattningsvarde%22%3A6%2C%22SistaRegistreringsdatum%22%3A%222025-09-01%22%2C%22SistaUndervisningsdatum%22%3A%222025-10-24%22%7D%5D%2C%22kod%22%3A%22EL1000%22%2C%22benamning%22%3A%22Reglerteknik%2C%20allm%C3%A4n%20kurs%22%2C%22Valvillkor%22%3A%22O%22%2C%22type%22%3A%22instance%22%7D%2C%7B%22utbildningsinstansUid%22%3A%22c91ecf3e-204f-11f0-a301-a2036b2340f3%22%2C%22uid%22%3A%22e1043db9-bea4-11ef-9c9e-74b5caef4769%22%2C%22tillfalleskod%22%3A%2251993%22%2C%22status%22%3A%7B%22code%22%3A%22S3%22%2C%22nameSv%22%3A%22Komplett%22%2C%22nameEn%22%3A%22Complete%22%7D%2C%22utbildningstyp%22%3A%7B%22id%22%3A%2222%22%2C%22code%22%3A%222007GKURS%22%2C%22name%22%3A%22Kurs%2C%20grundniv%C3%A5%22%2C%22nameOther%22%3A%22Course%2C%20First-cycle%22%2C%22creditsUnit%22%3A%7B%22code%22%3A%22HP%22%2C%22sv%22%3A%22H%C3%B6gskolepo%C3%A4ng%22%2C%22en%22%3A%22Credits%22%7D%2C%22level%22%3A%7B%22code%22%3A%221%22%2C%22name%22%3A%22Grundniv%C3%A5%22%7D%7D%2C%22omfattning%22%3A%7B%22number%22%3A4%2C%22formattedWithUnit%22%3A%224%2C0%20hp%22%7D%2C%22startperiod%22%3A%7B%22code%22%3A%22HT2025%22%2C%22startDay%22%3A%222025-08-25%22%2C%22lastDay%22%3A%222026-01-12%22%2C%22inDigits%22%3A%2220252%22%7D%2C%22Tillfallesperioder%22%3A%5B%7B%22ForstaRegistreringsdatum%22%3A%222025-10-23%22%2C%22ForstaUndervisningsdatum%22%3A%222025-10-27%22%2C%22Lasperiodsfordelning%22%3A%5B%7B%22Lasperiodskod%22%3A%22P2%22%2C%22Omfattningsvarde%22%3A4%2C%22link%22%3A%5B%5D%7D%5D%2C%22Omfattningsvarde%22%3A4%2C%22SistaRegistreringsdatum%22%3A%222025-11-03%22%2C%22SistaUndervisningsdatum%22%3A%222026-01-12%22%7D%5D%2C%22kod%22%3A%22SG1218%22%2C%22benamning%22%3A%22Str%C3%B6mningsmekanik%22%2C%22Valvillkor%22%3A%22O%22%2C%22type%22%3A%22instance%22%7D%2C%7B%22utbildningsinstansUid%22%3A%2282c467d5-73d8-11e8-b4e0-063f9afb40e3%22%2C%22uid%22%3A%22a5f6ec28-bba7-11ef-9553-beecfac44351%22%2C%22tillfalleskod%22%3A%2251383%22%2C%22status%22%3A%7B%22code%22%3A%22S3%22%2C%22nameSv%22%3A%22Komplett%22%2C%22nameEn%22%3A%22Complete%22%7D%2C%22utbildningstyp%22%3A%7B%22id%22%3A%2222%22%2C%22code%22%3A%222007GKURS%22%2C%22name%22%3A%22Kurs%2C%20grundniv%C3%A5%22%2C%22nameOther%22%3A%22Course%2C%20First-cycle%22%2C%22creditsUnit%22%3A%7B%22code%22%3A%22HP%22%2C%22sv%22%3A%22H%C3%B6gskolepo%C3%A4ng%22%2C%22en%22%3A%22Credits%22%7D%2C%22level%22%3A%7B%22code%22%3A%221%22%2C%22name%22%3A%22Grundniv%C3%A5%22%7D%7D%2C%22omfattning%22%3A%7B%22number%22%3A5%2C%22formattedWithUnit%22%3A%225%2C0%20hp%22%7D%2C%22startperiod%22%3A%7B%22code%22%3A%22HT2025%22%2C%22startDay%22%3A%222025-08-25%22%2C%22lastDay%22%3A%222026-01-12%22%2C%22inDigits%22%3A%2220252%22%7D%2C%22Tillfallesperioder%22%3A%5B%7B%22ForstaRegistreringsdatum%22%3A%222025-08-21%22%2C%22ForstaUndervisningsdatum%22%3A%222025-08-25%22%2C%22Lasperiodsfordelning%22%3A%5B%7B%22Lasperiodskod%22%3A%22P1%22%2C%22Omfattningsvarde%22%3A3%2C%22link%22%3A%5B%5D%7D%2C%7B%22Lasperiodskod%22%3A%22P2%22%2C%22Omfattningsvarde%22%3A2%2C%22link%22%3A%5B%5D%7D%5D%2C%22Omfattningsvarde%22%3A5%2C%22SistaRegistreringsdatum%22%3A%222025-09-01%22%2C%22SistaUndervisningsdatum%22%3A%222026-01-12%22%7D%5D%2C%22kod%22%3A%22SH1015%22%2C%22benamning%22%3A%22Till%C3%A4mpad%20modern%20fysik%22%2C%22Valvillkor%22%3A%22O%22%2C%22type%22%3A%22instance%22%7D%2C%7B%22utbildningsinstansUid%22%3A%22842382f0-73d8-11e8-b4e0-063f9afb40e3%22%2C%22uid%22%3A%22a92403f2-bbb1-11ef-9553-beecfac44351%22%2C%22tillfalleskod%22%3A%2250998%22%2C%22status%22%3A%7B%22code%22%3A%22S3%22%2C%22nameSv%22%3A%22Komplett%22%2C%22nameEn%22%3A%22Complete%22%7D%2C%22utbildningstyp%22%3A%7B%22id%22%3A%2222%22%2C%22code%22%3A%222007GKURS%22%2C%22name%22%3A%22Kurs%2C%20grundniv%C3%A5%22%2C%22nameOther%22%3A%22Course%2C%20First-cycle%22%2C%22creditsUnit%22%3A%7B%22code%22%3A%22HP%22%2C%22sv%22%3A%22H%C3%B6gskolepo%C3%A4ng%22%2C%22en%22%3A%22Credits%22%7D%2C%22level%22%3A%7B%22code%22%3A%221%22%2C%22name%22%3A%22Grundniv%C3%A5%22%7D%7D%2C%22omfattning%22%3A%7B%22number%22%3A6%2C%22formattedWithUnit%22%3A%226%2C0%20hp%22%7D%2C%22startperiod%22%3A%7B%22code%22%3A%22HT2025%22%2C%22startDay%22%3A%222025-08-25%22%2C%22lastDay%22%3A%222026-01-12%22%2C%22inDigits%22%3A%2220252%22%7D%2C%22Tillfallesperioder%22%3A%5B%7B%22ForstaRegistreringsdatum%22%3A%222025-10-23%22%2C%22ForstaUndervisningsdatum%22%3A%222025-10-27%22%2C%22Lasperiodsfordelning%22%3A%5B%7B%22Lasperiodskod%22%3A%22P2%22%2C%22Omfattningsvarde%22%3A6%2C%22link%22%3A%5B%5D%7D%5D%2C%22Omfattningsvarde%22%3A6%2C%22SistaRegistreringsdatum%22%3A%222025-11-03%22%2C%22SistaUndervisningsdatum%22%3A%222026-01-12%22%7D%5D%2C%22kod%22%3A%22SI1336%22%2C%22benamning%22%3A%22Simulering%20och%20modellering%22%2C%22Valvillkor%22%3A%22O%22%2C%22type%22%3A%22instance%22%7D%2C%7B%22utbildningsinstansUid%22%3A%2232936226-73d8-11e8-afa7-8e408e694e54%22%2C%22uid%22%3A%221ac95187-bc63-11ef-9553-beecfac44351%22%2C%22tillfalleskod%22%3A%2261505%22%2C%22status%22%3A%7B%22code%22%3A%22S3%22%2C%22nameSv%22%3A%22Komplett%22%2C%22nameEn%22%3A%22Complete%22%7D%2C%22utbildningstyp%22%3A%7B%22id%22%3A%2224%22%2C%22code%22%3A%222007AKURS%22%2C%22name%22%3A%22Kurs%2C%20avancerad%20niv%C3%A5%22%2C%22nameOther%22%3A%22Course%2C%20Second-cycle%22%2C%22creditsUnit%22%3A%7B%22code%22%3A%22HP%22%2C%22sv%22%3A%22H%C3%B6gskolepo%C3%A4ng%22%2C%22en%22%3A%22Credits%22%7D%2C%22level%22%3A%7B%22code%22%3A%222%22%2C%22name%22%3A%22Avancerad%20niv%C3%A5%22%7D%7D%2C%22omfattning%22%3A%7B%22number%22%3A7.5%2C%22formattedWithUnit%22%3A%227%2C5%20hp%22%7D%2C%22startperiod%22%3A%7B%22code%22%3A%22VT2026%22%2C%22startDay%22%3A%222026-01-13%22%2C%22lastDay%22%3A%222026-06-01%22%2C%22inDigits%22%3A%2220261%22%7D%2C%22Tillfallesperioder%22%3A%5B%7B%22ForstaRegistreringsdatum%22%3A%222026-01-08%22%2C%22ForstaUndervisningsdatum%22%3A%222026-01-13%22%2C%22Lasperiodsfordelning%22%3A%5B%7B%22Lasperiodskod%22%3A%22P3%22%2C%22Omfattningsvarde%22%3A7.5%2C%22link%22%3A%5B%5D%7D%5D%2C%22Omfattningsvarde%22%3A7.5%2C%22SistaRegistreringsdatum%22%3A%222026-01-19%22%2C%22SistaUndervisningsdatum%22%3A%222026-03-13%22%7D%5D%2C%22kod%22%3A%22AK2014%22%2C%22benamning%22%3A%22Beslutsteori%22%2C%22Valvillkor%22%3A%22V%22%2C%22type%22%3A%22instance%22%7D%2C%7B%22utbildningsinstansUid%22%3A%22f1a551c5-d6b8-11e8-8fd5-cf9d2c5c41ba%22%2C%22uid%22%3A%22d36c2f00-bee7-11ef-9c9e-74b5caef4769%22%2C%22tillfalleskod%22%3A%2260848%22%2C%22status%22%3A%7B%22code%22%3A%22S3%22%2C%22nameSv%22%3A%22Komplett%22%2C%22nameEn%22%3A%22Complete%22%7D%2C%22utbildningstyp%22%3A%7B%22id%22%3A%2222%22%2C%22code%22%3A%222007GKURS%22%2C%22name%22%3A%22Kurs%2C%20grundniv%C3%A5%22%2C%22nameOther%22%3A%22Course%2C%20First-cycle%22%2C%22creditsUnit%22%3A%7B%22code%22%3A%22HP%22%2C%22sv%22%3A%22H%C3%B6gskolepo%C3%A4ng%22%2C%22en%22%3A%22Credits%22%7D%2C%22level%22%3A%7B%22code%22%3A%221%22%2C%22name%22%3A%22Grundniv%C3%A5%22%7D%7D%2C%22omfattning%22%3A%7B%22number%22%3A1.5%2C%22formattedWithUnit%22%3A%221%2C5%20hp%22%7D%2C%22startperiod%22%3A%7B%22code%22%3A%22VT2026%22%2C%22startDay%22%3A%222026-01-13%22%2C%22lastDay%22%3A%222026-06-01%22%2C%22inDigits%22%3A%2220261%22%7D%2C%22Tillfallesperioder%22%3A%5B%7B%22ForstaRegistreringsdatum%22%3A%222026-01-08%22%2C%22ForstaUndervisningsdatum%22%3A%222026-01-13%22%2C%22Lasperiodsfordelning%22%3A%5B%7B%22Lasperiodskod%22%3A%22P3%22%2C%22Omfattningsvarde%22%3A1.5%2C%22link%22%3A%5B%5D%7D%5D%2C%22Omfattningsvarde%22%3A1.5%2C%22SistaRegistreringsdatum%22%3A%222026-01-19%22%2C%22SistaUndervisningsdatum%22%3A%222026-03-13%22%7D%5D%2C%22kod%22%3A%22DD1380%22%2C%22benamning%22%3A%22Javaprogrammering%20f%C3%B6r%20Pythonprogrammerare%22%2C%22Valvillkor%22%3A%22V%22%2C%22type%22%3A%22instance%22%7D%2C%7B%22utbildningsinstansUid%22%3A%2257b7f18f-a82e-11f0-8e06-8e0c8088416e%22%2C%22uid%22%3A%22adab00ea-bee8-11ef-9c9e-74b5caef4769%22%2C%22tillfalleskod%22%3A%2260319%22%2C%22status%22%3A%7B%22code%22%3A%22S3%22%2C%22nameSv%22%3A%22Komplett%22%2C%22nameEn%22%3A%22Complete%22%7D%2C%22utbildningstyp%22%3A%7B%22id%22%3A%2224%22%2C%22code%22%3A%222007AKURS%22%2C%22name%22%3A%22Kurs%2C%20avancerad%20niv%C3%A5%22%2C%22nameOther%22%3A%22Course%2C%20Second-cycle%22%2C%22creditsUnit%22%3A%7B%22code%22%3A%22HP%22%2C%22sv%22%3A%22H%C3%B6gskolepo%C3%A4ng%22%2C%22en%22%3A%22Credits%22%7D%2C%22level%22%3A%7B%22code%22%3A%222%22%2C%22name%22%3A%22Avancerad%20niv%C3%A5%22%7D%7D%2C%22omfattning%22%3A%7B%22number%22%3A7.5%2C%22formattedWithUnit%22%3A%227%2C5%20hp%22%7D%2C%22startperiod%22%3A%7B%22code%22%3A%22VT2026%22%2C%22startDay%22%3A%222026-01-13%22%2C%22lastDay%22%3A%222026-06-01%22%2C%22inDigits%22%3A%2220261%22%7D%2C%22Tillfallesperioder%22%3A%5B%7B%22ForstaRegistreringsdatum%22%3A%222026-01-08%22%2C%22ForstaUndervisningsdatum%22%3A%222026-01-13%22%2C%22Lasperiodsfordelning%22%3A%5B%7B%22Lasperiodskod%22%3A%22P3%22%2C%22Omfattningsvarde%22%3A3%2C%22link%22%3A%5B%5D%7D%2C%7B%22Lasperiodskod%22%3A%22P4%22%2C%22Omfattningsvarde%22%3A4.5%2C%22link%22%3A%5B%5D%7D%5D%2C%22Omfattningsvarde%22%3A7.5%2C%22SistaRegistreringsdatum%22%3A%222026-01-19%22%2C%22SistaUndervisningsdatum%22%3A%222026-06-01%22%7D%5D%2C%22kod%22%3A%22DD2352%22%2C%22benamning%22%3A%22Algoritmer%20och%20komplexitet%22%2C%22Valvillkor%22%3A%22V%22%2C%22type%22%3A%22instance%22%7D%2C%7B%22utbildningsinstansUid%22%3A%2278ff827f-db44-11e8-b548-8cda89c64326%22%2C%22uid%22%3A%2209f8e39b-ab3f-11ef-a240-57578bd7405a%22%2C%22tillfalleskod%22%3A%2260242%22%2C%22status%22%3A%7B%22code%22%3A%22S3%22%2C%22nameSv%22%3A%22Komplett%22%2C%22nameEn%22%3A%22Complete%22%7D%2C%22utbildningstyp%22%3A%7B%22id%22%3A%2224%22%2C%22code%22%3A%222007AKURS%22%2C%22name%22%3A%22Kurs%2C%20avancerad%20niv%C3%A5%22%2C%22nameOther%22%3A%22Course%2C%20Second-cycle%22%2C%22creditsUnit%22%3A%7B%22code%22%3A%22HP%22%2C%22sv%22%3A%22H%C3%B6gskolepo%C3%A4ng%22%2C%22en%22%3A%22Credits%22%7D%2C%22level%22%3A%7B%22code%22%3A%222%22%2C%22name%22%3A%22Avancerad%20niv%C3%A5%22%7D%7D%2C%22omfattning%22%3A%7B%22number%22%3A7.5%2C%22formattedWithUnit%22%3A%227%2C5%20hp%22%7D%2C%22startperiod%22%3A%7B%22code%22%3A%22VT2026%22%2C%22startDay%22%3A%222026-01-13%22%2C%22lastDay%22%3A%222026-06-01%22%2C%22inDigits%22%3A%2220261%22%7D%2C%22Tillfallesperioder%22%3A%5B%7B%22ForstaRegistreringsdatum%22%3A%222026-01-08%22%2C%22ForstaUndervisningsdatum%22%3A%222026-01-13%22%2C%22Lasperiodsfordelning%22%3A%5B%7B%22Lasperiodskod%22%3A%22P3%22%2C%22Omfattningsvarde%22%3A7.5%2C%22link%22%3A%5B%5D%7D%5D%2C%22Omfattningsvarde%22%3A7.5%2C%22SistaRegistreringsdatum%22%3A%222026-01-19%22%2C%22SistaUndervisningsdatum%22%3A%222026-03-13%22%7D%5D%2C%22kod%22%3A%22DD2421%22%2C%22benamning%22%3A%22Maskininl%C3%A4rning%22%2C%22Valvillkor%22%3A%22V%22%2C%22type%22%3A%22instance%22%7D%2C%7B%22utbildningsinstansUid%22%3A%22f1a19610-a9c7-11f0-b7df-f9101f074b4e%22%2C%22uid%22%3A%2259fc26a9-c9dc-11ef-9e07-d56117ae456b%22%2C%22tillfalleskod%22%3A%2260343%22%2C%22status%22%3A%7B%22code%22%3A%22S3%22%2C%22nameSv%22%3A%22Komplett%22%2C%22nameEn%22%3A%22Complete%22%7D%2C%22utbildningstyp%22%3A%7B%22id%22%3A%2222%22%2C%22code%22%3A%222007GKURS%22%2C%22name%22%3A%22Kurs%2C%20grundniv%C3%A5%22%2C%22nameOther%22%3A%22Course%2C%20First-cycle%22%2C%22creditsUnit%22%3A%7B%22code%22%3A%22HP%22%2C%22sv%22%3A%22H%C3%B6gskolepo%C3%A4ng%22%2C%22en%22%3A%22Credits%22%7D%2C%22level%22%3A%7B%22code%22%3A%221%22%2C%22name%22%3A%22Grundniv%C3%A5%22%7D%7D%2C%22omfattning%22%3A%7B%22number%22%3A6%2C%22formattedWithUnit%22%3A%226%2C0%20hp%22%7D%2C%22startperiod%22%3A%7B%22code%22%3A%22VT2026%22%2C%22startDay%22%3A%222026-01-13%22%2C%22lastDay%22%3A%222026-06-01%22%2C%22inDigits%22%3A%2220261%22%7D%2C%22Tillfallesperioder%22%3A%5B%7B%22ForstaRegistreringsdatum%22%3A%222026-03-12%22%2C%22ForstaUndervisningsdatum%22%3A%222026-03-16%22%2C%22Lasperiodsfordelning%22%3A%5B%7B%22Lasperiodskod%22%3A%22P4%22%2C%22Omfattningsvarde%22%3A6%2C%22link%22%3A%5B%5D%7D%5D%2C%22Omfattningsvarde%22%3A6%2C%22SistaRegistreringsdatum%22%3A%222026-03-23%22%2C%22SistaUndervisningsdatum%22%3A%222026-06-01%22%7D%5D%2C%22kod%22%3A%22EQ1120%22%2C%22benamning%22%3A%22Tidsdiskreta%20signaler%20och%20system%22%2C%22Valvillkor%22%3A%22V%22%2C%22type%22%3A%22instance%22%7D%2C%7B%22utbildningsinstansUid%22%3A%22102ef09f-31c6-11ec-8540-ebd4d50c41d5%22%2C%22uid%22%3A%22214ea196-cf4c-11ef-9bca-bbbddaff469b%22%2C%22tillfalleskod%22%3A%2260609%22%2C%22status%22%3A%7B%22code%22%3A%22S3%22%2C%22nameSv%22%3A%22Komplett%22%2C%22nameEn%22%3A%22Complete%22%7D%2C%22utbildningstyp%22%3A%7B%22id%22%3A%2224%22%2C%22code%22%3A%222007AKURS%22%2C%22name%22%3A%22Kurs%2C%20avancerad%20niv%C3%A5%22%2C%22nameOther%22%3A%22Course%2C%20Second-cycle%22%2C%22creditsUnit%22%3A%7B%22code%22%3A%22HP%22%2C%22sv%22%3A%22H%C3%B6gskolepo%C3%A4ng%22%2C%22en%22%3A%22Credits%22%7D%2C%22level%22%3A%7B%22code%22%3A%222%22%2C%22name%22%3A%22Avancerad%20niv%C3%A5%22%7D%7D%2C%22omfattning%22%3A%7B%22number%22%3A7.5%2C%22formattedWithUnit%22%3A%227%2C5%20hp%22%7D%2C%22startperiod%22%3A%7B%22code%22%3A%22VT2026%22%2C%22startDay%22%3A%222026-01-13%22%2C%22lastDay%22%3A%222026-06-01%22%2C%22inDigits%22%3A%2220261%22%7D%2C%22Tillfallesperioder%22%3A%5B%7B%22ForstaRegistreringsdatum%22%3A%222026-01-08%22%2C%22ForstaUndervisningsdatum%22%3A%222026-01-13%22%2C%22Lasperiodsfordelning%22%3A%5B%7B%22Lasperiodskod%22%3A%22P3%22%2C%22Omfattningsvarde%22%3A7.5%2C%22link%22%3A%5B%5D%7D%5D%2C%22Omfattningsvarde%22%3A7.5%2C%22SistaRegistreringsdatum%22%3A%222026-01-19%22%2C%22SistaUndervisningsdatum%22%3A%222026-03-13%22%7D%5D%2C%22kod%22%3A%22IL2240%22%2C%22benamning%22%3A%22Halvledarkomponenter%20f%C3%B6r%20integrerade%20kretsar%22%2C%22Valvillkor%22%3A%22V%22%2C%22type%22%3A%22instance%22%7D%2C%7B%22utbildningsinstansUid%22%3A%224e2ddf86-af0d-11f0-a2d9-d8333a7b420f%22%2C%22uid%22%3A%2202196236-cf61-11ef-9bca-bbbddaff469b%22%2C%22tillfalleskod%22%3A%2261019%22%2C%22status%22%3A%7B%22code%22%3A%22S3%22%2C%22nameSv%22%3A%22Komplett%22%2C%22nameEn%22%3A%22Complete%22%7D%2C%22utbildningstyp%22%3A%7B%22id%22%3A%2222%22%2C%22code%22%3A%222007GKURS%22%2C%22name%22%3A%22Kurs%2C%20grundniv%C3%A5%22%2C%22nameOther%22%3A%22Course%2C%20First-cycle%22%2C%22creditsUnit%22%3A%7B%22code%22%3A%22HP%22%2C%22sv%22%3A%22H%C3%B6gskolepo%C3%A4ng%22%2C%22en%22%3A%22Credits%22%7D%2C%22level%22%3A%7B%22code%22%3A%221%22%2C%22name%22%3A%22Grundniv%C3%A5%22%7D%7D%2C%22omfattning%22%3A%7B%22number%22%3A6%2C%22formattedWithUnit%22%3A%226%2C0%20hp%22%7D%2C%22startperiod%22%3A%7B%22code%22%3A%22VT2026%22%2C%22startDay%22%3A%222026-01-13%22%2C%22lastDay%22%3A%222026-06-01%22%2C%22inDigits%22%3A%2220261%22%7D%2C%22Tillfallesperioder%22%3A%5B%7B%22ForstaRegistreringsdatum%22%3A%222026-01-08%22%2C%22ForstaUndervisningsdatum%22%3A%222026-01-13%22%2C%22Lasperiodsfordelning%22%3A%5B%7B%22Lasperiodskod%22%3A%22P3%22%2C%22Omfattningsvarde%22%3A3%2C%22link%22%3A%5B%5D%7D%2C%7B%22Lasperiodskod%22%3A%22P4%22%2C%22Omfattningsvarde%22%3A3%2C%22link%22%3A%5B%5D%7D%5D%2C%22Omfattningsvarde%22%3A6%2C%22SistaRegistreringsdatum%22%3A%222026-01-19%22%2C%22SistaUndervisningsdatum%22%3A%222026-06-01%22%7D%5D%2C%22kod%22%3A%22MH1023%22%2C%22benamning%22%3A%22Praktiskt%20j%C3%A4mst%C3%A4lldhets-%20och%20m%C3%A5ngfaldsarbete%20i%20vetenskapliga%2C%20tekniska%20och%20industriella%20milj%C3%B6er%22%2C%22Valvillkor%22%3A%22V%22%2C%22type%22%3A%22instance%22%7D%2C%7B%22utbildningsinstansUid%22%3A%227fcfb8f5-73d8-11e8-b4e0-063f9afb40e3%22%2C%22uid%22%3A%22102b21ea-ce67-11ef-9bca-bbbddaff469b%22%2C%22tillfalleskod%22%3A%2261256%22%2C%22status%22%3A%7B%22code%22%3A%22S3%22%2C%22nameSv%22%3A%22Komplett%22%2C%22nameEn%22%3A%22Complete%22%7D%2C%22utbildningstyp%22%3A%7B%22id%22%3A%2222%22%2C%22code%22%3A%222007GKURS%22%2C%22name%22%3A%22Kurs%2C%20grundniv%C3%A5%22%2C%22nameOther%22%3A%22Course%2C%20First-cycle%22%2C%22creditsUnit%22%3A%7B%22code%22%3A%22HP%22%2C%22sv%22%3A%22H%C3%B6gskolepo%C3%A4ng%22%2C%22en%22%3A%22Credits%22%7D%2C%22level%22%3A%7B%22code%22%3A%221%22%2C%22name%22%3A%22Grundniv%C3%A5%22%7D%7D%2C%22omfattning%22%3A%7B%22number%22%3A7.5%2C%22formattedWithUnit%22%3A%227%2C5%20hp%22%7D%2C%22startperiod%22%3A%7B%22code%22%3A%22VT2026%22%2C%22startDay%22%3A%222026-01-13%22%2C%22lastDay%22%3A%222026-06-01%22%2C%22inDigits%22%3A%2220261%22%7D%2C%22Tillfallesperioder%22%3A%5B%7B%22ForstaRegistreringsdatum%22%3A%222026-01-08%22%2C%22ForstaUndervisningsdatum%22%3A%222026-01-13%22%2C%22Lasperiodsfordelning%22%3A%5B%7B%22Lasperiodskod%22%3A%22P4%22%2C%22Omfattningsvarde%22%3A3.8%2C%22link%22%3A%5B%5D%7D%2C%7B%22Lasperiodskod%22%3A%22P3%22%2C%22Omfattningsvarde%22%3A3.7%2C%22link%22%3A%5B%5D%7D%5D%2C%22Omfattningsvarde%22%3A7.5%2C%22SistaRegistreringsdatum%22%3A%222026-01-19%22%2C%22SistaUndervisningsdatum%22%3A%222026-06-01%22%7D%5D%2C%22kod%22%3A%22SF1677%22%2C%22benamning%22%3A%22Analysens%20grunder%22%2C%22Valvillkor%22%3A%22V%22%2C%22type%22%3A%22instance%22%7D%2C%7B%22utbildningsinstansUid%22%3A%227fd78129-73d8-11e8-b4e0-063f9afb40e3%22%2C%22uid%22%3A%2218c6ce77-ce67-11ef-9bca-bbbddaff469b%22%2C%22tillfalleskod%22%3A%2261255%22%2C%22status%22%3A%7B%22code%22%3A%22S3%22%2C%22nameSv%22%3A%22Komplett%22%2C%22nameEn%22%3A%22Complete%22%7D%2C%22utbildningstyp%22%3A%7B%22id%22%3A%2222%22%2C%22code%22%3A%222007GKURS%22%2C%22name%22%3A%22Kurs%2C%20grundniv%C3%A5%22%2C%22nameOther%22%3A%22Course%2C%20First-cycle%22%2C%22creditsUnit%22%3A%7B%22code%22%3A%22HP%22%2C%22sv%22%3A%22H%C3%B6gskolepo%C3%A4ng%22%2C%22en%22%3A%22Credits%22%7D%2C%22level%22%3A%7B%22code%22%3A%221%22%2C%22name%22%3A%22Grundniv%C3%A5%22%7D%7D%2C%22omfattning%22%3A%7B%22number%22%3A7.5%2C%22formattedWithUnit%22%3A%227%2C5%20hp%22%7D%2C%22startperiod%22%3A%7B%22code%22%3A%22VT2026%22%2C%22startDay%22%3A%222026-01-13%22%2C%22lastDay%22%3A%222026-06-01%22%2C%22inDigits%22%3A%2220261%22%7D%2C%22Tillfallesperioder%22%3A%5B%7B%22ForstaRegistreringsdatum%22%3A%222026-01-08%22%2C%22ForstaUndervisningsdatum%22%3A%222026-01-13%22%2C%22Lasperiodsfordelning%22%3A%5B%7B%22Lasperiodskod%22%3A%22P4%22%2C%22Omfattningsvarde%22%3A3.8%2C%22link%22%3A%5B%5D%7D%2C%7B%22Lasperiodskod%22%3A%22P3%22%2C%22Omfattningsvarde%22%3A3.7%2C%22link%22%3A%5B%5D%7D%5D%2C%22Omfattningsvarde%22%3A7.5%2C%22SistaRegistreringsdatum%22%3A%222026-01-19%22%2C%22SistaUndervisningsdatum%22%3A%222026-06-01%22%7D%5D%2C%22kod%22%3A%22SF1678%22%2C%22benamning%22%3A%22Grupper%20och%20ringar%22%2C%22Valvillkor%22%3A%22V%22%2C%22type%22%3A%22instance%22%7D%2C%7B%22utbildningsinstansUid%22%3A%227fe7389d-73d8-11e8-b4e0-063f9afb40e3%22%2C%22uid%22%3A%2228d67044-ce67-11ef-9bca-bbbddaff469b%22%2C%22tillfalleskod%22%3A%2260882%22%2C%22status%22%3A%7B%22code%22%3A%22S3%22%2C%22nameSv%22%3A%22Komplett%22%2C%22nameEn%22%3A%22Complete%22%7D%2C%22utbildningstyp%22%3A%7B%22id%22%3A%2222%22%2C%22code%22%3A%222007GKURS%22%2C%22name%22%3A%22Kurs%2C%20grundniv%C3%A5%22%2C%22nameOther%22%3A%22Course%2C%20First-cycle%22%2C%22creditsUnit%22%3A%7B%22code%22%3A%22HP%22%2C%22sv%22%3A%22H%C3%B6gskolepo%C3%A4ng%22%2C%22en%22%3A%22Credits%22%7D%2C%22level%22%3A%7B%22code%22%3A%221%22%2C%22name%22%3A%22Grundniv%C3%A5%22%7D%7D%2C%22omfattning%22%3A%7B%22number%22%3A7.5%2C%22formattedWithUnit%22%3A%227%2C5%20hp%22%7D%2C%22startperiod%22%3A%7B%22code%22%3A%22VT2026%22%2C%22startDay%22%3A%222026-01-13%22%2C%22lastDay%22%3A%222026-06-01%22%2C%22inDigits%22%3A%2220261%22%7D%2C%22Tillfallesperioder%22%3A%5B%7B%22ForstaRegistreringsdatum%22%3A%222026-01-08%22%2C%22ForstaUndervisningsdatum%22%3A%222026-01-13%22%2C%22Lasperiodsfordelning%22%3A%5B%7B%22Lasperiodskod%22%3A%22P3%22%2C%22Omfattningsvarde%22%3A7.5%2C%22link%22%3A%5B%5D%7D%5D%2C%22Omfattningsvarde%22%3A7.5%2C%22SistaRegistreringsdatum%22%3A%222026-01-19%22%2C%22SistaUndervisningsdatum%22%3A%222026-03-13%22%7D%5D%2C%22kod%22%3A%22SF1679%22%2C%22benamning%22%3A%22Diskret%20matematik%22%2C%22Valvillkor%22%3A%22V%22%2C%22type%22%3A%22instance%22%7D%2C%7B%22utbildningsinstansUid%22%3A%227ffb8407-73d8-11e8-b4e0-063f9afb40e3%22%2C%22uid%22%3A%2293367eb9-ce67-11ef-9bca-bbbddaff469b%22%2C%22tillfalleskod%22%3A%2260883%22%2C%22status%22%3A%7B%22code%22%3A%22S3%22%2C%22nameSv%22%3A%22Komplett%22%2C%22nameEn%22%3A%22Complete%22%7D%2C%22utbildningstyp%22%3A%7B%22id%22%3A%2222%22%2C%22code%22%3A%222007GKURS%22%2C%22name%22%3A%22Kurs%2C%20grundniv%C3%A5%22%2C%22nameOther%22%3A%22Course%2C%20First-cycle%22%2C%22creditsUnit%22%3A%7B%22code%22%3A%22HP%22%2C%22sv%22%3A%22H%C3%B6gskolepo%C3%A4ng%22%2C%22en%22%3A%22Credits%22%7D%2C%22level%22%3A%7B%22code%22%3A%221%22%2C%22name%22%3A%22Grundniv%C3%A5%22%7D%7D%2C%22omfattning%22%3A%7B%22number%22%3A7.5%2C%22formattedWithUnit%22%3A%227%2C5%20hp%22%7D%2C%22startperiod%22%3A%7B%22code%22%3A%22VT2026%22%2C%22startDay%22%3A%222026-01-13%22%2C%22lastDay%22%3A%222026-06-01%22%2C%22inDigits%22%3A%2220261%22%7D%2C%22Tillfallesperioder%22%3A%5B%7B%22ForstaRegistreringsdatum%22%3A%222026-01-08%22%2C%22ForstaUndervisningsdatum%22%3A%222026-01-13%22%2C%22Lasperiodsfordelning%22%3A%5B%7B%22Lasperiodskod%22%3A%22P4%22%2C%22Omfattningsvarde%22%3A3.8%2C%22link%22%3A%5B%5D%7D%2C%7B%22Lasperiodskod%22%3A%22P3%22%2C%22Omfattningsvarde%22%3A3.7%2C%22link%22%3A%5B%5D%7D%5D%2C%22Omfattningsvarde%22%3A7.5%2C%22SistaRegistreringsdatum%22%3A%222026-01-19%22%2C%22SistaUndervisningsdatum%22%3A%222026-06-01%22%7D%5D%2C%22kod%22%3A%22SF1691%22%2C%22benamning%22%3A%22Komplex%20analys%22%2C%22Valvillkor%22%3A%22V%22%2C%22type%22%3A%22instance%22%7D%2C%7B%22utbildningsinstansUid%22%3A%228010e0d4-73d8-11e8-b4e0-063f9afb40e3%22%2C%22uid%22%3A%22fa9003b2-ce67-11ef-9bca-bbbddaff469b%22%2C%22tillfalleskod%22%3A%2260884%22%2C%22status%22%3A%7B%22code%22%3A%22S3%22%2C%22nameSv%22%3A%22Komplett%22%2C%22nameEn%22%3A%22Complete%22%7D%2C%22utbildningstyp%22%3A%7B%22id%22%3A%2222%22%2C%22code%22%3A%222007GKURS%22%2C%22name%22%3A%22Kurs%2C%20grundniv%C3%A5%22%2C%22nameOther%22%3A%22Course%2C%20First-cycle%22%2C%22creditsUnit%22%3A%7B%22code%22%3A%22HP%22%2C%22sv%22%3A%22H%C3%B6gskolepo%C3%A4ng%22%2C%22en%22%3A%22Credits%22%7D%2C%22level%22%3A%7B%22code%22%3A%221%22%2C%22name%22%3A%22Grundniv%C3%A5%22%7D%7D%2C%22omfattning%22%3A%7B%22number%22%3A6%2C%22formattedWithUnit%22%3A%226%2C0%20hp%22%7D%2C%22startperiod%22%3A%7B%22code%22%3A%22VT2026%22%2C%22startDay%22%3A%222026-01-13%22%2C%22lastDay%22%3A%222026-06-01%22%2C%22inDigits%22%3A%2220261%22%7D%2C%22Tillfallesperioder%22%3A%5B%7B%22ForstaRegistreringsdatum%22%3A%222026-03-12%22%2C%22ForstaUndervisningsdatum%22%3A%222026-03-16%22%2C%22Lasperiodsfordelning%22%3A%5B%7B%22Lasperiodskod%22%3A%22P4%22%2C%22Omfattningsvarde%22%3A6%2C%22link%22%3A%5B%5D%7D%5D%2C%22Omfattningsvarde%22%3A6%2C%22SistaRegistreringsdatum%22%3A%222026-03-23%22%2C%22SistaUndervisningsdatum%22%3A%222026-06-01%22%7D%5D%2C%22kod%22%3A%22SF1861%22%2C%22benamning%22%3A%22Optimeringsl%C3%A4ra%22%2C%22Valvillkor%22%3A%22V%22%2C%22type%22%3A%22instance%22%7D%2C%7B%22utbildningsinstansUid%22%3A%22803d2109-73d8-11e8-afa7-8e408e694e54%22%2C%22uid%22%3A%2200e6c8ad-ce68-11ef-9bca-bbbddaff469b%22%2C%22tillfalleskod%22%3A%2261264%22%2C%22status%22%3A%7B%22code%22%3A%22S3%22%2C%22nameSv%22%3A%22Komplett%22%2C%22nameEn%22%3A%22Complete%22%7D%2C%22utbildningstyp%22%3A%7B%22id%22%3A%2222%22%2C%22code%22%3A%222007GKURS%22%2C%22name%22%3A%22Kurs%2C%20grundniv%C3%A5%22%2C%22nameOther%22%3A%22Course%2C%20First-cycle%22%2C%22creditsUnit%22%3A%7B%22code%22%3A%22HP%22%2C%22sv%22%3A%22H%C3%B6gskolepo%C3%A4ng%22%2C%22en%22%3A%22Credits%22%7D%2C%22level%22%3A%7B%22code%22%3A%221%22%2C%22name%22%3A%22Grundniv%C3%A5%22%7D%7D%2C%22omfattning%22%3A%7B%22number%22%3A3%2C%22formattedWithUnit%22%3A%223%2C0%20hp%22%7D%2C%22startperiod%22%3A%7B%22code%22%3A%22VT2026%22%2C%22startDay%22%3A%222026-01-13%22%2C%22lastDay%22%3A%222026-06-01%22%2C%22inDigits%22%3A%2220261%22%7D%2C%22Tillfallesperioder%22%3A%5B%7B%22ForstaRegistreringsdatum%22%3A%222026-03-12%22%2C%22ForstaUndervisningsdatum%22%3A%222026-03-16%22%2C%22Lasperiodsfordelning%22%3A%5B%7B%22Lasperiodskod%22%3A%22P4%22%2C%22Omfattningsvarde%22%3A3%2C%22link%22%3A%5B%5D%7D%5D%2C%22Omfattningsvarde%22%3A3%2C%22SistaRegistreringsdatum%22%3A%222026-03-23%22%2C%22SistaUndervisningsdatum%22%3A%222026-06-01%22%7D%5D%2C%22kod%22%3A%22SF1904%22%2C%22benamning%22%3A%22Markovprocesser%2C%20grundkurs%22%2C%22Valvillkor%22%3A%22V%22%2C%22type%22%3A%22instance%22%7D%2C%7B%22utbildningsinstansUid%22%3A%2280854df8-73d8-11e8-b4e0-063f9afb40e3%22%2C%22uid%22%3A%2223514071-ce69-11ef-9bca-bbbddaff469b%22%2C%22tillfalleskod%22%3A%2261253%22%2C%22status%22%3A%7B%22code%22%3A%22S3%22%2C%22nameSv%22%3A%22Komplett%22%2C%22nameEn%22%3A%22Complete%22%7D%2C%22utbildningstyp%22%3A%7B%22id%22%3A%2224%22%2C%22code%22%3A%222007AKURS%22%2C%22name%22%3A%22Kurs%2C%20avancerad%20niv%C3%A5%22%2C%22nameOther%22%3A%22Course%2C%20Second-cycle%22%2C%22creditsUnit%22%3A%7B%22code%22%3A%22HP%22%2C%22sv%22%3A%22H%C3%B6gskolepo%C3%A4ng%22%2C%22en%22%3A%22Credits%22%7D%2C%22level%22%3A%7B%22code%22%3A%222%22%2C%22name%22%3A%22Avancerad%20niv%C3%A5%22%7D%7D%2C%22omfattning%22%3A%7B%22number%22%3A7.5%2C%22formattedWithUnit%22%3A%227%2C5%20hp%22%7D%2C%22startperiod%22%3A%7B%22code%22%3A%22VT2026%22%2C%22startDay%22%3A%222026-01-13%22%2C%22lastDay%22%3A%222026-06-01%22%2C%22inDigits%22%3A%2220261%22%7D%2C%22Tillfallesperioder%22%3A%5B%7B%22ForstaRegistreringsdatum%22%3A%222026-03-12%22%2C%22ForstaUndervisningsdatum%22%3A%222026-03-16%22%2C%22Lasperiodsfordelning%22%3A%5B%7B%22Lasperiodskod%22%3A%22P4%22%2C%22Omfattningsvarde%22%3A7.5%2C%22link%22%3A%5B%5D%7D%5D%2C%22Omfattningsvarde%22%3A7.5%2C%22SistaRegistreringsdatum%22%3A%222026-03-23%22%2C%22SistaUndervisningsdatum%22%3A%222026-06-01%22%7D%5D%2C%22kod%22%3A%22SF2701%22%2C%22benamning%22%3A%22Finansiell%20matematik%2C%20grundkurs%22%2C%22Valvillkor%22%3A%22V%22%2C%22type%22%3A%22instance%22%7D%2C%7B%22utbildningsinstansUid%22%3A%2281278107-73d8-11e8-b4e0-063f9afb40e3%22%2C%22uid%22%3A%227261777d-ce6a-11ef-9bca-bbbddaff469b%22%2C%22tillfalleskod%22%3A%2260237%22%2C%22status%22%3A%7B%22code%22%3A%22S3%22%2C%22nameSv%22%3A%22Komplett%22%2C%22nameEn%22%3A%22Complete%22%7D%2C%22utbildningstyp%22%3A%7B%22id%22%3A%2224%22%2C%22code%22%3A%222007AKURS%22%2C%22name%22%3A%22Kurs%2C%20avancerad%20niv%C3%A5%22%2C%22nameOther%22%3A%22Course%2C%20Second-cycle%22%2C%22creditsUnit%22%3A%7B%22code%22%3A%22HP%22%2C%22sv%22%3A%22H%C3%B6gskolepo%C3%A4ng%22%2C%22en%22%3A%22Credits%22%7D%2C%22level%22%3A%7B%22code%22%3A%222%22%2C%22name%22%3A%22Avancerad%20niv%C3%A5%22%7D%7D%2C%22omfattning%22%3A%7B%22number%22%3A7.5%2C%22formattedWithUnit%22%3A%227%2C5%20hp%22%7D%2C%22startperiod%22%3A%7B%22code%22%3A%22VT2026%22%2C%22startDay%22%3A%222026-01-13%22%2C%22lastDay%22%3A%222026-06-01%22%2C%22inDigits%22%3A%2220261%22%7D%2C%22Tillfallesperioder%22%3A%5B%7B%22ForstaRegistreringsdatum%22%3A%222026-01-08%22%2C%22ForstaUndervisningsdatum%22%3A%222026-01-13%22%2C%22Lasperiodsfordelning%22%3A%5B%7B%22Lasperiodskod%22%3A%22P3%22%2C%22Omfattningsvarde%22%3A7.5%2C%22link%22%3A%5B%5D%7D%5D%2C%22Omfattningsvarde%22%3A7.5%2C%22SistaRegistreringsdatum%22%3A%222026-01-19%22%2C%22SistaUndervisningsdatum%22%3A%222026-03-13%22%7D%5D%2C%22kod%22%3A%22SF2930%22%2C%22benamning%22%3A%22Regressionsanalys%22%2C%22Valvillkor%22%3A%22V%22%2C%22type%22%3A%22instance%22%7D%2C%7B%22utbildningsinstansUid%22%3A%2234c0c34e-969b-11ef-8f91-f98ca46144d5%22%2C%22uid%22%3A%22dd2b3206-bba8-11ef-9553-beecfac44351%22%2C%22tillfalleskod%22%3A%2261094%22%2C%22status%22%3A%7B%22code%22%3A%22S3%22%2C%22nameSv%22%3A%22Komplett%22%2C%22nameEn%22%3A%22Complete%22%7D%2C%22utbildningstyp%22%3A%7B%22id%22%3A%2224%22%2C%22code%22%3A%222007AKURS%22%2C%22name%22%3A%22Kurs%2C%20avancerad%20niv%C3%A5%22%2C%22nameOther%22%3A%22Course%2C%20Second-cycle%22%2C%22creditsUnit%22%3A%7B%22code%22%3A%22HP%22%2C%22sv%22%3A%22H%C3%B6gskolepo%C3%A4ng%22%2C%22en%22%3A%22Credits%22%7D%2C%22level%22%3A%7B%22code%22%3A%222%22%2C%22name%22%3A%22Avancerad%20niv%C3%A5%22%7D%7D%2C%22omfattning%22%3A%7B%22number%22%3A7.5%2C%22formattedWithUnit%22%3A%227%2C5%20hp%22%7D%2C%22startperiod%22%3A%7B%22code%22%3A%22VT2026%22%2C%22startDay%22%3A%222026-01-13%22%2C%22lastDay%22%3A%222026-06-01%22%2C%22inDigits%22%3A%2220261%22%7D%2C%22Tillfallesperioder%22%3A%5B%7B%22ForstaRegistreringsdatum%22%3A%222026-03-12%22%2C%22ForstaUndervisningsdatum%22%3A%222026-03-16%22%2C%22Lasperiodsfordelning%22%3A%5B%7B%22Lasperiodskod%22%3A%22P4%22%2C%22Omfattningsvarde%22%3A7.5%2C%22link%22%3A%5B%5D%7D%5D%2C%22Omfattningsvarde%22%3A7.5%2C%22SistaRegistreringsdatum%22%3A%222026-03-23%22%2C%22SistaUndervisningsdatum%22%3A%222026-06-01%22%7D%5D%2C%22kod%22%3A%22SH2404%22%2C%22benamning%22%3A%22Astrofysik%22%2C%22Valvillkor%22%3A%22V%22%2C%22type%22%3A%22instance%22%7D%2C%7B%22utbildningsinstansUid%22%3A%221cc67613-8f96-11f0-b29b-713806674b84%22%2C%22uid%22%3A%22b1aa58d1-bbaa-11ef-9553-beecfac44351%22%2C%22tillfalleskod%22%3A%2260123%22%2C%22status%22%3A%7B%22code%22%3A%22S3%22%2C%22nameSv%22%3A%22Komplett%22%2C%22nameEn%22%3A%22Complete%22%7D%2C%22utbildningstyp%22%3A%7B%22id%22%3A%2222%22%2C%22code%22%3A%222007GKURS%22%2C%22name%22%3A%22Kurs%2C%20grundniv%C3%A5%22%2C%22nameOther%22%3A%22Course%2C%20First-cycle%22%2C%22creditsUnit%22%3A%7B%22code%22%3A%22HP%22%2C%22sv%22%3A%22H%C3%B6gskolepo%C3%A4ng%22%2C%22en%22%3A%22Credits%22%7D%2C%22level%22%3A%7B%22code%22%3A%221%22%2C%22name%22%3A%22Grundniv%C3%A5%22%7D%7D%2C%22omfattning%22%3A%7B%22number%22%3A3%2C%22formattedWithUnit%22%3A%223%2C0%20hp%22%7D%2C%22startperiod%22%3A%7B%22code%22%3A%22VT2026%22%2C%22startDay%22%3A%222026-01-13%22%2C%22lastDay%22%3A%222026-06-01%22%2C%22inDigits%22%3A%2220261%22%7D%2C%22Tillfallesperioder%22%3A%5B%7B%22ForstaRegistreringsdatum%22%3A%222026-03-12%22%2C%22ForstaUndervisningsdatum%22%3A%222026-03-16%22%2C%22Lasperiodsfordelning%22%3A%5B%7B%22Lasperiodskod%22%3A%22P4%22%2C%22Omfattningsvarde%22%3A3%2C%22link%22%3A%5B%5D%7D%5D%2C%22Omfattningsvarde%22%3A3%2C%22SistaRegistreringsdatum%22%3A%222026-03-23%22%2C%22SistaUndervisningsdatum%22%3A%222026-06-01%22%7D%5D%2C%22kod%22%3A%22SI1142%22%2C%22benamning%22%3A%22Fysikens%20matematiska%20metoder%2C%20till%C3%A4ggskurs%22%2C%22Valvillkor%22%3A%22V%22%2C%22type%22%3A%22instance%22%7D%2C%7B%22utbildningsinstansUid%22%3A%22841cf33a-73d8-11e8-b4e0-063f9afb40e3%22%2C%22uid%22%3A%22531e6fde-bbab-11ef-9553-beecfac44351%22%2C%22tillfalleskod%22%3A%2260163%22%2C%22status%22%3A%7B%22code%22%3A%22S3%22%2C%22nameSv%22%3A%22Komplett%22%2C%22nameEn%22%3A%22Complete%22%7D%2C%22utbildningstyp%22%3A%7B%22id%22%3A%2222%22%2C%22code%22%3A%222007GKURS%22%2C%22name%22%3A%22Kurs%2C%20grundniv%C3%A5%22%2C%22nameOther%22%3A%22Course%2C%20First-cycle%22%2C%22creditsUnit%22%3A%7B%22code%22%3A%22HP%22%2C%22sv%22%3A%22H%C3%B6gskolepo%C3%A4ng%22%2C%22en%22%3A%22Credits%22%7D%2C%22level%22%3A%7B%22code%22%3A%221%22%2C%22name%22%3A%22Grundniv%C3%A5%22%7D%7D%2C%22omfattning%22%3A%7B%22number%22%3A7.5%2C%22formattedWithUnit%22%3A%227%2C5%20hp%22%7D%2C%22startperiod%22%3A%7B%22code%22%3A%22VT2026%22%2C%22startDay%22%3A%222026-01-13%22%2C%22lastDay%22%3A%222026-06-01%22%2C%22inDigits%22%3A%2220261%22%7D%2C%22Tillfallesperioder%22%3A%5B%7B%22ForstaRegistreringsdatum%22%3A%222026-01-08%22%2C%22ForstaUndervisningsdatum%22%3A%222026-01-13%22%2C%22Lasperiodsfordelning%22%3A%5B%7B%22Lasperiodskod%22%3A%22P3%22%2C%22Omfattningsvarde%22%3A7.5%2C%22link%22%3A%5B%5D%7D%5D%2C%22Omfattningsvarde%22%3A7.5%2C%22SistaRegistreringsdatum%22%3A%222026-01-19%22%2C%22SistaUndervisningsdatum%22%3A%222026-03-13%22%7D%5D%2C%22kod%22%3A%22SI1162%22%2C%22benamning%22%3A%22Statistisk%20fysik%22%2C%22Valvillkor%22%3A%22V%22%2C%22type%22%3A%22instance%22%7D%2C%7B%22utbildningsinstansUid%22%3A%22c4c8cc60-8f98-11f0-b29b-713806674b84%22%2C%22uid%22%3A%227484175a-bbab-11ef-9553-beecfac44351%22%2C%22tillfalleskod%22%3A%2260925%22%2C%22status%22%3A%7B%22code%22%3A%22S3%22%2C%22nameSv%22%3A%22Komplett%22%2C%22nameEn%22%3A%22Complete%22%7D%2C%22utbildningstyp%22%3A%7B%22id%22%3A%2224%22%2C%22code%22%3A%222007AKURS%22%2C%22name%22%3A%22Kurs%2C%20avancerad%20niv%C3%A5%22%2C%22nameOther%22%3A%22Course%2C%20Second-cycle%22%2C%22creditsUnit%22%3A%7B%22code%22%3A%22HP%22%2C%22sv%22%3A%22H%C3%B6gskolepo%C3%A4ng%22%2C%22en%22%3A%22Credits%22%7D%2C%22level%22%3A%7B%22code%22%3A%222%22%2C%22name%22%3A%22Avancerad%20niv%C3%A5%22%7D%7D%2C%22omfattning%22%3A%7B%22number%22%3A7.5%2C%22formattedWithUnit%22%3A%227%2C5%20hp%22%7D%2C%22startperiod%22%3A%7B%22code%22%3A%22VT2026%22%2C%22startDay%22%3A%222026-01-13%22%2C%22lastDay%22%3A%222026-06-01%22%2C%22inDigits%22%3A%2220261%22%7D%2C%22Tillfallesperioder%22%3A%5B%7B%22ForstaRegistreringsdatum%22%3A%222026-03-12%22%2C%22ForstaUndervisningsdatum%22%3A%222026-03-16%22%2C%22Lasperiodsfordelning%22%3A%5B%7B%22Lasperiodskod%22%3A%22P4%22%2C%22Omfattningsvarde%22%3A7.5%2C%22link%22%3A%5B%5D%7D%5D%2C%22Omfattningsvarde%22%3A7.5%2C%22SistaRegistreringsdatum%22%3A%222026-03-23%22%2C%22SistaUndervisningsdatum%22%3A%222026-06-01%22%7D%5D%2C%22kod%22%3A%22SI2360%22%2C%22benamning%22%3A%22Analytisk%20mekanik%20och%20klassisk%20f%C3%A4ltteori%22%2C%22Valvillkor%22%3A%22V%22%2C%22type%22%3A%22instance%22%7D%2C%7B%22utbildningsinstansUid%22%3A%22209dbaf0-30e3-11ec-8540-ebd4d50c41d5%22%2C%22uid%22%3A%2237b9442e-d197-11ef-9bca-bbbddaff469b%22%2C%22tillfalleskod%22%3A%2260795%22%2C%22status%22%3A%7B%22code%22%3A%22S3%22%2C%22nameSv%22%3A%22Komplett%22%2C%22nameEn%22%3A%22Complete%22%7D%2C%22utbildningstyp%22%3A%7B%22id%22%3A%2224%22%2C%22code%22%3A%222007AKURS%22%2C%22name%22%3A%22Kurs%2C%20avancerad%20niv%C3%A5%22%2C%22nameOther%22%3A%22Course%2C%20Second-cycle%22%2C%22creditsUnit%22%3A%7B%22code%22%3A%22HP%22%2C%22sv%22%3A%22H%C3%B6gskolepo%C3%A4ng%22%2C%22en%22%3A%22Credits%22%7D%2C%22level%22%3A%7B%22code%22%3A%222%22%2C%22name%22%3A%22Avancerad%20niv%C3%A5%22%7D%7D%2C%22omfattning%22%3A%7B%22number%22%3A7.5%2C%22formattedWithUnit%22%3A%227%2C5%20hp%22%7D%2C%22startperiod%22%3A%7B%22code%22%3A%22VT2026%22%2C%22startDay%22%3A%222026-01-13%22%2C%22lastDay%22%3A%222026-06-01%22%2C%22inDigits%22%3A%2220261%22%7D%2C%22Tillfallesperioder%22%3A%5B%7B%22ForstaRegistreringsdatum%22%3A%222026-03-12%22%2C%22ForstaUndervisningsdatum%22%3A%222026-03-16%22%2C%22Lasperiodsfordelning%22%3A%5B%7B%22Lasperiodskod%22%3A%22P4%22%2C%22Omfattningsvarde%22%3A7.5%2C%22link%22%3A%5B%5D%7D%5D%2C%22Omfattningsvarde%22%3A7.5%2C%22SistaRegistreringsdatum%22%3A%222026-03-23%22%2C%22SistaUndervisningsdatum%22%3A%222026-06-01%22%7D%5D%2C%22kod%22%3A%22SK2712%22%2C%22benamning%22%3A%22Milj%C3%B6fysik%22%2C%22Valvillkor%22%3A%22V%22%2C%22type%22%3A%22instance%22%7D%2C%7B%22utbildningsinstansUid%22%3A%22b48a52a5-dd0c-11e8-bb7a-19f8cd1a470e%22%2C%22uid%22%3A%226728b9be-ce5c-11ef-9bca-bbbddaff469b%22%2C%22tillfalleskod%22%3A%2260889%22%2C%22status%22%3A%7B%22code%22%3A%22S3%22%2C%22nameSv%22%3A%22Komplett%22%2C%22nameEn%22%3A%22Complete%22%7D%2C%22utbildningstyp%22%3A%7B%22id%22%3A%2222%22%2C%22code%22%3A%222007GKURS%22%2C%22name%22%3A%22Kurs%2C%20grundniv%C3%A5%22%2C%22nameOther%22%3A%22Course%2C%20First-cycle%22%2C%22creditsUnit%22%3A%7B%22code%22%3A%22HP%22%2C%22sv%22%3A%22H%C3%B6gskolepo%C3%A4ng%22%2C%22en%22%3A%22Credits%22%7D%2C%22level%22%3A%7B%22code%22%3A%221%22%2C%22name%22%3A%22Grundniv%C3%A5%22%7D%7D%2C%22omfattning%22%3A%7B%22number%22%3A15%2C%22formattedWithUnit%22%3A%2215%2C0%20hp%22%7D%2C%22startperiod%22%3A%7B%22code%22%3A%22VT2026%22%2C%22startDay%22%3A%222026-01-13%22%2C%22lastDay%22%3A%222026-06-01%22%2C%22inDigits%22%3A%2220261%22%7D%2C%22Tillfallesperioder%22%3A%5B%7B%22ForstaRegistreringsdatum%22%3A%222026-01-08%22%2C%22ForstaUndervisningsdatum%22%3A%222026-01-13%22%2C%22Lasperiodsfordelning%22%3A%5B%7B%22Lasperiodskod%22%3A%22P4%22%2C%22Omfattningsvarde%22%3A7.5%2C%22link%22%3A%5B%5D%7D%2C%7B%22Lasperiodskod%22%3A%22P3%22%2C%22Omfattningsvarde%22%3A7.5%2C%22link%22%3A%5B%5D%7D%5D%2C%22Omfattningsvarde%22%3A15%2C%22SistaRegistreringsdatum%22%3A%222026-01-19%22%2C%22SistaUndervisningsdatum%22%3A%222026-06-01%22%7D%5D%2C%22kod%22%3A%22EF112X%22%2C%22benamning%22%3A%22Examensarbete%20inom%20elektroteknik%2C%20grundniv%C3%A5%22%2C%22Valvillkor%22%3A%22VV%22%2C%22type%22%3A%22instance%22%7D%2C%7B%22utbildningsinstansUid%22%3A%22f50679d1-969f-11ea-a1f9-cb69981448b1%22%2C%22uid%22%3A%22898fa0bd-b2e9-11ef-9c22-4dfcae5d4bc4%22%2C%22tillfalleskod%22%3A%2261514%22%2C%22status%22%3A%7B%22code%22%3A%22S3%22%2C%22nameSv%22%3A%22Komplett%22%2C%22nameEn%22%3A%22Complete%22%7D%2C%22utbildningstyp%22%3A%7B%22id%22%3A%2222%22%2C%22code%22%3A%222007GKURS%22%2C%22name%22%3A%22Kurs%2C%20grundniv%C3%A5%22%2C%22nameOther%22%3A%22Course%2C%20First-cycle%22%2C%22creditsUnit%22%3A%7B%22code%22%3A%22HP%22%2C%22sv%22%3A%22H%C3%B6gskolepo%C3%A4ng%22%2C%22en%22%3A%22Credits%22%7D%2C%22level%22%3A%7B%22code%22%3A%221%22%2C%22name%22%3A%22Grundniv%C3%A5%22%7D%7D%2C%22omfattning%22%3A%7B%22number%22%3A15%2C%22formattedWithUnit%22%3A%2215%2C0%20hp%22%7D%2C%22startperiod%22%3A%7B%22code%22%3A%22VT2026%22%2C%22startDay%22%3A%222026-01-13%22%2C%22lastDay%22%3A%222026-06-01%22%2C%22inDigits%22%3A%2220261%22%7D%2C%22Tillfallesperioder%22%3A%5B%7B%22ForstaRegistreringsdatum%22%3A%222026-01-08%22%2C%22ForstaUndervisningsdatum%22%3A%222026-01-13%22%2C%22Lasperiodsfordelning%22%3A%5B%7B%22Lasperiodskod%22%3A%22P4%22%2C%22Omfattningsvarde%22%3A7.5%2C%22link%22%3A%5B%5D%7D%2C%7B%22Lasperiodskod%22%3A%22P3%22%2C%22Omfattningsvarde%22%3A7.5%2C%22link%22%3A%5B%5D%7D%5D%2C%22Omfattningsvarde%22%3A15%2C%22SistaRegistreringsdatum%22%3A%222026-01-19%22%2C%22SistaUndervisningsdatum%22%3A%222026-06-01%22%7D%5D%2C%22kod%22%3A%22SA114X%22%2C%22benamning%22%3A%22Examensarbete%20inom%20teknisk%20fysik%2C%20grundniv%C3%A5%22%2C%22Valvillkor%22%3A%22VV%22%2C%22type%22%3A%22instance%22%7D%5D%2C%22freeTexts%22%3A%5B%5D%2C%22supplementaryInfo%22%3A%22%3Cp%3EBaserat%20p%C3%A5%20l%C3%A4s%C3%A5rsplan%20beslutad%20f%C3%B6r%20l%C3%A4s%C3%A5ret%202024%2F2025.%20%C3%84ndringar%20kan%20ske%20f%C3%B6r%20kommande%20l%C3%A4s%C3%A5r.%3C%2Fp%3E%5Cn%3Cp%3EP%C3%A5%20v%C3%A5ren%20i%20%C3%A5rskurs%203%20finns%20ett%20utrymme%20p%C3%A5%2015%20hp%20valfria%20kurser.%3C%2Fp%3E%5Cn%3Cp%3E%3Cstrong%3EValbara%20masterprogram%20som%20leder%20till%20civilingenj%C3%B6rsexamen%20i%20Teknisk%20fysik%20%C3%A4r%3A%3C%2Fstrong%3E%3C%2Fp%3E%5Cn%3Cul%3E%5Cn%3Cli%3E%3Cstrong%3ETeknisk%20fysik%3C%2Fstrong%3E%3C%2Fli%3E%5Cn%3Cli%3E%3Cstrong%3EMatematik%3C%2Fstrong%3E%3Cbr%20%2F%3E%5Cnbeh%C3%B6righetsgivande%20kurser%3A%20SF1677%20%5C%22Analysens%20grunder%5C%22%207%2C5hp%20och%20SF1678%20%5C%22Grupper%20och%20ringar%5C%22%207%2C5hp%3C%2Fli%3E%5Cn%3Cli%3E%3Cstrong%3ETill%C3%A4mpad%20matematik%20och%20ber%C3%A4kningsmatematik%3C%2Fstrong%3E%3C%2Fli%3E%5Cn%3Cli%3E%3Cstrong%3ETeknisk%20mekanik%3C%2Fstrong%3E%3C%2Fli%3E%5Cn%3Cli%3E%3Cstrong%3EK%C3%A4rnenergi%3C%2Fstrong%3E%3C%2Fli%3E%5Cn%3Cli%3E%3Cstrong%3ECybers%C3%A4kerhet%3C%2Fstrong%3E%3Cbr%20%2F%3E%5Cnbeh%C3%B6righetsgivande%20kurser%3A%20DD2352%20Algoritmer%20och%20komplexitet%5C%22%207%2C5hp%20och%20SF1679%20%5C%22Diskret%20matematik%5C%22%207%2C5hp%3C%2Fli%3E%5Cn%3Cli%3E%3Cstrong%3EDatatologi%3C%2Fstrong%3E%3Cbr%20%2F%3E%5Cnbeh%C3%B6righetsgivande%20kurser%3A%20DD2352%20%5C%22Algoritmer%20och%20komplexitet%5C%22%207%2C5hp%2C%20SF1679%20%5C%22Diskret%20matematik%5C%22%207%2C5hp%20och%20DD1380%20%5C%22Javaprogrammering%20f%C3%B6r%20Python-programmerare%5C%22%201%2C5hp%3C%2Fli%3E%5Cn%3Cli%3E%3Cstrong%3EElekromagnetism%2C%20fusion%20och%20rymdteknik%3C%2Fstrong%3E%3C%2Fli%3E%5Cn%3Cli%3E%3Cstrong%3EFlyg-%20och%20rymdteknik%3C%2Fstrong%3E%3C%2Fli%3E%5Cn%3Cli%3E%3Cstrong%3EFordonsteknik%3C%2Fstrong%3E%3C%2Fli%3E%5Cn%3Cli%3E%3Cstrong%3EInformation%20och%20n%C3%A4tverksteknologi%3C%2Fstrong%3E%3Cbr%20%2F%3E%5Cnbeh%C3%B6righetsgivande%20kurs%3A%20EQ1120%20%5C%22Tidsdiskreta%20signaler%20och%20system%5C%22%206hp%3C%2Fli%3E%5Cn%3Cli%3E%3Cstrong%3ENanoteknik%3C%2Fstrong%3E%3C%2Fli%3E%5Cn%3Cli%3E%3Cstrong%3EMarina%20system%20(ej%20sp%C3%A5r%20Management)%3C%2Fstrong%3E%3C%2Fli%3E%5Cn%3Cli%3E%3Cstrong%3EMaskininl%C3%A4rning%3C%2Fstrong%3E%3C%2Fli%3E%5Cn%3Cli%3E%3Cstrong%3ESystemteknik%20och%20robotik%3C%2Fstrong%3E%3C%2Fli%3E%5Cn%3Cli%3E%3Cstrong%3EBiostatistik%20och%20datavetenskap%3C%2Fstrong%3E%3C%2Fli%3E%5Cn%3C%2Ful%3E%5Cn%3Cp%3E%26nbsp%3BOBS!%20De%20beh%C3%B6rightesgivande%20kurserna%20ska%20vara%20avslutade.%3C%2Fp%3E%22%2C%22conditionallyElectiveCoursesInfo%22%3A%22%3Cp%3EEn%20ska%20l%C3%A4sas.%3C%2Fp%3E%5Cn%3Cp%3EEF112X%20l%C3%A4ses%20%C3%A4ven%20av%20de%20som%20g%C3%B6r%20inom%20datalogi.%3C%2Fp%3E%22%7D%2C%7B%22yearNumber%22%3A4%2C%22courses%22%3A%5B%5D%2C%22freeTexts%22%3A%5B%5D%2C%22supplementaryInfo%22%3A%22%3Cp%3EUtbildningens%20tv%C3%A5%20sista%20%C3%A5r%20l%C3%A4ses%20inom%20ramen%20f%C3%B6r%20ett%20masterprogram.%3C%2Fp%3E%5Cn%3Cp%3EF%C3%B6r%20kurser%20inom%20%C3%A5rskurs%204%2C%20se%20l%C3%A4s%C3%A5rsplan%20f%C3%B6r%20%C3%A5rskurs%201%20inom%20det%20masterprogram%20du%20har%20valt.%3C%2Fp%3E%5Cn%3Cp%3EValbara%20masterprogram%20som%20leder%20till%20civilingenj%C3%B6rsexamen%20i%20Teknisk%20fysik%20%C3%A4r%3A%3C%2Fp%3E%5Cn%3Cp%3ETeknisk%20fysik%3C%2Fp%3E%5Cn%3Cp%3EMatematik%3C%2Fp%3E%5Cn%3Cp%3ETill%C3%A4mpad%20matematik%20och%20ber%C3%A4kningsmatematik%3C%2Fp%3E%5Cn%3Cp%3ETeknisk%20mekanik%3C%2Fp%3E%5Cn%3Cp%3EK%C3%A4rnenergiteknik%3C%2Fp%3E%5Cn%3Cp%3EDatalogi%3C%2Fp%3E%5Cn%3Cp%3EElektromagnetism%2C%20fusion%20och%20rymdteknik%3C%2Fp%3E%5Cn%3Cp%3EFlyg-%20och%20rymdteknik%3C%2Fp%3E%5Cn%3Cp%3EFordonsteknik%3C%2Fp%3E%5Cn%3Cp%3EInformation%20och%20n%C3%A4tverksteknologi%3C%2Fp%3E%5Cn%3Cp%3ENanoteknik%3C%2Fp%3E%5Cn%3Cp%3EMarina%20system%20(ej%20sp%C3%A5r%20Management)%3C%2Fp%3E%5Cn%3Cp%3EMaskininl%C3%A4rning%3C%2Fp%3E%5Cn%3Cp%3ESystemteknik%20och%20robotik%3C%2Fp%3E%5Cn%3Cp%3ECybers%C3%A4kerhet%3C%2Fp%3E%5Cn%3Cp%3EBiostatistik%20och%20datavetenskap%3C%2Fp%3E%22%7D%2C%7B%22yearNumber%22%3A5%2C%22courses%22%3A%5B%5D%2C%22freeTexts%22%3A%5B%5D%2C%22supplementaryInfo%22%3A%22%3Cp%3EUtbildningens%20tv%C3%A5%20sista%20%C3%A5r%20l%C3%A4ses%20inom%20ramen%20f%C3%B6r%20ett%20masterprogram.%3C%2Fp%3E%5Cn%3Cp%3EF%C3%B6r%20kurser%20inom%20%C3%A5rskurs%205%2C%20se%20l%C3%A4s%C3%A5rsplan%20f%C3%B6r%20%C3%A5rskurs%202%20inom%20det%20masterprogram%20du%20har%20valt.%3C%2Fp%3E%5Cn%3Cp%3EValbara%20masterprogram%20som%20leder%20till%20civilingenj%C3%B6rsexamen%20i%20Teknisk%20fysik%20%C3%A4r%3A%3C%2Fp%3E%5Cn%3Cp%3ETeknisk%20fysik%3C%2Fp%3E%5Cn%3Cp%3EMatematik%3C%2Fp%3E%5Cn%3Cp%3ETill%C3%A4mpad%20matematik%20och%20ber%C3%A4kningsmatematik%3C%2Fp%3E%5Cn%3Cp%3ETeknisk%20mekanik%3C%2Fp%3E%5Cn%3Cp%3EK%C3%A4rnenergiteknik%3C%2Fp%3E%5Cn%3Cp%3EDatalogi%3C%2Fp%3E%5Cn%3Cp%3EElektromagnetism%2C%20fusion%20och%20rymdteknik%3C%2Fp%3E%5Cn%3Cp%3EFlyg-%20och%20rymdteknik%3C%2Fp%3E%5Cn%3Cp%3EFordonsteknik%3C%2Fp%3E%5Cn%3Cp%3EInformation%20och%20n%C3%A4tverksteknologi%3C%2Fp%3E%5Cn%3Cp%3ENanoteknik%3C%2Fp%3E%5Cn%3Cp%3EMarina%20system%20(ej%20sp%C3%A5r%20Management)%3C%2Fp%3E%5Cn%3Cp%3EMaskininl%C3%A4rning%3C%2Fp%3E%5Cn%3Cp%3ESystemteknik%20och%20robotik%3C%2Fp%3E%22%7D%5D%7D%5D%2C%22errorType%22%3A%7B%22MISSING_ADMISSION%22%3A%22missing_admission%22%7D%2C%22error%22%3Anull%2C%22curriculumInfos%22%3A%5B%7B%22code%22%3A%22%22%2C%22specializationName%22%3Anull%2C%22isCommon%22%3Atrue%2C%22participations%22%3A%7B%22O%22%3A%5B%7B%22course%22%3A%7B%22courseCode%22%3A%22EI1320%22%2C%22title%22%3A%22Teoretisk%20elektroteknik%22%2C%22credits%22%3A9%2C%22formattedCredits%22%3A%229%2C0%20hp%22%2C%22educationalLevel%22%3A%22Grundniv%C3%A5%22%2C%22electiveCondition%22%3A%22O%22%2C%22status%22%3A%7B%22code%22%3A%22S3%22%2C%22nameSv%22%3A%22Komplett%22%2C%22nameEn%22%3A%22Complete%22%7D%7D%2C%22applicationCode%22%3A%2251986%22%2C%22term%22%3A%2220252%22%2C%22creditsPerPeriod%22%3A%5B0%2C6%2C3%2C0%2C0%2C0%5D%7D%2C%7B%22course%22%3A%7B%22courseCode%22%3A%22EL1000%22%2C%22title%22%3A%22Reglerteknik%2C%20allm%C3%A4n%20kurs%22%2C%22credits%22%3A6%2C%22formattedCredits%22%3A%226%2C0%20hp%22%2C%22educationalLevel%22%3A%22Grundniv%C3%A5%22%2C%22electiveCondition%22%3A%22O%22%2C%22status%22%3A%7B%22code%22%3A%22S3%22%2C%22nameSv%22%3A%22Komplett%22%2C%22nameEn%22%3A%22Complete%22%7D%7D%2C%22applicationCode%22%3A%2251987%22%2C%22term%22%3A%2220252%22%2C%22creditsPerPeriod%22%3A%5B0%2C6%2C0%2C0%2C0%2C0%5D%7D%2C%7B%22course%22%3A%7B%22courseCode%22%3A%22SG1218%22%2C%22title%22%3A%22Str%C3%B6mningsmekanik%22%2C%22credits%22%3A4%2C%22formattedCredits%22%3A%224%2C0%20hp%22%2C%22educationalLevel%22%3A%22Grundniv%C3%A5%22%2C%22electiveCondition%22%3A%22O%22%2C%22status%22%3A%7B%22code%22%3A%22S3%22%2C%22nameSv%22%3A%22Komplett%22%2C%22nameEn%22%3A%22Complete%22%7D%7D%2C%22applicationCode%22%3A%2251993%22%2C%22term%22%3A%2220252%22%2C%22creditsPerPeriod%22%3A%5B0%2C0%2C4%2C0%2C0%2C0%5D%7D%2C%7B%22course%22%3A%7B%22courseCode%22%3A%22SH1015%22%2C%22title%22%3A%22Till%C3%A4mpad%20modern%20fysik%22%2C%22credits%22%3A5%2C%22formattedCredits%22%3A%225%2C0%20hp%22%2C%22educationalLevel%22%3A%22Grundniv%C3%A5%22%2C%22electiveCondition%22%3A%22O%22%2C%22status%22%3A%7B%22code%22%3A%22S3%22%2C%22nameSv%22%3A%22Komplett%22%2C%22nameEn%22%3A%22Complete%22%7D%7D%2C%22applicationCode%22%3A%2251383%22%2C%22term%22%3A%2220252%22%2C%22creditsPerPeriod%22%3A%5B0%2C3%2C2%2C0%2C0%2C0%5D%7D%2C%7B%22course%22%3A%7B%22courseCode%22%3A%22SI1336%22%2C%22title%22%3A%22Simulering%20och%20modellering%22%2C%22credits%22%3A6%2C%22formattedCredits%22%3A%226%2C0%20hp%22%2C%22educationalLevel%22%3A%22Grundniv%C3%A5%22%2C%22electiveCondition%22%3A%22O%22%2C%22status%22%3A%7B%22code%22%3A%22S3%22%2C%22nameSv%22%3A%22Komplett%22%2C%22nameEn%22%3A%22Complete%22%7D%7D%2C%22applicationCode%22%3A%2250998%22%2C%22term%22%3A%2220252%22%2C%22creditsPerPeriod%22%3A%5B0%2C0%2C6%2C0%2C0%2C0%5D%7D%5D%2C%22V%22%3A%5B%7B%22course%22%3A%7B%22courseCode%22%3A%22AK2014%22%2C%22title%22%3A%22Beslutsteori%22%2C%22credits%22%3A7.5%2C%22formattedCredits%22%3A%227%2C5%20hp%22%2C%22educationalLevel%22%3A%22Avancerad%20niv%C3%A5%22%2C%22electiveCondition%22%3A%22V%22%2C%22status%22%3A%7B%22code%22%3A%22S3%22%2C%22nameSv%22%3A%22Komplett%22%2C%22nameEn%22%3A%22Complete%22%7D%7D%2C%22applicationCode%22%3A%2261505%22%2C%22term%22%3A%2220261%22%2C%22creditsPerPeriod%22%3A%5B0%2C0%2C0%2C7.5%2C0%2C0%5D%7D%2C%7B%22course%22%3A%7B%22courseCode%22%3A%22DD1380%22%2C%22title%22%3A%22Javaprogrammering%20f%C3%B6r%20Pythonprogrammerare%22%2C%22credits%22%3A1.5%2C%22formattedCredits%22%3A%221%2C5%20hp%22%2C%22educationalLevel%22%3A%22Grundniv%C3%A5%22%2C%22electiveCondition%22%3A%22V%22%2C%22status%22%3A%7B%22code%22%3A%22S3%22%2C%22nameSv%22%3A%22Komplett%22%2C%22nameEn%22%3A%22Complete%22%7D%7D%2C%22applicationCode%22%3A%2260848%22%2C%22term%22%3A%2220261%22%2C%22creditsPerPeriod%22%3A%5B0%2C0%2C0%2C1.5%2C0%2C0%5D%7D%2C%7B%22course%22%3A%7B%22courseCode%22%3A%22DD2352%22%2C%22title%22%3A%22Algoritmer%20och%20komplexitet%22%2C%22credits%22%3A7.5%2C%22formattedCredits%22%3A%227%2C5%20hp%22%2C%22educationalLevel%22%3A%22Avancerad%20niv%C3%A5%22%2C%22electiveCondition%22%3A%22V%22%2C%22status%22%3A%7B%22code%22%3A%22S3%22%2C%22nameSv%22%3A%22Komplett%22%2C%22nameEn%22%3A%22Complete%22%7D%7D%2C%22applicationCode%22%3A%2260319%22%2C%22term%22%3A%2220261%22%2C%22creditsPerPeriod%22%3A%5B0%2C0%2C0%2C3%2C4.5%2C0%5D%7D%2C%7B%22course%22%3A%7B%22courseCode%22%3A%22DD2421%22%2C%22title%22%3A%22Maskininl%C3%A4rning%22%2C%22credits%22%3A7.5%2C%22formattedCredits%22%3A%227%2C5%20hp%22%2C%22educationalLevel%22%3A%22Avancerad%20niv%C3%A5%22%2C%22electiveCondition%22%3A%22V%22%2C%22status%22%3A%7B%22code%22%3A%22S3%22%2C%22nameSv%22%3A%22Komplett%22%2C%22nameEn%22%3A%22Complete%22%7D%7D%2C%22applicationCode%22%3A%2260242%22%2C%22term%22%3A%2220261%22%2C%22creditsPerPeriod%22%3A%5B0%2C0%2C0%2C7.5%2C0%2C0%5D%7D%2C%7B%22course%22%3A%7B%22courseCode%22%3A%22EQ1120%22%2C%22title%22%3A%22Tidsdiskreta%20signaler%20och%20system%22%2C%22credits%22%3A6%2C%22formattedCredits%22%3A%226%2C0%20hp%22%2C%22educationalLevel%22%3A%22Grundniv%C3%A5%22%2C%22electiveCondition%22%3A%22V%22%2C%22status%22%3A%7B%22code%22%3A%22S3%22%2C%22nameSv%22%3A%22Komplett%22%2C%22nameEn%22%3A%22Complete%22%7D%7D%2C%22applicationCode%22%3A%2260343%22%2C%22term%22%3A%2220261%22%2C%22creditsPerPeriod%22%3A%5B0%2C0%2C0%2C0%2C6%2C0%5D%7D%2C%7B%22course%22%3A%7B%22courseCode%22%3A%22IL2240%22%2C%22title%22%3A%22Halvledarkomponenter%20f%C3%B6r%20integrerade%20kretsar%22%2C%22credits%22%3A7.5%2C%22formattedCredits%22%3A%227%2C5%20hp%22%2C%22educationalLevel%22%3A%22Avancerad%20niv%C3%A5%22%2C%22electiveCondition%22%3A%22V%22%2C%22status%22%3A%7B%22code%22%3A%22S3%22%2C%22nameSv%22%3A%22Komplett%22%2C%22nameEn%22%3A%22Complete%22%7D%7D%2C%22applicationCode%22%3A%2260609%22%2C%22term%22%3A%2220261%22%2C%22creditsPerPeriod%22%3A%5B0%2C0%2C0%2C7.5%2C0%2C0%5D%7D%2C%7B%22course%22%3A%7B%22courseCode%22%3A%22MH1023%22%2C%22title%22%3A%22Praktiskt%20j%C3%A4mst%C3%A4lldhets-%20och%20m%C3%A5ngfaldsarbete%20i%20vetenskapliga%2C%20tekniska%20och%20industriella%20milj%C3%B6er%22%2C%22credits%22%3A6%2C%22formattedCredits%22%3A%226%2C0%20hp%22%2C%22educationalLevel%22%3A%22Grundniv%C3%A5%22%2C%22electiveCondition%22%3A%22V%22%2C%22status%22%3A%7B%22code%22%3A%22S3%22%2C%22nameSv%22%3A%22Komplett%22%2C%22nameEn%22%3A%22Complete%22%7D%7D%2C%22applicationCode%22%3A%2261019%22%2C%22term%22%3A%2220261%22%2C%22creditsPerPeriod%22%3A%5B0%2C0%2C0%2C3%2C3%2C0%5D%7D%2C%7B%22course%22%3A%7B%22courseCode%22%3A%22SF1677%22%2C%22title%22%3A%22Analysens%20grunder%22%2C%22credits%22%3A7.5%2C%22formattedCredits%22%3A%227%2C5%20hp%22%2C%22educationalLevel%22%3A%22Grundniv%C3%A5%22%2C%22electiveCondition%22%3A%22V%22%2C%22status%22%3A%7B%22code%22%3A%22S3%22%2C%22nameSv%22%3A%22Komplett%22%2C%22nameEn%22%3A%22Complete%22%7D%7D%2C%22applicationCode%22%3A%2261256%22%2C%22term%22%3A%2220261%22%2C%22creditsPerPeriod%22%3A%5B0%2C0%2C0%2C3.7%2C3.8%2C0%5D%7D%2C%7B%22course%22%3A%7B%22courseCode%22%3A%22SF1678%22%2C%22title%22%3A%22Grupper%20och%20ringar%22%2C%22credits%22%3A7.5%2C%22formattedCredits%22%3A%227%2C5%20hp%22%2C%22educationalLevel%22%3A%22Grundniv%C3%A5%22%2C%22electiveCondition%22%3A%22V%22%2C%22status%22%3A%7B%22code%22%3A%22S3%22%2C%22nameSv%22%3A%22Komplett%22%2C%22nameEn%22%3A%22Complete%22%7D%7D%2C%22applicationCode%22%3A%2261255%22%2C%22term%22%3A%2220261%22%2C%22creditsPerPeriod%22%3A%5B0%2C0%2C0%2C3.7%2C3.8%2C0%5D%7D%2C%7B%22course%22%3A%7B%22courseCode%22%3A%22SF1679%22%2C%22title%22%3A%22Diskret%20matematik%22%2C%22credits%22%3A7.5%2C%22formattedCredits%22%3A%227%2C5%20hp%22%2C%22educationalLevel%22%3A%22Grundniv%C3%A5%22%2C%22electiveCondition%22%3A%22V%22%2C%22status%22%3A%7B%22code%22%3A%22S3%22%2C%22nameSv%22%3A%22Komplett%22%2C%22nameEn%22%3A%22Complete%22%7D%7D%2C%22applicationCode%22%3A%2260882%22%2C%22term%22%3A%2220261%22%2C%22creditsPerPeriod%22%3A%5B0%2C0%2C0%2C7.5%2C0%2C0%5D%7D%2C%7B%22course%22%3A%7B%22courseCode%22%3A%22SF1691%22%2C%22title%22%3A%22Komplex%20analys%22%2C%22credits%22%3A7.5%2C%22formattedCredits%22%3A%227%2C5%20hp%22%2C%22educationalLevel%22%3A%22Grundniv%C3%A5%22%2C%22electiveCondition%22%3A%22V%22%2C%22status%22%3A%7B%22code%22%3A%22S3%22%2C%22nameSv%22%3A%22Komplett%22%2C%22nameEn%22%3A%22Complete%22%7D%7D%2C%22applicationCode%22%3A%2260883%22%2C%22term%22%3A%2220261%22%2C%22creditsPerPeriod%22%3A%5B0%2C0%2C0%2C3.7%2C3.8%2C0%5D%7D%2C%7B%22course%22%3A%7B%22courseCode%22%3A%22SF1861%22%2C%22title%22%3A%22Optimeringsl%C3%A4ra%22%2C%22credits%22%3A6%2C%22formattedCredits%22%3A%226%2C0%20hp%22%2C%22educationalLevel%22%3A%22Grundniv%C3%A5%22%2C%22electiveCondition%22%3A%22V%22%2C%22status%22%3A%7B%22code%22%3A%22S3%22%2C%22nameSv%22%3A%22Komplett%22%2C%22nameEn%22%3A%22Complete%22%7D%7D%2C%22applicationCode%22%3A%2260884%22%2C%22term%22%3A%2220261%22%2C%22creditsPerPeriod%22%3A%5B0%2C0%2C0%2C0%2C6%2C0%5D%7D%2C%7B%22course%22%3A%7B%22courseCode%22%3A%22SF1904%22%2C%22title%22%3A%22Markovprocesser%2C%20grundkurs%22%2C%22credits%22%3A3%2C%22formattedCredits%22%3A%223%2C0%20hp%22%2C%22educationalLevel%22%3A%22Grundniv%C3%A5%22%2C%22electiveCondition%22%3A%22V%22%2C%22status%22%3A%7B%22code%22%3A%22S3%22%2C%22nameSv%22%3A%22Komplett%22%2C%22nameEn%22%3A%22Complete%22%7D%7D%2C%22applicationCode%22%3A%2261264%22%2C%22term%22%3A%2220261%22%2C%22creditsPerPeriod%22%3A%5B0%2C0%2C0%2C0%2C3%2C0%5D%7D%2C%7B%22course%22%3A%7B%22courseCode%22%3A%22SF2701%22%2C%22title%22%3A%22Finansiell%20matematik%2C%20grundkurs%22%2C%22credits%22%3A7.5%2C%22formattedCredits%22%3A%227%2C5%20hp%22%2C%22educationalLevel%22%3A%22Avancerad%20niv%C3%A5%22%2C%22electiveCondition%22%3A%22V%22%2C%22status%22%3A%7B%22code%22%3A%22S3%22%2C%22nameSv%22%3A%22Komplett%22%2C%22nameEn%22%3A%22Complete%22%7D%7D%2C%22applicationCode%22%3A%2261253%22%2C%22term%22%3A%2220261%22%2C%22creditsPerPeriod%22%3A%5B0%2C0%2C0%2C0%2C7.5%2C0%5D%7D%2C%7B%22course%22%3A%7B%22courseCode%22%3A%22SF2930%22%2C%22title%22%3A%22Regressionsanalys%22%2C%22credits%22%3A7.5%2C%22formattedCredits%22%3A%227%2C5%20hp%22%2C%22educationalLevel%22%3A%22Avancerad%20niv%C3%A5%22%2C%22electiveCondition%22%3A%22V%22%2C%22status%22%3A%7B%22code%22%3A%22S3%22%2C%22nameSv%22%3A%22Komplett%22%2C%22nameEn%22%3A%22Complete%22%7D%7D%2C%22applicationCode%22%3A%2260237%22%2C%22term%22%3A%2220261%22%2C%22creditsPerPeriod%22%3A%5B0%2C0%2C0%2C7.5%2C0%2C0%5D%7D%2C%7B%22course%22%3A%7B%22courseCode%22%3A%22SH2404%22%2C%22title%22%3A%22Astrofysik%22%2C%22credits%22%3A7.5%2C%22formattedCredits%22%3A%227%2C5%20hp%22%2C%22educationalLevel%22%3A%22Avancerad%20niv%C3%A5%22%2C%22electiveCondition%22%3A%22V%22%2C%22status%22%3A%7B%22code%22%3A%22S3%22%2C%22nameSv%22%3A%22Komplett%22%2C%22nameEn%22%3A%22Complete%22%7D%7D%2C%22applicationCode%22%3A%2261094%22%2C%22term%22%3A%2220261%22%2C%22creditsPerPeriod%22%3A%5B0%2C0%2C0%2C0%2C7.5%2C0%5D%7D%2C%7B%22course%22%3A%7B%22courseCode%22%3A%22SI1142%22%2C%22title%22%3A%22Fysikens%20matematiska%20metoder%2C%20till%C3%A4ggskurs%22%2C%22credits%22%3A3%2C%22formattedCredits%22%3A%223%2C0%20hp%22%2C%22educationalLevel%22%3A%22Grundniv%C3%A5%22%2C%22electiveCondition%22%3A%22V%22%2C%22status%22%3A%7B%22code%22%3A%22S3%22%2C%22nameSv%22%3A%22Komplett%22%2C%22nameEn%22%3A%22Complete%22%7D%7D%2C%22applicationCode%22%3A%2260123%22%2C%22term%22%3A%2220261%22%2C%22creditsPerPeriod%22%3A%5B0%2C0%2C0%2C0%2C3%2C0%5D%7D%2C%7B%22course%22%3A%7B%22courseCode%22%3A%22SI1162%22%2C%22title%22%3A%22Statistisk%20fysik%22%2C%22credits%22%3A7.5%2C%22formattedCredits%22%3A%227%2C5%20hp%22%2C%22educationalLevel%22%3A%22Grundniv%C3%A5%22%2C%22electiveCondition%22%3A%22V%22%2C%22status%22%3A%7B%22code%22%3A%22S3%22%2C%22nameSv%22%3A%22Komplett%22%2C%22nameEn%22%3A%22Complete%22%7D%7D%2C%22applicationCode%22%3A%2260163%22%2C%22term%22%3A%2220261%22%2C%22creditsPerPeriod%22%3A%5B0%2C0%2C0%2C7.5%2C0%2C0%5D%7D%2C%7B%22course%22%3A%7B%22courseCode%22%3A%22SI2360%22%2C%22title%22%3A%22Analytisk%20mekanik%20och%20klassisk%20f%C3%A4ltteori%22%2C%22credits%22%3A7.5%2C%22formattedCredits%22%3A%227%2C5%20hp%22%2C%22educationalLevel%22%3A%22Avancerad%20niv%C3%A5%22%2C%22electiveCondition%22%3A%22V%22%2C%22status%22%3A%7B%22code%22%3A%22S3%22%2C%22nameSv%22%3A%22Komplett%22%2C%22nameEn%22%3A%22Complete%22%7D%7D%2C%22applicationCode%22%3A%2260925%22%2C%22term%22%3A%2220261%22%2C%22creditsPerPeriod%22%3A%5B0%2C0%2C0%2C0%2C7.5%2C0%5D%7D%2C%7B%22course%22%3A%7B%22courseCode%22%3A%22SK2712%22%2C%22title%22%3A%22Milj%C3%B6fysik%22%2C%22credits%22%3A7.5%2C%22formattedCredits%22%3A%227%2C5%20hp%22%2C%22educationalLevel%22%3A%22Avancerad%20niv%C3%A5%22%2C%22electiveCondition%22%3A%22V%22%2C%22status%22%3A%7B%22code%22%3A%22S3%22%2C%22nameSv%22%3A%22Komplett%22%2C%22nameEn%22%3A%22Complete%22%7D%7D%2C%22applicationCode%22%3A%2260795%22%2C%22term%22%3A%2220261%22%2C%22creditsPerPeriod%22%3A%5B0%2C0%2C0%2C0%2C7.5%2C0%5D%7D%5D%2C%22VV%22%3A%5B%7B%22course%22%3A%7B%22courseCode%22%3A%22EF112X%22%2C%22title%22%3A%22Examensarbete%20inom%20elektroteknik%2C%20grundniv%C3%A5%22%2C%22credits%22%3A15%2C%22formattedCredits%22%3A%2215%2C0%20hp%22%2C%22educationalLevel%22%3A%22Grundniv%C3%A5%22%2C%22electiveCondition%22%3A%22VV%22%2C%22status%22%3A%7B%22code%22%3A%22S3%22%2C%22nameSv%22%3A%22Komplett%22%2C%22nameEn%22%3A%22Complete%22%7D%7D%2C%22applicationCode%22%3A%2260889%22%2C%22term%22%3A%2220261%22%2C%22creditsPerPeriod%22%3A%5B0%2C0%2C0%2C7.5%2C7.5%2C0%5D%7D%2C%7B%22course%22%3A%7B%22courseCode%22%3A%22SA114X%22%2C%22title%22%3A%22Examensarbete%20inom%20teknisk%20fysik%2C%20grundniv%C3%A5%22%2C%22credits%22%3A15%2C%22formattedCredits%22%3A%2215%2C0%20hp%22%2C%22educationalLevel%22%3A%22Grundniv%C3%A5%22%2C%22electiveCondition%22%3A%22VV%22%2C%22status%22%3A%7B%22code%22%3A%22S3%22%2C%22nameSv%22%3A%22Komplett%22%2C%22nameEn%22%3A%22Complete%22%7D%7D%2C%22applicationCode%22%3A%2261514%22%2C%22term%22%3A%2220261%22%2C%22creditsPerPeriod%22%3A%5B0%2C0%2C0%2C7.5%2C7.5%2C0%5D%7D%5D%7D%2C%22supplementaryInformation%22%3A%22%3Cp%3EBaserat%20p%C3%A5%20l%C3%A4s%C3%A5rsplan%20beslutad%20f%C3%B6r%20l%C3%A4s%C3%A5ret%202024%2F2025.%20%C3%84ndringar%20kan%20ske%20f%C3%B6r%20kommande%20l%C3%A4s%C3%A5r.%3C%2Fp%3E%5Cn%3Cp%3EP%C3%A5%20v%C3%A5ren%20i%20%C3%A5rskurs%203%20finns%20ett%20utrymme%20p%C3%A5%2015%20hp%20valfria%20kurser.%3C%2Fp%3E%5Cn%3Cp%3E%3Cstrong%3EValbara%20masterprogram%20som%20leder%20till%20civilingenj%C3%B6rsexamen%20i%20Teknisk%20fysik%20%C3%A4r%3A%3C%2Fstrong%3E%3C%2Fp%3E%5Cn%3Cul%3E%5Cn%3Cli%3E%3Cstrong%3ETeknisk%20fysik%3C%2Fstrong%3E%3C%2Fli%3E%5Cn%3Cli%3E%3Cstrong%3EMatematik%3C%2Fstrong%3E%3Cbr%20%2F%3E%5Cnbeh%C3%B6righetsgivande%20kurser%3A%20SF1677%20%5C%22Analysens%20grunder%5C%22%207%2C5hp%20och%20SF1678%20%5C%22Grupper%20och%20ringar%5C%22%207%2C5hp%3C%2Fli%3E%5Cn%3Cli%3E%3Cstrong%3ETill%C3%A4mpad%20matematik%20och%20ber%C3%A4kningsmatematik%3C%2Fstrong%3E%3C%2Fli%3E%5Cn%3Cli%3E%3Cstrong%3ETeknisk%20mekanik%3C%2Fstrong%3E%3C%2Fli%3E%5Cn%3Cli%3E%3Cstrong%3EK%C3%A4rnenergi%3C%2Fstrong%3E%3C%2Fli%3E%5Cn%3Cli%3E%3Cstrong%3ECybers%C3%A4kerhet%3C%2Fstrong%3E%3Cbr%20%2F%3E%5Cnbeh%C3%B6righetsgivande%20kurser%3A%20DD2352%20Algoritmer%20och%20komplexitet%5C%22%207%2C5hp%20och%20SF1679%20%5C%22Diskret%20matematik%5C%22%207%2C5hp%3C%2Fli%3E%5Cn%3Cli%3E%3Cstrong%3EDatatologi%3C%2Fstrong%3E%3Cbr%20%2F%3E%5Cnbeh%C3%B6righetsgivande%20kurser%3A%20DD2352%20%5C%22Algoritmer%20och%20komplexitet%5C%22%207%2C5hp%2C%20SF1679%20%5C%22Diskret%20matematik%5C%22%207%2C5hp%20och%20DD1380%20%5C%22Javaprogrammering%20f%C3%B6r%20Python-programmerare%5C%22%201%2C5hp%3C%2Fli%3E%5Cn%3Cli%3E%3Cstrong%3EElekromagnetism%2C%20fusion%20och%20rymdteknik%3C%2Fstrong%3E%3C%2Fli%3E%5Cn%3Cli%3E%3Cstrong%3EFlyg-%20och%20rymdteknik%3C%2Fstrong%3E%3C%2Fli%3E%5Cn%3Cli%3E%3Cstrong%3EFordonsteknik%3C%2Fstrong%3E%3C%2Fli%3E%5Cn%3Cli%3E%3Cstrong%3EInformation%20och%20n%C3%A4tverksteknologi%3C%2Fstrong%3E%3Cbr%20%2F%3E%5Cnbeh%C3%B6righetsgivande%20kurs%3A%20EQ1120%20%5C%22Tidsdiskreta%20signaler%20och%20system%5C%22%206hp%3C%2Fli%3E%5Cn%3Cli%3E%3Cstrong%3ENanoteknik%3C%2Fstrong%3E%3C%2Fli%3E%5Cn%3Cli%3E%3Cstrong%3EMarina%20system%20(ej%20sp%C3%A5r%20Management)%3C%2Fstrong%3E%3C%2Fli%3E%5Cn%3Cli%3E%3Cstrong%3EMaskininl%C3%A4rning%3C%2Fstrong%3E%3C%2Fli%3E%5Cn%3Cli%3E%3Cstrong%3ESystemteknik%20och%20robotik%3C%2Fstrong%3E%3C%2Fli%3E%5Cn%3Cli%3E%3Cstrong%3EBiostatistik%20och%20datavetenskap%3C%2Fstrong%3E%3C%2Fli%3E%5Cn%3C%2Ful%3E%5Cn%3Cp%3E%26nbsp%3BOBS!%20De%20beh%C3%B6rightesgivande%20kurserna%20ska%20vara%20avslutade.%3C%2Fp%3E%22%2C%22conditionallyElectiveCoursesInformation%22%3A%22%3Cp%3EEn%20ska%20l%C3%A4sas.%3C%2Fp%3E%5Cn%3Cp%3EEF112X%20l%C3%A4ses%20%C3%A4ven%20av%20de%20som%20g%C3%B6r%20inom%20datalogi.%3C%2Fp%3E%22%2C%22isFirstSpec%22%3Afalse%2C%22hasInfo%22%3Atrue%2C%22freeTexts%22%3A%5B%5D%7D%5D%2C%22lengthInStudyYears%22%3A5%2C%22thisHostBaseUrl%22%3Anull%7D";</script>
+
+<!---->
+
+  <div id="app"></div>
+    </div>
+  </div>
+  <!--indexOff: all-->
+  <!-- add "scroll-to-top" button when scrolled down -->
+  <div id="back-to-top" role="link" aria-label="Till sidans topp"></div>
+  <footer class="kth-footer student-web">
+      <div class="kth-footer__content">
+              
+  
+  
+  
+  
+    <div class="columnSplitterWrapper" data-cid="1.1066523" lang="sv">
+      
+      <div class="columnSplitter  using4Columns ">
+        <div class="col c1">
+          
+  
+  
+  
+  
+    <div class="block list links" data-cid="1.1066524" lang="sv">
+      <h2>Studentwebben</h2>
+      
+      <ul>
+        <li><a href="/student/studier">Studier</a></li>
+        <li><a href="/student/stod">Stöd och vägledning</a></li>
+        <li><a href="/student/it">IT och digitala tjänster</a></li>
+        <li><a href="/student/kontakt">Kontakt</a></li>
+      </ul>
+    </div>
+  
+  
+  
+        </div>
+        <div class="col c2">
+          
+  
+  
+  
+  
+    <div class="block list links" data-cid="1.1066531" lang="sv">
+      <h2>Tjänster</h2>
+      
+      <ul>
+        <li><a href="/student/studier/schema">Schema</a></li>
+        <li><a href="https://canvas.kth.se/">Canvas</a></li>
+        <li><a href="http://webmail.kth.se">Webbmejl</a></li>
+        <li><a href="/student/it/studenttjanster/personligamenyn">Personliga menyn</a></li>
+        <li><a href="https://www.student.ladok.se/student/app/studentwebb/">Ladok för studenter</a></li>
+      </ul>
+    </div>
+  
+  
+  
+        </div>
+        <div class="col c3">
+          
+  
+  
+  
+  
+    <div class="block list links" data-cid="1.1066534" lang="sv">
+      <h2>Kontakt</h2>
+      
+      <ul>
+        <li><a href="/student/kontakt/kontaktuppgifter/kontakta-utbildningsprogram-1.1170401">Kontakta utbildningsprogram</a></li>
+        <li><a href="/student/kontakt/kontaktuppgifter/kontakta-kurs-1.1171899">Kontakta kurs</a></li>
+        <li><a href="/student/it/contact">IT-support</a></li>
+        <li><a href="/student/kontakt/campus/kth-entre">KTH Entré</a></li>
+        <li><a href="/student/kontakt/campus/kth-biblioteket-1.2479">KTH Biblioteket</a></li>
+      </ul>
+    </div>
+  
+  
+  
+        </div>
+        <div class="col c4">
+          
+  
+  
+  
+  
+    <article class="block teaser top white" data-cid="1.1083631" lang="sv">
+      
+      <div class="teaserBody   ">
+        
+        
+        <div class="lead">
+          
+          
+        
+          
+          <p><strong>KTH</strong><br> <em>100 44 Stockholm<br> +46 8 790 60 00<br>
+        
+      
+        
+          
+  
+  
+  
+  
+    <a class="block link" data-cid="1.1083633" lang="sv" href="mailto:info@kth.se">info@kth.se</a>
+  
+  
+  
+          
+        
+      
+        
+          
+          </em><br> &nbsp;</p>
+        
+      
+        </div>
+        
+      </div>
+    </article>
+  
+  
+  
+        </div>
+      </div>
+    </div>
+  
+  
+  
+      </div>
+  </footer>
+  <!--indexOn: all-->  <script src="/student/kurser/static/app.js?v=2.0.0-20260427.1_59b0"></script>
+</body>
+
+</html>

--- a/tests/fixtures/program_CTFYS_20242_arskurs3.html
+++ b/tests/fixtures/program_CTFYS_20242_arskurs3.html
@@ -1,0 +1,681 @@
+<!DOCTYPE html>
+<html lang="sv">
+
+<head>
+  <title>Civilingenjörsutbildning i teknisk fysik (CTFYS), Utbildningsplan kull HT2024, Årskurs 3 | KTH</title>
+  <meta charset="utf-8">
+  <meta http-equiv="X-UA-Compatible" content="IE=edge">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <meta name="description" content="">
+  <link rel="shortcut icon" id="favicon" href="/student/kurser/static/icon/favicon">
+
+
+  
+  
+  
+
+  <link href="/student/kurser/static/kth-style/css/kth-bootstrap.css?v=2.0.0-20260427.1_59b0" media="screen" rel="stylesheet">
+<link href="/student/kurser/assets/fonts.css?v=2.0.0-20260427.1_59b0" media="screen" rel="stylesheet">
+<link href="/student/kurser/static/app.css?v=2.0.0-20260427.1_59b0" media="screen" rel="stylesheet">
+
+    
+
+
+
+
+  <!-- Begin JavaScript contentId-1_1137647 -->
+  <script>var klaroConfig = {
+    testing: false,
+  acceptAll: true,
+  styling: {
+      theme: [],
+  },
+  htmlTexts: false,
+  groupByPurpose: false,
+  storageMethod: 'cookie',
+  cookieDomain: 'kth.se',
+  cookieExpiresAfterDays: 30,
+  hideDeclineAll: false,
+  translations: {
+      sv: {
+          service: {
+            disableAll: {
+              description: 'Använd detta reglage för att tillåta alla tjänster eller endast nödvändiga.',
+              title: 'Ändra för alla tjänster',
+            },
+          },
+          consentModal: {
+            description:
+              'Här kan du se och anpassa vilken information vi samlar om dig.',
+          },
+          privacyPolicy: {
+              name: 'kakor',
+              text: 'Läs mer om hur vi hanterar {privacyPolicy}.',
+          },
+          privacyPolicyUrl: 'https://www.kth.se/gemensamt/om-kakor-cookies-pa-kth-s-webbplats-1.844',
+          consentNotice: {
+              title: '',
+              testing: 'Observera att Klaro körs i testläge',
+              description: 'Denna webbplats använder tjänster som kan lagra information om dig och hur du använder denna webbplats. Vissa tjänster är nödvändiga för att webbplatsen ska fungera och andra är valbara.',
+              learnMore: 'Hantera valbara tjänster',
+          },
+          decline: 'Tillåt bara nödvändiga tjänster',
+          ok: 'Tillåt alla tjänster',
+          purposeItem: {
+              service: 'Tjänster'
+          },
+            contextualConsent:{
+                acceptAlways: 'Alltid',
+                acceptOnce: 'Ja',
+                description: 'Du har tidigare nekat visning av innehåll av typen "{title}". Vill du visa innehållet?',
+          }
+      },
+      en: {
+          service: {
+            disableAll: {
+              description: 'Use this slider to allow all cookies or only necessary.',
+              title: 'Change for all services',
+            },
+          },
+        consentModal: {
+            description:
+              'Here you can assess and customise the services we use on this website.',
+          },
+          privacyPolicy: {
+              name: 'cookies',
+              text: 'Find out more about our usage of {privacyPolicy}.',
+          },
+          privacyPolicyUrl: 'https://www.kth.se/en/gemensamt/om-kakor-cookies-pa-kth-s-webbplats-1.844',
+          consentNotice: {
+              title: '',
+              testing: 'Please note that Klaro is currently running in test mode',
+              description: 'This website uses services that may store information about you and how you use the website. Some services are necessary for the website to work, and others are optional.',
+              learnMore: 'Manage services',
+          },
+          decline: 'Accept only necessary services',
+          ok: 'Accept all services',
+          purposeItem: {
+              service: 'Services'
+          },
+            contextualConsent:{
+                acceptAlways: 'Always',
+                acceptOnce: 'Yes',
+                description: 'You have previously denied the display of content of the type "{title}". Do you want to show content?',
+          }
+      }
+  },
+  services: [
+      {
+          name: "required-consent",
+          default: true,
+          contextualConsentOnly: false,
+          required: true,
+          translations: {
+              zz: {
+                  title: 'Required Services',
+                  description: 'These services are necessary for the site to function and cannot be turned off. They are usually used when you utilise a function on the website that needs an answer, such as setting cookies, logging in, or filling in a form.'
+              },
+              sv: {
+                  title: 'Nödvändiga tjänster',
+                  description: 'Dessa tjänster är nödvändiga för att webbplatsen ska fungera och kan inte stängas av. De används främst när du nyttjar en funktion på webbplatsen som behöver ett svar, exempelvis ställer in kakor, loggar in eller fyller i formulär.'
+              },
+          },
+      },
+      {
+          name: "media-consent",
+          default: false,
+          translations: {
+              zz: {
+                  title: 'External media',
+                  description: 'Media on the site embedded from external providers like Youtube, Vimeo and Kaltura. When these are played, the providers may use cookies and local storage.'
+              },
+              sv: {
+                  title: 'Extern media',
+                  description: 'Inbäddad media från externa leverantörer som Youtube, Vimeo och Kaltura. När media spelas upp kan leverantörerna använda sig av kakor och lokal lagring.'
+              },
+          },
+      },
+      {
+        name: "service-consent",
+        default: false,
+        translations: {
+          zz: {
+            title: 'External Services',
+            description: 'Embedded services by external providers such as forms, maps, chat applications et c. When these are loaded, the providers may use cookies and local storage.'
+          },
+          sv: {
+            title: 'Externa tjänster',
+            description: 'Inbäddade tjänster från externa leverantörer såsom formulär, kartor, chat-funktion et c. När tjänsterna laddas in kan leverantörerna använda sig av kakor och lokal lagring.'
+          },
+        },
+      },
+      {
+          name: "analytics-consent",
+          default: false,
+          translations: {
+              zz: {
+                  title: 'Analytics and Tracking',
+                  description: 'The website uses Matomo to evaluate and improve the website content, experience and structure. The information collected is anonymised and only stored at KTH servers.'
+              },
+              sv: {
+                  title: 'Analys och spårning',
+                  description: 'Webbplatsen använder Matomo för att utvärdera och förbättra webbplatsens innehåll, upplevelse och struktur. Insamlandet av informationen anonymiseras och lagras enbart på KTH-servrar.'
+              },
+          },
+      },
+      {
+        name: "marketing-consent",
+        default: false,
+        translations: {
+            zz: {
+                title: 'Marketing',
+                description: 'The website contains pages that, via cookies, communicate with advertising services and social media.'
+            },
+            sv: {
+                title: 'Marknadsföring',
+                description: 'På webbplatsen förekommer sidor som via kakor kommunicerar med annonseringstjänster och sociala medier.'
+            },
+        },
+    }
+    
+  ]
+}</script>
+  
+  
+  <!-- End JavaScript contentId-1_1137647 -->
+
+
+
+    
+
+  
+  
+  
+  <script src="/student/kurser/static/kth-style/js/klaro-no-css.js?v=2.0.0-20260427.1_59b0"></script>
+<script src="/student/kurser/static/vendor.js?v=2.0.0-20260427.1_59b0"></script>
+<script src="/student/kurser/static/browserConfig?v=2.0.0-20260427.1_59b0"></script>
+<script src="/student/kurser/static/kth-style/js/backtotop.js?v=2.0.0-20260427.1_59b0"></script>
+
+  <script src="https://www.kth.se/social/toolbar/widget.js"></script>
+
+</head>
+
+<body>
+  <a class="skipToMainContent" href="#mainContent" tabindex="1">Hoppa till huvudinnehållet</a>
+  <!--indexOff: all-->
+  <header class="kth-header student-web">
+    <div class="kth-header__container">
+      <a href="/student" class="kth-logotype">
+        <figure>
+          <img class="blue" alt="Till KTH:s startsida" width="64" height="64" src="/student/kurser/assets/logotype/logotype-blue.svg">
+        </figure>
+      </a>      
+  
+  
+  
+  
+  
+    <nav class="kth-mega-menu" aria-label="Huvudmeny" data-ajax-path="/cm/1.1066510?l=sv&amp;contentIdPath=/2.75593/1.1066510/&amp;target=">
+      <ul>
+        
+          <li><button data-id="1.1066571" class="kth-menu-item dropdown">
+              <span>
+                Studier
+              </span>
+            </button>
+            <dialog class="kth-menu-panel">
+              <div class="kth-menu-panel__container">
+                <div class="kth-menu-panel__header">
+                  <div>
+                    <a href="/student/studier">
+                      <h2>
+                        Studier
+                      </h2>
+                    </a>
+                  </div>
+                  <button class="kth-icon-button close" title="Stäng" aria-label="Stäng">
+                    <span class="kth-visually-hidden">close</span>
+                  </button>
+                </div>
+                <div class="kth-menu-panel__content"></div>
+              </div>
+            </dialog>
+          </li>
+          <li><button data-id="1.1070324" class="kth-menu-item dropdown">
+              <span>
+                Stöd och vägledning
+              </span>
+            </button>
+            <dialog class="kth-menu-panel">
+              <div class="kth-menu-panel__container">
+                <div class="kth-menu-panel__header">
+                  <div>
+                    <a href="/student/stod">
+                      <h2>
+                        Stöd och vägledning
+                      </h2>
+                    </a>
+                  </div>
+                  <button class="kth-icon-button close" title="Stäng" aria-label="Stäng">
+                    <span class="kth-visually-hidden">close</span>
+                  </button>
+                </div>
+                <div class="kth-menu-panel__content"></div>
+              </div>
+            </dialog>
+          </li>
+          <li><button data-id="1.1178595" class="kth-menu-item dropdown">
+              <span>
+                IT och digitala tjänster
+              </span>
+            </button>
+            <dialog class="kth-menu-panel">
+              <div class="kth-menu-panel__container">
+                <div class="kth-menu-panel__header">
+                  <div>
+                    <a href="/student/it">
+                      <h2>
+                        IT och digitala tjänster
+                      </h2>
+                    </a>
+                  </div>
+                  <button class="kth-icon-button close" title="Stäng" aria-label="Stäng">
+                    <span class="kth-visually-hidden">close</span>
+                  </button>
+                </div>
+                <div class="kth-menu-panel__content"></div>
+              </div>
+            </dialog>
+          </li>
+          <li><button data-id="1.1178638" class="kth-menu-item dropdown">
+              <span>
+                Kontakt
+              </span>
+            </button>
+            <dialog class="kth-menu-panel">
+              <div class="kth-menu-panel__container">
+                <div class="kth-menu-panel__header">
+                  <div>
+                    <a href="/student/kontakt">
+                      <h2>
+                        Kontakt
+                      </h2>
+                    </a>
+                  </div>
+                  <button class="kth-icon-button close" title="Stäng" aria-label="Stäng">
+                    <span class="kth-visually-hidden">close</span>
+                  </button>
+                </div>
+                <div class="kth-menu-panel__content"></div>
+              </div>
+            </dialog>
+          </li>
+        
+      </ul>
+    </nav>
+  
+    <!-- Mobile menu -->
+    <nav class="kth-mega-menu--collapsable">
+      <dialog class="kth-mobile-menu">
+        <div class="kth-mobile-menu__navigation">
+          <button class="kth-icon-button close" title="Stäng" aria-label="Stäng">
+            <span class="kth-visually-hidden">Close</span>
+          </button>
+        </div>
+        <div class="kth-mobile-menu__content">
+          <ul class="kth-mobile-menu__items">
+            <li>
+              <button class="kth-mobile-menu__item" data-id="1.1066571">
+                <span>
+                  Studier
+                </span>
+              </button>
+              <dialog class="kth-menu-panel--modal">
+                <button class="kth-icon-button close" title="Stäng" aria-label="Stäng">
+                  <span class="kth-visually-hidden">Close</span>
+                </button>
+                <div class="kth-menu-panel__content"></div>
+              </dialog>
+            </li>
+            <li>
+              <button class="kth-mobile-menu__item" data-id="1.1070324">
+                <span>
+                  Stöd och vägledning
+                </span>
+              </button>
+              <dialog class="kth-menu-panel--modal">
+                <button class="kth-icon-button close" title="Stäng" aria-label="Stäng">
+                  <span class="kth-visually-hidden">Close</span>
+                </button>
+                <div class="kth-menu-panel__content"></div>
+              </dialog>
+            </li>
+            <li>
+              <button class="kth-mobile-menu__item" data-id="1.1178595">
+                <span>
+                  IT och digitala tjänster
+                </span>
+              </button>
+              <dialog class="kth-menu-panel--modal">
+                <button class="kth-icon-button close" title="Stäng" aria-label="Stäng">
+                  <span class="kth-visually-hidden">Close</span>
+                </button>
+                <div class="kth-menu-panel__content"></div>
+              </dialog>
+            </li>
+            <li>
+              <button class="kth-mobile-menu__item" data-id="1.1178638">
+                <span>
+                  Kontakt
+                </span>
+              </button>
+              <dialog class="kth-menu-panel--modal">
+                <button class="kth-icon-button close" title="Stäng" aria-label="Stäng">
+                  <span class="kth-visually-hidden">Close</span>
+                </button>
+                <div class="kth-menu-panel__content"></div>
+              </dialog>
+            </li>
+          </ul>
+        </div>
+      </dialog>
+      <dialog class="kth-mobile-menu details" data-id="1.1066571">
+        <div class="kth-mobile-menu__navigation">
+          <button class="kth-button back">Huvudmeny</button>
+          <button class="kth-icon-button close" title="Stäng" aria-label="Stäng">
+            <span class="kth-visually-hidden">Close</span>
+          </button>
+        </div>
+        <div class="kth-mobile-menu__header">
+          <a href="/student/studier">
+            <h2>
+              Studier
+            </h2>
+          </a>
+        </div>
+        <div class="kth-mobile-menu__content">
+          <div class="kth-mobile-menu__cortina-content"></div>
+        </div>
+      </dialog><dialog class="kth-mobile-menu details" data-id="1.1070324">
+        <div class="kth-mobile-menu__navigation">
+          <button class="kth-button back">Huvudmeny</button>
+          <button class="kth-icon-button close" title="Stäng" aria-label="Stäng">
+            <span class="kth-visually-hidden">Close</span>
+          </button>
+        </div>
+        <div class="kth-mobile-menu__header">
+          <a href="/student/stod">
+            <h2>
+              Stöd och vägledning
+            </h2>
+          </a>
+        </div>
+        <div class="kth-mobile-menu__content">
+          <div class="kth-mobile-menu__cortina-content"></div>
+        </div>
+      </dialog><dialog class="kth-mobile-menu details" data-id="1.1178595">
+        <div class="kth-mobile-menu__navigation">
+          <button class="kth-button back">Huvudmeny</button>
+          <button class="kth-icon-button close" title="Stäng" aria-label="Stäng">
+            <span class="kth-visually-hidden">Close</span>
+          </button>
+        </div>
+        <div class="kth-mobile-menu__header">
+          <a href="/student/it">
+            <h2>
+              IT och digitala tjänster
+            </h2>
+          </a>
+        </div>
+        <div class="kth-mobile-menu__content">
+          <div class="kth-mobile-menu__cortina-content"></div>
+        </div>
+      </dialog><dialog class="kth-mobile-menu details" data-id="1.1178638">
+        <div class="kth-mobile-menu__navigation">
+          <button class="kth-button back">Huvudmeny</button>
+          <button class="kth-icon-button close" title="Stäng" aria-label="Stäng">
+            <span class="kth-visually-hidden">Close</span>
+          </button>
+        </div>
+        <div class="kth-mobile-menu__header">
+          <a href="/student/kontakt">
+            <h2>
+              Kontakt
+            </h2>
+          </a>
+        </div>
+        <div class="kth-mobile-menu__content">
+          <div class="kth-mobile-menu__cortina-content"></div>
+        </div>
+      </dialog>
+    </nav>
+    <!-- Mobile menu -->
+  
+    
+    <script>/* eslint-disable no-unused-expressions, no-unused-vars, no-undef */"use strict";window.addEventListener("load",(()=>{function e(e){return document.querySelector(".kth-mega-menu[data-ajax-path]")?.getAttribute("data-ajax-path")+e}function t(){document.querySelectorAll("dialog").forEach((e=>e.close()))}function n(e){const n=e.querySelector(".kth-icon-button.close");e.addEventListener("keydown",(t=>{"Escape"===t.key&&e.close()})),n instanceof HTMLButtonElement&&n.addEventListener("click",(()=>{t()}))}function o(e,o){n(e),o.addEventListener("click",(n=>{n.preventDefault(),e.open?t():(t(),e.show())})),document.addEventListener("click",(n=>{!e.open||n.composedPath().includes(o)||n.composedPath().includes(e)||(n.preventDefault(),t())}))}function c(e,o,c){const i=e.querySelector(".kth-button.back");n(e),o.addEventListener("click",(n=>{n.preventDefault(),t(),e.showModal()})),i instanceof HTMLButtonElement&&i.addEventListener("click",(()=>{e.close(),c&&c.showModal()}))}var i,l;document.querySelectorAll(".kth-menu-item[data-id], .kth-menu-item--modal[data-id]").forEach((t=>{const n=t.nextElementSibling,o=n?.querySelector(".kth-menu-panel__content");if(!(t instanceof HTMLElement))return;if(!(n instanceof HTMLDialogElement))return;const c=t.dataset.id;let i;function l(){o instanceof HTMLElement&&(i||(i=fetch(e(c)).then((e=>e.text()))),i.then((e=>{o.innerHTML=e})))}t.addEventListener("mouseover",l),t.addEventListener("click",l)})),document.querySelectorAll(".kth-mobile-menu__item[data-id]").forEach((t=>{if(!(t instanceof HTMLElement))return;const n=t.dataset.id,o=document.querySelector(`.kth-mobile-menu[data-id='${n}']`),c=o?.querySelector(".kth-mobile-menu__cortina-content");if(!(o instanceof HTMLDialogElement))return;let i;t.addEventListener("click",(function(){c instanceof HTMLElement&&(i||(i=fetch(e(n)).then((e=>e.text()))),i.then((e=>{c.innerHTML=e})))}))})),function(e,n){if(e){for(const e of n){if(!(e instanceof HTMLElement))continue;const t=e.nextElementSibling;t instanceof HTMLDialogElement&&o(t,e)}e.addEventListener("focusout",(function(n){const o=n.relatedTarget;o&&o instanceof Node&&!e.contains(o)&&t()}))}}(document.querySelector(".kth-header"),document.querySelectorAll(".kth-mega-menu .kth-menu-item")),i=document.querySelector(".kth-menu-item.collapsable"),l=document.querySelector(".kth-mobile-menu"),i instanceof HTMLElement&&l instanceof HTMLDialogElement&&c(l,i),function(e,t){if(!t||t instanceof HTMLDialogElement)for(const n of e){if(!(n instanceof HTMLElement))continue;const e=n.getAttribute("data-id"),o=document.querySelector(`.kth-mobile-menu[data-id='${e}']`);if(!(o instanceof HTMLDialogElement))return;c(o,n,t)}}(document.querySelectorAll(".kth-mobile-menu__item"),document.querySelector(".kth-mobile-menu"))})),window.addEventListener("load",(()=>{const e={threshold:32,className:"collapsed"};function t(e,{threshold:t,className:n}){window.scrollY>t?e?.classList.add(n):e?.classList.remove(n)}!function(n,o=e){t(n,o),window.addEventListener("scroll",(()=>{t(n,o)}))}(document.querySelector(".kth-header"))}));</script>
+  
+  
+  
+      <ul class="kth-header__tools">
+        <li><button class="kth-menu-item search">
+      <span>Sök</span>
+  </button>
+  <dialog class="kth-menu-panel">
+      <div class="kth-menu-panel__container search">
+          <button class="kth-icon-button close">
+              <span class="kth-visually-hidden">Stäng</span>
+          </button>
+          <div class="kth-menu-panel__content">
+                  
+  
+  
+  
+  
+    <div class="block search mainWidget default-size" data-cid="1.1066521" lang="sv">
+      <div id="widget_yhnutasc" class="searchWidgetContainer"><div class="searchWidget"><div class="searchInputBar"><form class="searchInputForm" method="GET" role="search" action="https://www.kth.se/search"><div class="searchAutoCompleteField kth-search"><label for="widget_yhnutasc_search__Field">Sök på Studentwebben</label><input id="widget_yhnutasc_search__Field" name="q" autoComplete="off" type="text" maxLength="1024" value=""/><button type="submit"><span class="kth-visually-hidden">Sök</span></button></div><input type="hidden" name="urlFilter" value="https://www.kth.se/student"/><input type="hidden" name="entityFilter" value="kth-profile,kth-course,kth-place,kth-program,kth-system"/><input type="hidden" name="metaSystemFilter" value=""/><input type="hidden" name="documentFilter" value=""/><input type="hidden" name="filterLabel" value="Sök på Studentwebben"/><input type="hidden" name="l" value="sv"/><input type="hidden" name="noscript" class="noscriptInput" value=""/></form></div><div class="searchAlternativesWidget"><div class="searchAlternativesWidgetLinks"><a href="https://www.kth.se/search?l=sv">Sök på KTH:s webbplats</a><a href="https://intra.kth.se/search?l=sv">Sök på KTH Intranät</a></div></div></div></div>
+  
+  <script>
+    (() => {
+      const SCRIPT_PATH = 'https://www.kth.se/search/static/widget.js?v=2.0.0-20250606.1_9d7abae6'
+      const STYLE_PATH = 'https://www.kth.se/search/static/widget.css?v=2.0.0-20250606.1_9d7abae6'
+      const DATA_PATH = 'https://www.kth.se/search/widgetData.js?widgetId=widget_yhnutasc&filterLabel=S%C3%B6k%20p%C3%A5%20Studentwebben&placeholder=S%C3%B6k%20p%C3%A5%20KTH%3As%20webbplats&urlFilter=https%3A%2F%2Fwww.kth.se%2Fstudent&isFilterRemovable=false&entityFilter=kth-profile%2Ckth-course%2Ckth-place%2Ckth-program%2Ckth-system&l=sv&includeLinks=true'
+      const WIDGET_ID = 'widget_yhnutasc'
+      const scriptAnchor = document.currentScript
+  
+      const observer = new IntersectionObserver((entries, observer) => {
+  
+        if (entries[0].target?.checkVisibility?.()) {
+  
+          if (!window.searchWidgetIsLoaded) {
+  
+            const styleElement = document.createElement('link')
+            styleElement.href = STYLE_PATH
+            styleElement.media = "screen"
+            styleElement.rel = "stylesheet"
+            styleElement.async = 1
+            scriptAnchor.after(styleElement)
+  
+            const scriptElement = document.createElement('script')
+            scriptElement.src = SCRIPT_PATH
+            scriptElement.async = 1
+            scriptAnchor.after(scriptElement)
+          }
+  
+          const dataElement = document.createElement('script')
+          dataElement.src = DATA_PATH
+          dataElement.async = 1
+          scriptAnchor.after(dataElement)
+  
+          window.searchWidgetIsLoaded = true
+          observer.disconnect()
+        }
+      }).observe(document.getElementById(WIDGET_ID))
+    })()
+  </script>
+      
+      <script>/* eslint-disable no-unused-expressions, no-unused-vars, no-undef */"use strict";!function(){function e(){document.querySelectorAll("dialog").forEach((e=>e.close()))}window.addEventListener("load",(function(){document.querySelectorAll(".block.search").forEach((t=>{t.parentElement.className.includes("kth-menu-panel__content")&&function(t,n){if(!(n instanceof HTMLElement))return;const c=n.nextElementSibling;if(!(c instanceof HTMLDialogElement))return;c.addEventListener("keydown",(t=>{"Escape"===t.key&&e()}));const o=c.querySelector(".close");o instanceof HTMLButtonElement&&o.addEventListener("click",(()=>{e()})),n.addEventListener("click",(n=>{n.preventDefault(),c.open?e():(e(),c.show(),function(e){const t=e.querySelector("template");if(null===t)return;const n=t.content;t.replaceWith(n)}(t),function(e){const t=e.querySelector(".searchAutoCompleteField")?.querySelector("input");t&&t.focus()}(c))})),document.addEventListener("click",(t=>{!c.open||t.composedPath().includes(n)||t.composedPath().includes(c)||(t.preventDefault(),e())}))}(t,document.querySelector(".kth-menu-item.search"))}))}))}();</script>
+    </div>
+  
+  
+  
+          </div>
+      </div>
+  </dialog></li>
+        <li><a class="kth-menu-item language" hreflang="en-US" href="?l=en">English</a></li>
+      </ul>
+      <button class="kth-menu-item menu collapsable">
+        <span>Meny</span>
+      </button>
+    </div>
+  </header>
+  <div class="kth-content articleNavigation">
+    <div class="row justify-content-between">
+      
+    <nav id="breadcrumbs" aria-label="Brödsmulor" class="kth-breadcrumbs">
+      <ol class="kth-breadcrumbs__list">
+        <li><a href="/student">Studentwebben</a></li><li><a href="/student/studier">Studier</a></li><li><a href="/student/kurser/kurser-inom-program">Kurs- och programkatalogen</a></li><li><a href="/student/kurser/program/CTFYS">Civilingenjörsutbildning i teknisk fysik</a></li>
+      </ol>
+    </nav>
+   
+    </div>
+  </div>
+  <!--indexOn: all-->  <div class="kth-content">
+    <div class="row">
+        <script>window.__compressedApplicationStore__ = "%7B%22browserConfig%22%3A%7B%22proxyPrefixPath%22%3A%7B%22uri%22%3A%22%2Fstudent%2Fkurser%22%2C%22searchPage%22%3A%22%2Fstudent%2Fkurser%2Fsokkurs%22%2C%22searchResult%22%3A%22%2Fstudent%2Fkurser%2Fsokkurs%2Fresultat%22%2C%22courseSearchInternApi%22%3A%22%2Fstudent%2Fkurser%2Fintern-api%2Fsok%22%2C%22department%22%3A%22%2Fstudent%2Fkurser%2Forg%22%2C%22programme%22%3A%22%2Fstudent%2Fkurser%2Fprogram%22%2C%22programmesList%22%3A%22%2Fstudent%2Fkurser%2Fkurser-inom-program%22%2C%22schoolsList%22%3A%22%2Fstudent%2Fkurser%2Fprogram%22%2C%22studyHandbook%22%3A%22%2Fstudent%2Fprogram%2Fshb%22%2C%22thirdCycleCourseSearch%22%3A%22%2Futbildning%2Fforskarutbildning%2Fkurser%2Fsok%22%2C%22thirdCycleCourseSearchResult%22%3A%22%2Futbildning%2Fforskarutbildning%2Fkurser%2Fsok%2Fresultat%22%2C%22thirdCycleSchoolsAndDepartments%22%3A%22%2Futbildning%2Fforskarutbildning%2Fkurser%2Favdelning%22%2C%22thirdCycleCoursesPerDepartment%22%3A%22%2Futbildning%2Fforskarutbildning%2Fkurser%2Forg%22%2C%22programmeSyllabusPDF%22%3A%22%2Fstudent%2Fkurser%2Fintern-api%2FPDFRenderFunction%22%7D%2C%22redirectProxyPath%22%3A%7B%22studentRoot%22%3A%22%2Fstudent%2Fkurser%22%2C%22thirdCycleRoot%22%3A%22%2Futbildning%2Fforskarutbildning%2Fkurser%22%2C%22coursesPerDepartment%22%3A%22%2Fstudent%2Fkurser%2Fkurser-per-avdelning%22%2C%22departmentCourses%22%3A%22%2Fstudent%2Fkurser%2Favdelning%2F%3AdepartmentCode%2Fkurser%2F%22%7D%2C%22markHtmlFromKopps%22%3Afalse%2C%22markHtmlFromLadok%22%3Afalse%2C%22env%22%3A%22prod%22%7D%2C%22statusCode%22%3A200%2C%22language%22%3A%22sv%22%2C%22languageIndex%22%3A1%2C%22programmeCode%22%3A%22CTFYS%22%2C%22programmeName%22%3A%22Civilingenj%C3%B6rsutbildning%20i%20teknisk%20fysik%22%2C%22owningSchoolCode%22%3A%22SCI%2FSkolan%20f%C3%B6r%20teknikvetenskap%22%2C%22term%22%3A%2220242%22%2C%22studyYear%22%3A%223%22%2C%22curriculums%22%3A%5B%7B%22studyYears%22%3A%5B%7B%22yearNumber%22%3A1%2C%22courses%22%3A%22%3Ch3%20id%3D%5C%22gemensammakurser%5C%22%3EGemensamma%20kurser%3C%2Fh3%3E%5Cn%3Ch4%20id%3D%5C%22obligatoriskakurser%5C%22%3EObligatoriska%20kurser%3C%2Fh4%3E%5Cn%3Ctable%3E%5Cn%3Cthead%3E%5Cn%3Ctr%3E%5Cn%3Cth%3EKurskod%3C%2Fth%3E%5Cn%3Cth%3EKursnamn%3C%2Fth%3E%5Cn%3Cth%3EOmfattning%3C%2Fth%3E%5Cn%3Cth%3EUtbildningsniv%C3%A5%3C%2Fth%3E%5Cn%3C%2Ftr%3E%5Cn%3C%2Fthead%3E%5Cn%3Ctbody%3E%5Cn%3Ctr%3E%5Cn%3Ctd%3EDD1331%3C%2Ftd%3E%5Cn%3Ctd%3EGrundl%C3%A4ggande%20programmering%3C%2Ftd%3E%5Cn%3Ctd%3E5%20hp%3C%2Ftd%3E%5Cn%3Ctd%3EGrundniv%C3%A5%3C%2Ftd%3E%5Cn%3C%2Ftr%3E%5Cn%3Ctr%3E%5Cn%3Ctd%3ESF1672%3C%2Ftd%3E%5Cn%3Ctd%3ELinj%C3%A4r%20algebra%3C%2Ftd%3E%5Cn%3Ctd%3E7.5%20hp%3C%2Ftd%3E%5Cn%3Ctd%3EGrundniv%C3%A5%3C%2Ftd%3E%5Cn%3C%2Ftr%3E%5Cn%3Ctr%3E%5Cn%3Ctd%3ESF1673%3C%2Ftd%3E%5Cn%3Ctd%3EAnalys%20i%20en%20variabel%3C%2Ftd%3E%5Cn%3Ctd%3E7.5%20hp%3C%2Ftd%3E%5Cn%3Ctd%3EGrundniv%C3%A5%3C%2Ftd%3E%5Cn%3C%2Ftr%3E%5Cn%3Ctr%3E%5Cn%3Ctd%3ESF1674%3C%2Ftd%3E%5Cn%3Ctd%3EFlervariabelanalys%3C%2Ftd%3E%5Cn%3Ctd%3E7.5%20hp%3C%2Ftd%3E%5Cn%3Ctd%3EGrundniv%C3%A5%3C%2Ftd%3E%5Cn%3C%2Ftr%3E%5Cn%3Ctr%3E%5Cn%3Ctd%3ESF1922%3C%2Ftd%3E%5Cn%3Ctd%3ESannolikhetsteori%20och%20statistik%3C%2Ftd%3E%5Cn%3Ctd%3E6%20hp%3C%2Ftd%3E%5Cn%3Ctd%3EGrundniv%C3%A5%3C%2Ftd%3E%5Cn%3C%2Ftr%3E%5Cn%3Ctr%3E%5Cn%3Ctd%3ESG1112%3C%2Ftd%3E%5Cn%3Ctd%3EMekanik%20I%3C%2Ftd%3E%5Cn%3Ctd%3E9%20hp%3C%2Ftd%3E%5Cn%3Ctd%3EGrundniv%C3%A5%3C%2Ftd%3E%5Cn%3C%2Ftr%3E%5Cn%3Ctr%3E%5Cn%3Ctd%3ESI1121%3C%2Ftd%3E%5Cn%3Ctd%3ETermodynamik%3C%2Ftd%3E%5Cn%3Ctd%3E6%20hp%3C%2Ftd%3E%5Cn%3Ctd%3EGrundniv%C3%A5%3C%2Ftd%3E%5Cn%3C%2Ftr%3E%5Cn%3Ctr%3E%5Cn%3Ctd%3ESK1104%3C%2Ftd%3E%5Cn%3Ctd%3EKlassisk%20fysik%3C%2Ftd%3E%5Cn%3Ctd%3E7.5%20hp%3C%2Ftd%3E%5Cn%3Ctd%3EGrundniv%C3%A5%3C%2Ftd%3E%5Cn%3C%2Ftr%3E%5Cn%3Ctr%3E%5Cn%3Ctd%3ESK1105%3C%2Ftd%3E%5Cn%3Ctd%3EExperimentell%20fysik%3C%2Ftd%3E%5Cn%3Ctd%3E4%20hp%3C%2Ftd%3E%5Cn%3Ctd%3EGrundniv%C3%A5%3C%2Ftd%3E%5Cn%3C%2Ftr%3E%5Cn%3C%2Ftbody%3E%5Cn%3C%2Ftable%3E%5Cn%3Ch4%20id%3D%5C%22valfriakurser%5C%22%3EValfria%20kurser%3C%2Fh4%3E%5Cn%3Ctable%3E%5Cn%3Cthead%3E%5Cn%3Ctr%3E%5Cn%3Cth%3EKurskod%3C%2Fth%3E%5Cn%3Cth%3EKursnamn%3C%2Fth%3E%5Cn%3Cth%3EOmfattning%3C%2Fth%3E%5Cn%3Cth%3EUtbildningsniv%C3%A5%3C%2Fth%3E%5Cn%3C%2Ftr%3E%5Cn%3C%2Fthead%3E%5Cn%3Ctbody%3E%5Cn%3Ctr%3E%5Cn%3Ctd%3EDD1301%3C%2Ftd%3E%5Cn%3Ctd%3EDatorintroduktion%3C%2Ftd%3E%5Cn%3Ctd%3E1.5%20hp%3C%2Ftd%3E%5Cn%3Ctd%3EGrundniv%C3%A5%3C%2Ftd%3E%5Cn%3C%2Ftr%3E%5Cn%3C%2Ftbody%3E%5Cn%3C%2Ftable%3E%22%2C%22freeTexts%22%3A%5B%5D%7D%2C%7B%22yearNumber%22%3A2%2C%22courses%22%3A%5B%7B%22utbildningsinstansUid%22%3A%227eb5e492-73d8-11e8-b4e0-063f9afb40e3%22%2C%22uid%22%3A%2262491f0b-ce66-11ef-9bca-bbbddaff469b%22%2C%22tillfalleskod%22%3A%2251630%22%2C%22status%22%3A%7B%22code%22%3A%22S3%22%2C%22nameSv%22%3A%22Komplett%22%2C%22nameEn%22%3A%22Complete%22%7D%2C%22utbildningstyp%22%3A%7B%22id%22%3A%2222%22%2C%22code%22%3A%222007GKURS%22%2C%22name%22%3A%22Kurs%2C%20grundniv%C3%A5%22%2C%22nameOther%22%3A%22Course%2C%20First-cycle%22%2C%22creditsUnit%22%3A%7B%22code%22%3A%22HP%22%2C%22sv%22%3A%22H%C3%B6gskolepo%C3%A4ng%22%2C%22en%22%3A%22Credits%22%7D%2C%22level%22%3A%7B%22code%22%3A%221%22%2C%22name%22%3A%22Grundniv%C3%A5%22%7D%7D%2C%22omfattning%22%3A%7B%22number%22%3A6%2C%22formattedWithUnit%22%3A%226%2C0%20hp%22%7D%2C%22startperiod%22%3A%7B%22code%22%3A%22HT2025%22%2C%22startDay%22%3A%222025-08-25%22%2C%22lastDay%22%3A%222026-01-12%22%2C%22inDigits%22%3A%2220252%22%7D%2C%22Tillfallesperioder%22%3A%5B%7B%22ForstaRegistreringsdatum%22%3A%222025-10-23%22%2C%22ForstaUndervisningsdatum%22%3A%222025-10-27%22%2C%22Lasperiodsfordelning%22%3A%5B%7B%22Lasperiodskod%22%3A%22P2%22%2C%22Omfattningsvarde%22%3A1%2C%22link%22%3A%5B%5D%7D%5D%2C%22Omfattningsvarde%22%3A1%2C%22SistaRegistreringsdatum%22%3A%222025-11-03%22%2C%22SistaUndervisningsdatum%22%3A%222026-01-12%22%7D%2C%7B%22ForstaRegistreringsdatum%22%3A%222026-01-08%22%2C%22ForstaUndervisningsdatum%22%3A%222026-01-13%22%2C%22Lasperiodsfordelning%22%3A%5B%7B%22Lasperiodskod%22%3A%22P3%22%2C%22Omfattningsvarde%22%3A5%2C%22link%22%3A%5B%5D%7D%5D%2C%22Omfattningsvarde%22%3A5%2C%22SistaRegistreringsdatum%22%3A%222026-01-19%22%2C%22SistaUndervisningsdatum%22%3A%222026-03-13%22%7D%5D%2C%22kod%22%3A%22SF1544%22%2C%22benamning%22%3A%22Numeriska%20metoder%2C%20grundkurs%20IV%22%2C%22Valvillkor%22%3A%22O%22%2C%22type%22%3A%22instance%22%7D%2C%7B%22utbildningsinstansUid%22%3A%227fe75fb1-73d8-11e8-b4e0-063f9afb40e3%22%2C%22uid%22%3A%2233595346-ce67-11ef-9bca-bbbddaff469b%22%2C%22tillfalleskod%22%3A%2251982%22%2C%22status%22%3A%7B%22code%22%3A%22S3%22%2C%22nameSv%22%3A%22Komplett%22%2C%22nameEn%22%3A%22Complete%22%7D%2C%22utbildningstyp%22%3A%7B%22id%22%3A%2222%22%2C%22code%22%3A%222007GKURS%22%2C%22name%22%3A%22Kurs%2C%20grundniv%C3%A5%22%2C%22nameOther%22%3A%22Course%2C%20First-cycle%22%2C%22creditsUnit%22%3A%7B%22code%22%3A%22HP%22%2C%22sv%22%3A%22H%C3%B6gskolepo%C3%A4ng%22%2C%22en%22%3A%22Credits%22%7D%2C%22level%22%3A%7B%22code%22%3A%221%22%2C%22name%22%3A%22Grundniv%C3%A5%22%7D%7D%2C%22omfattning%22%3A%7B%22number%22%3A6%2C%22formattedWithUnit%22%3A%226%2C0%20hp%22%7D%2C%22startperiod%22%3A%7B%22code%22%3A%22HT2025%22%2C%22startDay%22%3A%222025-08-25%22%2C%22lastDay%22%3A%222026-01-12%22%2C%22inDigits%22%3A%2220252%22%7D%2C%22Tillfallesperioder%22%3A%5B%7B%22ForstaRegistreringsdatum%22%3A%222025-10-23%22%2C%22ForstaUndervisningsdatum%22%3A%222025-10-27%22%2C%22Lasperiodsfordelning%22%3A%5B%7B%22Lasperiodskod%22%3A%22P2%22%2C%22Omfattningsvarde%22%3A6%2C%22link%22%3A%5B%5D%7D%5D%2C%22Omfattningsvarde%22%3A6%2C%22SistaRegistreringsdatum%22%3A%222025-11-03%22%2C%22SistaUndervisningsdatum%22%3A%222026-01-12%22%7D%5D%2C%22kod%22%3A%22SF1681%22%2C%22benamning%22%3A%22Linj%C3%A4r%20algebra%2C%20forts%C3%A4ttningskurs%22%2C%22Valvillkor%22%3A%22O%22%2C%22type%22%3A%22instance%22%7D%2C%7B%22utbildningsinstansUid%22%3A%227fe75fb0-73d8-11e8-b4e0-063f9afb40e3%22%2C%22uid%22%3A%22642a462b-ce67-11ef-9bca-bbbddaff469b%22%2C%22tillfalleskod%22%3A%2250280%22%2C%22status%22%3A%7B%22code%22%3A%22S3%22%2C%22nameSv%22%3A%22Komplett%22%2C%22nameEn%22%3A%22Complete%22%7D%2C%22utbildningstyp%22%3A%7B%22id%22%3A%2222%22%2C%22code%22%3A%222007GKURS%22%2C%22name%22%3A%22Kurs%2C%20grundniv%C3%A5%22%2C%22nameOther%22%3A%22Course%2C%20First-cycle%22%2C%22creditsUnit%22%3A%7B%22code%22%3A%22HP%22%2C%22sv%22%3A%22H%C3%B6gskolepo%C3%A4ng%22%2C%22en%22%3A%22Credits%22%7D%2C%22level%22%3A%7B%22code%22%3A%221%22%2C%22name%22%3A%22Grundniv%C3%A5%22%7D%7D%2C%22omfattning%22%3A%7B%22number%22%3A9%2C%22formattedWithUnit%22%3A%229%2C0%20hp%22%7D%2C%22startperiod%22%3A%7B%22code%22%3A%22HT2025%22%2C%22startDay%22%3A%222025-08-25%22%2C%22lastDay%22%3A%222026-01-12%22%2C%22inDigits%22%3A%2220252%22%7D%2C%22Tillfallesperioder%22%3A%5B%7B%22ForstaRegistreringsdatum%22%3A%222025-08-21%22%2C%22ForstaUndervisningsdatum%22%3A%222025-08-25%22%2C%22Lasperiodsfordelning%22%3A%5B%7B%22Lasperiodskod%22%3A%22P2%22%2C%22Omfattningsvarde%22%3A4%2C%22link%22%3A%5B%5D%7D%2C%7B%22Lasperiodskod%22%3A%22P1%22%2C%22Omfattningsvarde%22%3A5%2C%22link%22%3A%5B%5D%7D%5D%2C%22Omfattningsvarde%22%3A9%2C%22SistaRegistreringsdatum%22%3A%222025-09-01%22%2C%22SistaUndervisningsdatum%22%3A%222026-01-12%22%7D%5D%2C%22kod%22%3A%22SF1683%22%2C%22benamning%22%3A%22Differentialekvationer%20och%20transformmetoder%22%2C%22Valvillkor%22%3A%22O%22%2C%22type%22%3A%22instance%22%7D%2C%7B%22utbildningsinstansUid%22%3A%2281a42ab1-73d8-11e8-b4e0-063f9afb40e3%22%2C%22uid%22%3A%22f1a23275-bea3-11ef-9c9e-74b5caef4769%22%2C%22tillfalleskod%22%3A%2251631%22%2C%22status%22%3A%7B%22code%22%3A%22S3%22%2C%22nameSv%22%3A%22Komplett%22%2C%22nameEn%22%3A%22Complete%22%7D%2C%22utbildningstyp%22%3A%7B%22id%22%3A%2222%22%2C%22code%22%3A%222007GKURS%22%2C%22name%22%3A%22Kurs%2C%20grundniv%C3%A5%22%2C%22nameOther%22%3A%22Course%2C%20First-cycle%22%2C%22creditsUnit%22%3A%7B%22code%22%3A%22HP%22%2C%22sv%22%3A%22H%C3%B6gskolepo%C3%A4ng%22%2C%22en%22%3A%22Credits%22%7D%2C%22level%22%3A%7B%22code%22%3A%221%22%2C%22name%22%3A%22Grundniv%C3%A5%22%7D%7D%2C%22omfattning%22%3A%7B%22number%22%3A6%2C%22formattedWithUnit%22%3A%226%2C0%20hp%22%7D%2C%22startperiod%22%3A%7B%22code%22%3A%22HT2025%22%2C%22startDay%22%3A%222025-08-25%22%2C%22lastDay%22%3A%222026-01-12%22%2C%22inDigits%22%3A%2220252%22%7D%2C%22Tillfallesperioder%22%3A%5B%7B%22ForstaRegistreringsdatum%22%3A%222025-08-21%22%2C%22ForstaUndervisningsdatum%22%3A%222025-08-25%22%2C%22Lasperiodsfordelning%22%3A%5B%7B%22Lasperiodskod%22%3A%22P1%22%2C%22Omfattningsvarde%22%3A6%2C%22link%22%3A%5B%5D%7D%5D%2C%22Omfattningsvarde%22%3A6%2C%22SistaRegistreringsdatum%22%3A%222025-09-01%22%2C%22SistaUndervisningsdatum%22%3A%222025-10-24%22%7D%5D%2C%22kod%22%3A%22SG1113%22%2C%22benamning%22%3A%22Mekanik%2C%20forts%C3%A4ttningskurs%22%2C%22Valvillkor%22%3A%22O%22%2C%22type%22%3A%22instance%22%7D%2C%7B%22utbildningsinstansUid%22%3A%2282c467d4-73d8-11e8-b4e0-063f9afb40e3%22%2C%22uid%22%3A%229ade5891-bba7-11ef-9553-beecfac44351%22%2C%22tillfalleskod%22%3A%2251382%22%2C%22status%22%3A%7B%22code%22%3A%22S3%22%2C%22nameSv%22%3A%22Komplett%22%2C%22nameEn%22%3A%22Complete%22%7D%2C%22utbildningstyp%22%3A%7B%22id%22%3A%2222%22%2C%22code%22%3A%222007GKURS%22%2C%22name%22%3A%22Kurs%2C%20grundniv%C3%A5%22%2C%22nameOther%22%3A%22Course%2C%20First-cycle%22%2C%22creditsUnit%22%3A%7B%22code%22%3A%22HP%22%2C%22sv%22%3A%22H%C3%B6gskolepo%C3%A4ng%22%2C%22en%22%3A%22Credits%22%7D%2C%22level%22%3A%7B%22code%22%3A%221%22%2C%22name%22%3A%22Grundniv%C3%A5%22%7D%7D%2C%22omfattning%22%3A%7B%22number%22%3A4%2C%22formattedWithUnit%22%3A%224%2C0%20hp%22%7D%2C%22startperiod%22%3A%7B%22code%22%3A%22HT2025%22%2C%22startDay%22%3A%222025-08-25%22%2C%22lastDay%22%3A%222026-01-12%22%2C%22inDigits%22%3A%2220252%22%7D%2C%22Tillfallesperioder%22%3A%5B%7B%22ForstaRegistreringsdatum%22%3A%222025-10-23%22%2C%22ForstaUndervisningsdatum%22%3A%222025-10-27%22%2C%22Lasperiodsfordelning%22%3A%5B%7B%22Lasperiodskod%22%3A%22P2%22%2C%22Omfattningsvarde%22%3A4%2C%22link%22%3A%5B%5D%7D%5D%2C%22Omfattningsvarde%22%3A4%2C%22SistaRegistreringsdatum%22%3A%222025-11-03%22%2C%22SistaUndervisningsdatum%22%3A%222026-01-12%22%7D%5D%2C%22kod%22%3A%22SH1014%22%2C%22benamning%22%3A%22Modern%20fysik%22%2C%22Valvillkor%22%3A%22O%22%2C%22type%22%3A%22instance%22%7D%2C%7B%22utbildningsinstansUid%22%3A%2284079666-73d8-11e8-b4e0-063f9afb40e3%22%2C%22uid%22%3A%220deb231b-bbab-11ef-9553-beecfac44351%22%2C%22tillfalleskod%22%3A%2250258%22%2C%22status%22%3A%7B%22code%22%3A%22S3%22%2C%22nameSv%22%3A%22Komplett%22%2C%22nameEn%22%3A%22Complete%22%7D%2C%22utbildningstyp%22%3A%7B%22id%22%3A%2222%22%2C%22code%22%3A%222007GKURS%22%2C%22name%22%3A%22Kurs%2C%20grundniv%C3%A5%22%2C%22nameOther%22%3A%22Course%2C%20First-cycle%22%2C%22creditsUnit%22%3A%7B%22code%22%3A%22HP%22%2C%22sv%22%3A%22H%C3%B6gskolepo%C3%A4ng%22%2C%22en%22%3A%22Credits%22%7D%2C%22level%22%3A%7B%22code%22%3A%221%22%2C%22name%22%3A%22Grundniv%C3%A5%22%7D%7D%2C%22omfattning%22%3A%7B%22number%22%3A4%2C%22formattedWithUnit%22%3A%224%2C0%20hp%22%7D%2C%22startperiod%22%3A%7B%22code%22%3A%22HT2025%22%2C%22startDay%22%3A%222025-08-25%22%2C%22lastDay%22%3A%222026-01-12%22%2C%22inDigits%22%3A%2220252%22%7D%2C%22Tillfallesperioder%22%3A%5B%7B%22ForstaRegistreringsdatum%22%3A%222025-08-21%22%2C%22ForstaUndervisningsdatum%22%3A%222025-08-25%22%2C%22Lasperiodsfordelning%22%3A%5B%7B%22Lasperiodskod%22%3A%22P1%22%2C%22Omfattningsvarde%22%3A4%2C%22link%22%3A%5B%5D%7D%5D%2C%22Omfattningsvarde%22%3A4%2C%22SistaRegistreringsdatum%22%3A%222025-09-01%22%2C%22SistaUndervisningsdatum%22%3A%222025-10-24%22%7D%5D%2C%22kod%22%3A%22SI1146%22%2C%22benamning%22%3A%22Vektoranalys%22%2C%22Valvillkor%22%3A%22O%22%2C%22type%22%3A%22instance%22%7D%2C%7B%22utbildningsinstansUid%22%3A%222001332f-a81e-11f0-8e06-8e0c8088416e%22%2C%22uid%22%3A%225560453c-bee7-11ef-9c9e-74b5caef4769%22%2C%22tillfalleskod%22%3A%2261493%22%2C%22status%22%3A%7B%22code%22%3A%22S3%22%2C%22nameSv%22%3A%22Komplett%22%2C%22nameEn%22%3A%22Complete%22%7D%2C%22utbildningstyp%22%3A%7B%22id%22%3A%2222%22%2C%22code%22%3A%222007GKURS%22%2C%22name%22%3A%22Kurs%2C%20grundniv%C3%A5%22%2C%22nameOther%22%3A%22Course%2C%20First-cycle%22%2C%22creditsUnit%22%3A%7B%22code%22%3A%22HP%22%2C%22sv%22%3A%22H%C3%B6gskolepo%C3%A4ng%22%2C%22en%22%3A%22Credits%22%7D%2C%22level%22%3A%7B%22code%22%3A%221%22%2C%22name%22%3A%22Grundniv%C3%A5%22%7D%7D%2C%22omfattning%22%3A%7B%22number%22%3A6%2C%22formattedWithUnit%22%3A%226%2C0%20hp%22%7D%2C%22startperiod%22%3A%7B%22code%22%3A%22VT2026%22%2C%22startDay%22%3A%222026-01-13%22%2C%22lastDay%22%3A%222026-06-01%22%2C%22inDigits%22%3A%2220261%22%7D%2C%22Tillfallesperioder%22%3A%5B%7B%22ForstaRegistreringsdatum%22%3A%222026-03-12%22%2C%22ForstaUndervisningsdatum%22%3A%222026-03-16%22%2C%22Lasperiodsfordelning%22%3A%5B%7B%22Lasperiodskod%22%3A%22P4%22%2C%22Omfattningsvarde%22%3A6%2C%22link%22%3A%5B%5D%7D%5D%2C%22Omfattningsvarde%22%3A6%2C%22SistaRegistreringsdatum%22%3A%222026-03-23%22%2C%22SistaUndervisningsdatum%22%3A%222026-06-01%22%7D%5D%2C%22kod%22%3A%22DD1327%22%2C%22benamning%22%3A%22Grundl%C3%A4ggande%20datalogi%22%2C%22Valvillkor%22%3A%22O%22%2C%22type%22%3A%22instance%22%7D%2C%7B%22utbildningsinstansUid%22%3A%227e2b318f-73d8-11e8-afa7-8e408e694e54%22%2C%22uid%22%3A%22738c9815-beb0-11ef-9c9e-74b5caef4769%22%2C%22tillfalleskod%22%3A%2261495%22%2C%22status%22%3A%7B%22code%22%3A%22S3%22%2C%22nameSv%22%3A%22Komplett%22%2C%22nameEn%22%3A%22Complete%22%7D%2C%22utbildningstyp%22%3A%7B%22id%22%3A%2222%22%2C%22code%22%3A%222007GKURS%22%2C%22name%22%3A%22Kurs%2C%20grundniv%C3%A5%22%2C%22nameOther%22%3A%22Course%2C%20First-cycle%22%2C%22creditsUnit%22%3A%7B%22code%22%3A%22HP%22%2C%22sv%22%3A%22H%C3%B6gskolepo%C3%A4ng%22%2C%22en%22%3A%22Credits%22%7D%2C%22level%22%3A%7B%22code%22%3A%221%22%2C%22name%22%3A%22Grundniv%C3%A5%22%7D%7D%2C%22omfattning%22%3A%7B%22number%22%3A9%2C%22formattedWithUnit%22%3A%229%2C0%20hp%22%7D%2C%22startperiod%22%3A%7B%22code%22%3A%22VT2026%22%2C%22startDay%22%3A%222026-01-13%22%2C%22lastDay%22%3A%222026-06-01%22%2C%22inDigits%22%3A%2220261%22%7D%2C%22Tillfallesperioder%22%3A%5B%7B%22ForstaRegistreringsdatum%22%3A%222026-01-08%22%2C%22ForstaUndervisningsdatum%22%3A%222026-01-13%22%2C%22Lasperiodsfordelning%22%3A%5B%7B%22Lasperiodskod%22%3A%22P4%22%2C%22Omfattningsvarde%22%3A3%2C%22link%22%3A%5B%5D%7D%2C%7B%22Lasperiodskod%22%3A%22P3%22%2C%22Omfattningsvarde%22%3A6%2C%22link%22%3A%5B%5D%7D%5D%2C%22Omfattningsvarde%22%3A9%2C%22SistaRegistreringsdatum%22%3A%222026-01-19%22%2C%22SistaUndervisningsdatum%22%3A%222026-06-01%22%7D%5D%2C%22kod%22%3A%22SE1055%22%2C%22benamning%22%3A%22H%C3%A5llfasthetsl%C3%A4ra%2C%20grundkurs%20med%20energimetoder%22%2C%22Valvillkor%22%3A%22O%22%2C%22type%22%3A%22instance%22%7D%2C%7B%22utbildningsinstansUid%22%3A%228410be34-73d8-11e8-b4e0-063f9afb40e3%22%2C%22uid%22%3A%2247f95929-bbab-11ef-9553-beecfac44351%22%2C%22tillfalleskod%22%3A%2260157%22%2C%22status%22%3A%7B%22code%22%3A%22S3%22%2C%22nameSv%22%3A%22Komplett%22%2C%22nameEn%22%3A%22Complete%22%7D%2C%22utbildningstyp%22%3A%7B%22id%22%3A%2222%22%2C%22code%22%3A%222007GKURS%22%2C%22name%22%3A%22Kurs%2C%20grundniv%C3%A5%22%2C%22nameOther%22%3A%22Course%2C%20First-cycle%22%2C%22creditsUnit%22%3A%7B%22code%22%3A%22HP%22%2C%22sv%22%3A%22H%C3%B6gskolepo%C3%A4ng%22%2C%22en%22%3A%22Credits%22%7D%2C%22level%22%3A%7B%22code%22%3A%221%22%2C%22name%22%3A%22Grundniv%C3%A5%22%7D%7D%2C%22omfattning%22%3A%7B%22number%22%3A6%2C%22formattedWithUnit%22%3A%226%2C0%20hp%22%7D%2C%22startperiod%22%3A%7B%22code%22%3A%22VT2026%22%2C%22startDay%22%3A%222026-01-13%22%2C%22lastDay%22%3A%222026-06-01%22%2C%22inDigits%22%3A%2220261%22%7D%2C%22Tillfallesperioder%22%3A%5B%7B%22ForstaRegistreringsdatum%22%3A%222026-03-12%22%2C%22ForstaUndervisningsdatum%22%3A%222026-03-16%22%2C%22Lasperiodsfordelning%22%3A%5B%7B%22Lasperiodskod%22%3A%22P4%22%2C%22Omfattningsvarde%22%3A6%2C%22link%22%3A%5B%5D%7D%5D%2C%22Omfattningsvarde%22%3A6%2C%22SistaRegistreringsdatum%22%3A%222026-03-23%22%2C%22SistaUndervisningsdatum%22%3A%222026-06-01%22%7D%5D%2C%22kod%22%3A%22SI1155%22%2C%22benamning%22%3A%22Teoretisk%20fysik%22%2C%22Valvillkor%22%3A%22O%22%2C%22type%22%3A%22instance%22%7D%2C%7B%22utbildningsinstansUid%22%3A%22841e04ac-73d8-11e8-b4e0-063f9afb40e3%22%2C%22uid%22%3A%221ba5b1dd-bbab-11ef-9553-beecfac44351%22%2C%22tillfalleskod%22%3A%2260181%22%2C%22status%22%3A%7B%22code%22%3A%22S3%22%2C%22nameSv%22%3A%22Komplett%22%2C%22nameEn%22%3A%22Complete%22%7D%2C%22utbildningstyp%22%3A%7B%22id%22%3A%2222%22%2C%22code%22%3A%222007GKURS%22%2C%22name%22%3A%22Kurs%2C%20grundniv%C3%A5%22%2C%22nameOther%22%3A%22Course%2C%20First-cycle%22%2C%22creditsUnit%22%3A%7B%22code%22%3A%22HP%22%2C%22sv%22%3A%22H%C3%B6gskolepo%C3%A4ng%22%2C%22en%22%3A%22Credits%22%7D%2C%22level%22%3A%7B%22code%22%3A%221%22%2C%22name%22%3A%22Grundniv%C3%A5%22%7D%7D%2C%22omfattning%22%3A%7B%22number%22%3A4%2C%22formattedWithUnit%22%3A%224%2C0%20hp%22%7D%2C%22startperiod%22%3A%7B%22code%22%3A%22VT2026%22%2C%22startDay%22%3A%222026-01-13%22%2C%22lastDay%22%3A%222026-06-01%22%2C%22inDigits%22%3A%2220261%22%7D%2C%22Tillfallesperioder%22%3A%5B%7B%22ForstaRegistreringsdatum%22%3A%222026-01-08%22%2C%22ForstaUndervisningsdatum%22%3A%222026-01-13%22%2C%22Lasperiodsfordelning%22%3A%5B%7B%22Lasperiodskod%22%3A%22P3%22%2C%22Omfattningsvarde%22%3A4%2C%22link%22%3A%5B%5D%7D%5D%2C%22Omfattningsvarde%22%3A4%2C%22SistaRegistreringsdatum%22%3A%222026-01-19%22%2C%22SistaUndervisningsdatum%22%3A%222026-03-13%22%7D%5D%2C%22kod%22%3A%22SI1200%22%2C%22benamning%22%3A%22Fysikens%20matematiska%20metoder%22%2C%22Valvillkor%22%3A%22O%22%2C%22type%22%3A%22instance%22%7D%5D%2C%22freeTexts%22%3A%5B%5D%2C%22supplementaryInfo%22%3A%22%3Cp%3EBaserat%20p%C3%A5%20l%C3%A4s%C3%A5rsplan%20beslutad%20f%C3%B6r%20l%C3%A4s%C3%A5ret%202024%2F2025.%20%C3%84ndringar%20kan%20ske%20f%C3%B6r%20kommande%20l%C3%A4s%C3%A5r.%3C%2Fp%3E%22%7D%2C%7B%22yearNumber%22%3A3%2C%22courses%22%3A%5B%7B%22utbildningsinstansUid%22%3A%2232936226-73d8-11e8-afa7-8e408e694e54%22%2C%22uid%22%3A%2259ae8159-cf7f-11f0-9d49-fd72c5714a36%22%2C%22tillfalleskod%22%3A%2212018%22%2C%22status%22%3A%7B%22code%22%3A%22S2%22%2C%22nameSv%22%3A%22P%C3%A5b%C3%B6rjad%22%2C%22nameEn%22%3A%22Started%22%7D%2C%22utbildningstyp%22%3A%7B%22id%22%3A%2224%22%2C%22code%22%3A%222007AKURS%22%2C%22name%22%3A%22Kurs%2C%20avancerad%20niv%C3%A5%22%2C%22nameOther%22%3A%22Course%2C%20Second-cycle%22%2C%22creditsUnit%22%3A%7B%22code%22%3A%22HP%22%2C%22sv%22%3A%22H%C3%B6gskolepo%C3%A4ng%22%2C%22en%22%3A%22Credits%22%7D%2C%22level%22%3A%7B%22code%22%3A%222%22%2C%22name%22%3A%22Avancerad%20niv%C3%A5%22%7D%7D%2C%22omfattning%22%3A%7B%22number%22%3A7.5%2C%22formattedWithUnit%22%3A%227%2C5%20hp%22%7D%2C%22startperiod%22%3A%7B%22code%22%3A%22VT2027%22%2C%22startDay%22%3A%222027-01-12%22%2C%22lastDay%22%3A%222027-05-31%22%2C%22inDigits%22%3A%2220271%22%7D%2C%22Tillfallesperioder%22%3A%5B%7B%22ForstaRegistreringsdatum%22%3A%222027-01-07%22%2C%22ForstaUndervisningsdatum%22%3A%222027-01-12%22%2C%22Lasperiodsfordelning%22%3A%5B%7B%22Lasperiodskod%22%3A%22P3%22%2C%22Omfattningsvarde%22%3A7.5%2C%22link%22%3A%5B%5D%7D%5D%2C%22Omfattningsvarde%22%3A7.5%2C%22SistaRegistreringsdatum%22%3A%222027-01-18%22%2C%22SistaUndervisningsdatum%22%3A%222027-03-12%22%7D%5D%2C%22kod%22%3A%22AK2014%22%2C%22benamning%22%3A%22Beslutsteori%22%2C%22Valvillkor%22%3A%22V%22%2C%22type%22%3A%22instance%22%7D%2C%7B%22utbildningsinstansUid%22%3A%22f1a551c5-d6b8-11e8-8fd5-cf9d2c5c41ba%22%2C%22uid%22%3A%226429c29f-c9e4-11f0-a255-650837bd40cf%22%2C%22tillfalleskod%22%3A%2211765%22%2C%22status%22%3A%7B%22code%22%3A%22S2%22%2C%22nameSv%22%3A%22P%C3%A5b%C3%B6rjad%22%2C%22nameEn%22%3A%22Started%22%7D%2C%22utbildningstyp%22%3A%7B%22id%22%3A%2222%22%2C%22code%22%3A%222007GKURS%22%2C%22name%22%3A%22Kurs%2C%20grundniv%C3%A5%22%2C%22nameOther%22%3A%22Course%2C%20First-cycle%22%2C%22creditsUnit%22%3A%7B%22code%22%3A%22HP%22%2C%22sv%22%3A%22H%C3%B6gskolepo%C3%A4ng%22%2C%22en%22%3A%22Credits%22%7D%2C%22level%22%3A%7B%22code%22%3A%221%22%2C%22name%22%3A%22Grundniv%C3%A5%22%7D%7D%2C%22omfattning%22%3A%7B%22number%22%3A1.5%2C%22formattedWithUnit%22%3A%221%2C5%20hp%22%7D%2C%22startperiod%22%3A%7B%22code%22%3A%22VT2027%22%2C%22startDay%22%3A%222027-01-12%22%2C%22lastDay%22%3A%222027-05-31%22%2C%22inDigits%22%3A%2220271%22%7D%2C%22Tillfallesperioder%22%3A%5B%7B%22ForstaRegistreringsdatum%22%3A%222027-01-07%22%2C%22ForstaUndervisningsdatum%22%3A%222027-01-12%22%2C%22Lasperiodsfordelning%22%3A%5B%7B%22Lasperiodskod%22%3A%22P3%22%2C%22Omfattningsvarde%22%3A1.5%2C%22link%22%3A%5B%5D%7D%5D%2C%22Omfattningsvarde%22%3A1.5%2C%22SistaRegistreringsdatum%22%3A%222027-01-18%22%2C%22SistaUndervisningsdatum%22%3A%222027-03-12%22%7D%5D%2C%22kod%22%3A%22DD1380%22%2C%22benamning%22%3A%22Javaprogrammering%20f%C3%B6r%20Pythonprogrammerare%22%2C%22Valvillkor%22%3A%22V%22%2C%22type%22%3A%22instance%22%7D%2C%7B%22utbildningsinstansUid%22%3A%2257b7f18f-a82e-11f0-8e06-8e0c8088416e%22%2C%22uid%22%3A%229da7a6e2-c9e1-11f0-a255-650837bd40cf%22%2C%22tillfalleskod%22%3A%2211549%22%2C%22status%22%3A%7B%22code%22%3A%22S2%22%2C%22nameSv%22%3A%22P%C3%A5b%C3%B6rjad%22%2C%22nameEn%22%3A%22Started%22%7D%2C%22utbildningstyp%22%3A%7B%22id%22%3A%2224%22%2C%22code%22%3A%222007AKURS%22%2C%22name%22%3A%22Kurs%2C%20avancerad%20niv%C3%A5%22%2C%22nameOther%22%3A%22Course%2C%20Second-cycle%22%2C%22creditsUnit%22%3A%7B%22code%22%3A%22HP%22%2C%22sv%22%3A%22H%C3%B6gskolepo%C3%A4ng%22%2C%22en%22%3A%22Credits%22%7D%2C%22level%22%3A%7B%22code%22%3A%222%22%2C%22name%22%3A%22Avancerad%20niv%C3%A5%22%7D%7D%2C%22omfattning%22%3A%7B%22number%22%3A7.5%2C%22formattedWithUnit%22%3A%227%2C5%20hp%22%7D%2C%22startperiod%22%3A%7B%22code%22%3A%22VT2027%22%2C%22startDay%22%3A%222027-01-12%22%2C%22lastDay%22%3A%222027-05-31%22%2C%22inDigits%22%3A%2220271%22%7D%2C%22Tillfallesperioder%22%3A%5B%7B%22ForstaRegistreringsdatum%22%3A%222027-01-07%22%2C%22ForstaUndervisningsdatum%22%3A%222027-01-12%22%2C%22Lasperiodsfordelning%22%3A%5B%7B%22Lasperiodskod%22%3A%22P3%22%2C%22Omfattningsvarde%22%3A3%2C%22link%22%3A%5B%5D%7D%2C%7B%22Lasperiodskod%22%3A%22P4%22%2C%22Omfattningsvarde%22%3A4.5%2C%22link%22%3A%5B%5D%7D%5D%2C%22Omfattningsvarde%22%3A7.5%2C%22SistaRegistreringsdatum%22%3A%222027-01-18%22%2C%22SistaUndervisningsdatum%22%3A%222027-05-31%22%7D%5D%2C%22kod%22%3A%22DD2352%22%2C%22benamning%22%3A%22Algoritmer%20och%20komplexitet%22%2C%22Valvillkor%22%3A%22V%22%2C%22type%22%3A%22instance%22%7D%2C%7B%22utbildningsinstansUid%22%3A%2278ff827f-db44-11e8-b548-8cda89c64326%22%2C%22uid%22%3A%220936ef65-c9f9-11f0-a255-650837bd40cf%22%2C%22tillfalleskod%22%3A%2211803%22%2C%22status%22%3A%7B%22code%22%3A%22S2%22%2C%22nameSv%22%3A%22P%C3%A5b%C3%B6rjad%22%2C%22nameEn%22%3A%22Started%22%7D%2C%22utbildningstyp%22%3A%7B%22id%22%3A%2224%22%2C%22code%22%3A%222007AKURS%22%2C%22name%22%3A%22Kurs%2C%20avancerad%20niv%C3%A5%22%2C%22nameOther%22%3A%22Course%2C%20Second-cycle%22%2C%22creditsUnit%22%3A%7B%22code%22%3A%22HP%22%2C%22sv%22%3A%22H%C3%B6gskolepo%C3%A4ng%22%2C%22en%22%3A%22Credits%22%7D%2C%22level%22%3A%7B%22code%22%3A%222%22%2C%22name%22%3A%22Avancerad%20niv%C3%A5%22%7D%7D%2C%22omfattning%22%3A%7B%22number%22%3A7.5%2C%22formattedWithUnit%22%3A%227%2C5%20hp%22%7D%2C%22startperiod%22%3A%7B%22code%22%3A%22VT2027%22%2C%22startDay%22%3A%222027-01-12%22%2C%22lastDay%22%3A%222027-05-31%22%2C%22inDigits%22%3A%2220271%22%7D%2C%22Tillfallesperioder%22%3A%5B%7B%22ForstaRegistreringsdatum%22%3A%222027-01-07%22%2C%22ForstaUndervisningsdatum%22%3A%222027-01-12%22%2C%22Lasperiodsfordelning%22%3A%5B%7B%22Lasperiodskod%22%3A%22P3%22%2C%22Omfattningsvarde%22%3A7.5%2C%22link%22%3A%5B%5D%7D%5D%2C%22Omfattningsvarde%22%3A7.5%2C%22SistaRegistreringsdatum%22%3A%222027-01-18%22%2C%22SistaUndervisningsdatum%22%3A%222027-03-12%22%7D%5D%2C%22kod%22%3A%22DD2421%22%2C%22benamning%22%3A%22Maskininl%C3%A4rning%22%2C%22Valvillkor%22%3A%22V%22%2C%22type%22%3A%22instance%22%7D%2C%7B%22utbildningsinstansUid%22%3A%22f1a19610-a9c7-11f0-b7df-f9101f074b4e%22%2C%22uid%22%3A%22622aa087-cb78-11f0-a255-650837bd40cf%22%2C%22tillfalleskod%22%3A%2212088%22%2C%22status%22%3A%7B%22code%22%3A%22S2%22%2C%22nameSv%22%3A%22P%C3%A5b%C3%B6rjad%22%2C%22nameEn%22%3A%22Started%22%7D%2C%22utbildningstyp%22%3A%7B%22id%22%3A%2222%22%2C%22code%22%3A%222007GKURS%22%2C%22name%22%3A%22Kurs%2C%20grundniv%C3%A5%22%2C%22nameOther%22%3A%22Course%2C%20First-cycle%22%2C%22creditsUnit%22%3A%7B%22code%22%3A%22HP%22%2C%22sv%22%3A%22H%C3%B6gskolepo%C3%A4ng%22%2C%22en%22%3A%22Credits%22%7D%2C%22level%22%3A%7B%22code%22%3A%221%22%2C%22name%22%3A%22Grundniv%C3%A5%22%7D%7D%2C%22omfattning%22%3A%7B%22number%22%3A6%2C%22formattedWithUnit%22%3A%226%2C0%20hp%22%7D%2C%22startperiod%22%3A%7B%22code%22%3A%22VT2027%22%2C%22startDay%22%3A%222027-01-12%22%2C%22lastDay%22%3A%222027-05-31%22%2C%22inDigits%22%3A%2220271%22%7D%2C%22Tillfallesperioder%22%3A%5B%7B%22ForstaRegistreringsdatum%22%3A%222027-03-11%22%2C%22ForstaUndervisningsdatum%22%3A%222027-03-15%22%2C%22Lasperiodsfordelning%22%3A%5B%7B%22Lasperiodskod%22%3A%22P4%22%2C%22Omfattningsvarde%22%3A6%2C%22link%22%3A%5B%5D%7D%5D%2C%22Omfattningsvarde%22%3A6%2C%22SistaRegistreringsdatum%22%3A%222027-03-22%22%2C%22SistaUndervisningsdatum%22%3A%222027-05-31%22%7D%5D%2C%22kod%22%3A%22EQ1120%22%2C%22benamning%22%3A%22Tidsdiskreta%20signaler%20och%20system%22%2C%22Valvillkor%22%3A%22V%22%2C%22type%22%3A%22instance%22%7D%2C%7B%22utbildningsinstansUid%22%3A%224e2ddf86-af0d-11f0-a2d9-d8333a7b420f%22%2C%22uid%22%3A%2233a0ecb7-c538-11f0-905a-aee84a7a4808%22%2C%22tillfalleskod%22%3A%2210924%22%2C%22status%22%3A%7B%22code%22%3A%22S2%22%2C%22nameSv%22%3A%22P%C3%A5b%C3%B6rjad%22%2C%22nameEn%22%3A%22Started%22%7D%2C%22utbildningstyp%22%3A%7B%22id%22%3A%2222%22%2C%22code%22%3A%222007GKURS%22%2C%22name%22%3A%22Kurs%2C%20grundniv%C3%A5%22%2C%22nameOther%22%3A%22Course%2C%20First-cycle%22%2C%22creditsUnit%22%3A%7B%22code%22%3A%22HP%22%2C%22sv%22%3A%22H%C3%B6gskolepo%C3%A4ng%22%2C%22en%22%3A%22Credits%22%7D%2C%22level%22%3A%7B%22code%22%3A%221%22%2C%22name%22%3A%22Grundniv%C3%A5%22%7D%7D%2C%22omfattning%22%3A%7B%22number%22%3A6%2C%22formattedWithUnit%22%3A%226%2C0%20hp%22%7D%2C%22startperiod%22%3A%7B%22code%22%3A%22VT2027%22%2C%22startDay%22%3A%222027-01-12%22%2C%22lastDay%22%3A%222027-05-31%22%2C%22inDigits%22%3A%2220271%22%7D%2C%22Tillfallesperioder%22%3A%5B%7B%22ForstaRegistreringsdatum%22%3A%222027-01-07%22%2C%22ForstaUndervisningsdatum%22%3A%222027-01-12%22%2C%22Lasperiodsfordelning%22%3A%5B%7B%22Lasperiodskod%22%3A%22P3%22%2C%22Omfattningsvarde%22%3A3%2C%22link%22%3A%5B%5D%7D%2C%7B%22Lasperiodskod%22%3A%22P4%22%2C%22Omfattningsvarde%22%3A3%2C%22link%22%3A%5B%5D%7D%5D%2C%22Omfattningsvarde%22%3A6%2C%22SistaRegistreringsdatum%22%3A%222027-01-18%22%2C%22SistaUndervisningsdatum%22%3A%222027-05-31%22%7D%5D%2C%22kod%22%3A%22MH1023%22%2C%22benamning%22%3A%22Praktiskt%20j%C3%A4mst%C3%A4lldhets-%20och%20m%C3%A5ngfaldsarbete%20i%20vetenskapliga%2C%20tekniska%20och%20industriella%20milj%C3%B6er%22%2C%22Valvillkor%22%3A%22V%22%2C%22type%22%3A%22instance%22%7D%2C%7B%22utbildningsinstansUid%22%3A%227fcfb8f5-73d8-11e8-b4e0-063f9afb40e3%22%2C%22uid%22%3A%2245f52581-d020-11f0-8398-f473a8a341d5%22%2C%22tillfalleskod%22%3A%2212370%22%2C%22status%22%3A%7B%22code%22%3A%22S2%22%2C%22nameSv%22%3A%22P%C3%A5b%C3%B6rjad%22%2C%22nameEn%22%3A%22Started%22%7D%2C%22utbildningstyp%22%3A%7B%22id%22%3A%2222%22%2C%22code%22%3A%222007GKURS%22%2C%22name%22%3A%22Kurs%2C%20grundniv%C3%A5%22%2C%22nameOther%22%3A%22Course%2C%20First-cycle%22%2C%22creditsUnit%22%3A%7B%22code%22%3A%22HP%22%2C%22sv%22%3A%22H%C3%B6gskolepo%C3%A4ng%22%2C%22en%22%3A%22Credits%22%7D%2C%22level%22%3A%7B%22code%22%3A%221%22%2C%22name%22%3A%22Grundniv%C3%A5%22%7D%7D%2C%22omfattning%22%3A%7B%22number%22%3A7.5%2C%22formattedWithUnit%22%3A%227%2C5%20hp%22%7D%2C%22startperiod%22%3A%7B%22code%22%3A%22VT2027%22%2C%22startDay%22%3A%222027-01-12%22%2C%22lastDay%22%3A%222027-05-31%22%2C%22inDigits%22%3A%2220271%22%7D%2C%22Tillfallesperioder%22%3A%5B%7B%22ForstaRegistreringsdatum%22%3A%222027-01-07%22%2C%22ForstaUndervisningsdatum%22%3A%222027-01-12%22%2C%22Lasperiodsfordelning%22%3A%5B%7B%22Lasperiodskod%22%3A%22P4%22%2C%22Omfattningsvarde%22%3A3.8%2C%22link%22%3A%5B%5D%7D%2C%7B%22Lasperiodskod%22%3A%22P3%22%2C%22Omfattningsvarde%22%3A3.7%2C%22link%22%3A%5B%5D%7D%5D%2C%22Omfattningsvarde%22%3A7.5%2C%22SistaRegistreringsdatum%22%3A%222027-01-18%22%2C%22SistaUndervisningsdatum%22%3A%222027-05-31%22%7D%5D%2C%22kod%22%3A%22SF1677%22%2C%22benamning%22%3A%22Analysens%20grunder%22%2C%22Valvillkor%22%3A%22V%22%2C%22type%22%3A%22instance%22%7D%2C%7B%22utbildningsinstansUid%22%3A%227fd78129-73d8-11e8-b4e0-063f9afb40e3%22%2C%22uid%22%3A%2245dda5d0-d020-11f0-8398-f473a8a341d5%22%2C%22tillfalleskod%22%3A%2212371%22%2C%22status%22%3A%7B%22code%22%3A%22S2%22%2C%22nameSv%22%3A%22P%C3%A5b%C3%B6rjad%22%2C%22nameEn%22%3A%22Started%22%7D%2C%22utbildningstyp%22%3A%7B%22id%22%3A%2222%22%2C%22code%22%3A%222007GKURS%22%2C%22name%22%3A%22Kurs%2C%20grundniv%C3%A5%22%2C%22nameOther%22%3A%22Course%2C%20First-cycle%22%2C%22creditsUnit%22%3A%7B%22code%22%3A%22HP%22%2C%22sv%22%3A%22H%C3%B6gskolepo%C3%A4ng%22%2C%22en%22%3A%22Credits%22%7D%2C%22level%22%3A%7B%22code%22%3A%221%22%2C%22name%22%3A%22Grundniv%C3%A5%22%7D%7D%2C%22omfattning%22%3A%7B%22number%22%3A7.5%2C%22formattedWithUnit%22%3A%227%2C5%20hp%22%7D%2C%22startperiod%22%3A%7B%22code%22%3A%22VT2027%22%2C%22startDay%22%3A%222027-01-12%22%2C%22lastDay%22%3A%222027-05-31%22%2C%22inDigits%22%3A%2220271%22%7D%2C%22Tillfallesperioder%22%3A%5B%7B%22ForstaRegistreringsdatum%22%3A%222027-01-07%22%2C%22ForstaUndervisningsdatum%22%3A%222027-01-12%22%2C%22Lasperiodsfordelning%22%3A%5B%7B%22Lasperiodskod%22%3A%22P4%22%2C%22Omfattningsvarde%22%3A3.8%2C%22link%22%3A%5B%5D%7D%2C%7B%22Lasperiodskod%22%3A%22P3%22%2C%22Omfattningsvarde%22%3A3.7%2C%22link%22%3A%5B%5D%7D%5D%2C%22Omfattningsvarde%22%3A7.5%2C%22SistaRegistreringsdatum%22%3A%222027-01-18%22%2C%22SistaUndervisningsdatum%22%3A%222027-05-31%22%7D%5D%2C%22kod%22%3A%22SF1678%22%2C%22benamning%22%3A%22Grupper%20och%20ringar%22%2C%22Valvillkor%22%3A%22V%22%2C%22type%22%3A%22instance%22%7D%2C%7B%22utbildningsinstansUid%22%3A%227fe7389d-73d8-11e8-b4e0-063f9afb40e3%22%2C%22uid%22%3A%22ab3f72fb-c93f-11f0-a255-650837bd40cf%22%2C%22tillfalleskod%22%3A%2212373%22%2C%22status%22%3A%7B%22code%22%3A%22S2%22%2C%22nameSv%22%3A%22P%C3%A5b%C3%B6rjad%22%2C%22nameEn%22%3A%22Started%22%7D%2C%22utbildningstyp%22%3A%7B%22id%22%3A%2222%22%2C%22code%22%3A%222007GKURS%22%2C%22name%22%3A%22Kurs%2C%20grundniv%C3%A5%22%2C%22nameOther%22%3A%22Course%2C%20First-cycle%22%2C%22creditsUnit%22%3A%7B%22code%22%3A%22HP%22%2C%22sv%22%3A%22H%C3%B6gskolepo%C3%A4ng%22%2C%22en%22%3A%22Credits%22%7D%2C%22level%22%3A%7B%22code%22%3A%221%22%2C%22name%22%3A%22Grundniv%C3%A5%22%7D%7D%2C%22omfattning%22%3A%7B%22number%22%3A7.5%2C%22formattedWithUnit%22%3A%227%2C5%20hp%22%7D%2C%22startperiod%22%3A%7B%22code%22%3A%22VT2027%22%2C%22startDay%22%3A%222027-01-12%22%2C%22lastDay%22%3A%222027-05-31%22%2C%22inDigits%22%3A%2220271%22%7D%2C%22Tillfallesperioder%22%3A%5B%7B%22ForstaRegistreringsdatum%22%3A%222027-01-07%22%2C%22ForstaUndervisningsdatum%22%3A%222027-01-12%22%2C%22Lasperiodsfordelning%22%3A%5B%7B%22Lasperiodskod%22%3A%22P3%22%2C%22Omfattningsvarde%22%3A7.5%2C%22link%22%3A%5B%5D%7D%5D%2C%22Omfattningsvarde%22%3A7.5%2C%22SistaRegistreringsdatum%22%3A%222027-01-18%22%2C%22SistaUndervisningsdatum%22%3A%222027-03-12%22%7D%5D%2C%22kod%22%3A%22SF1679%22%2C%22benamning%22%3A%22Diskret%20matematik%22%2C%22Valvillkor%22%3A%22V%22%2C%22type%22%3A%22instance%22%7D%2C%7B%22utbildningsinstansUid%22%3A%227ffb8407-73d8-11e8-b4e0-063f9afb40e3%22%2C%22uid%22%3A%224603084f-d020-11f0-8398-f473a8a341d5%22%2C%22tillfalleskod%22%3A%2212383%22%2C%22status%22%3A%7B%22code%22%3A%22S2%22%2C%22nameSv%22%3A%22P%C3%A5b%C3%B6rjad%22%2C%22nameEn%22%3A%22Started%22%7D%2C%22utbildningstyp%22%3A%7B%22id%22%3A%2222%22%2C%22code%22%3A%222007GKURS%22%2C%22name%22%3A%22Kurs%2C%20grundniv%C3%A5%22%2C%22nameOther%22%3A%22Course%2C%20First-cycle%22%2C%22creditsUnit%22%3A%7B%22code%22%3A%22HP%22%2C%22sv%22%3A%22H%C3%B6gskolepo%C3%A4ng%22%2C%22en%22%3A%22Credits%22%7D%2C%22level%22%3A%7B%22code%22%3A%221%22%2C%22name%22%3A%22Grundniv%C3%A5%22%7D%7D%2C%22omfattning%22%3A%7B%22number%22%3A7.5%2C%22formattedWithUnit%22%3A%227%2C5%20hp%22%7D%2C%22startperiod%22%3A%7B%22code%22%3A%22VT2027%22%2C%22startDay%22%3A%222027-01-12%22%2C%22lastDay%22%3A%222027-05-31%22%2C%22inDigits%22%3A%2220271%22%7D%2C%22Tillfallesperioder%22%3A%5B%7B%22ForstaRegistreringsdatum%22%3A%222027-01-07%22%2C%22ForstaUndervisningsdatum%22%3A%222027-01-12%22%2C%22Lasperiodsfordelning%22%3A%5B%7B%22Lasperiodskod%22%3A%22P4%22%2C%22Omfattningsvarde%22%3A3.8%2C%22link%22%3A%5B%5D%7D%2C%7B%22Lasperiodskod%22%3A%22P3%22%2C%22Omfattningsvarde%22%3A3.7%2C%22link%22%3A%5B%5D%7D%5D%2C%22Omfattningsvarde%22%3A7.5%2C%22SistaRegistreringsdatum%22%3A%222027-01-18%22%2C%22SistaUndervisningsdatum%22%3A%222027-05-31%22%7D%5D%2C%22kod%22%3A%22SF1691%22%2C%22benamning%22%3A%22Komplex%20analys%22%2C%22Valvillkor%22%3A%22V%22%2C%22type%22%3A%22instance%22%7D%2C%7B%22utbildningsinstansUid%22%3A%228010e0d4-73d8-11e8-b4e0-063f9afb40e3%22%2C%22uid%22%3A%224662db7f-d020-11f0-8398-f473a8a341d5%22%2C%22tillfalleskod%22%3A%2212388%22%2C%22status%22%3A%7B%22code%22%3A%22S2%22%2C%22nameSv%22%3A%22P%C3%A5b%C3%B6rjad%22%2C%22nameEn%22%3A%22Started%22%7D%2C%22utbildningstyp%22%3A%7B%22id%22%3A%2222%22%2C%22code%22%3A%222007GKURS%22%2C%22name%22%3A%22Kurs%2C%20grundniv%C3%A5%22%2C%22nameOther%22%3A%22Course%2C%20First-cycle%22%2C%22creditsUnit%22%3A%7B%22code%22%3A%22HP%22%2C%22sv%22%3A%22H%C3%B6gskolepo%C3%A4ng%22%2C%22en%22%3A%22Credits%22%7D%2C%22level%22%3A%7B%22code%22%3A%221%22%2C%22name%22%3A%22Grundniv%C3%A5%22%7D%7D%2C%22omfattning%22%3A%7B%22number%22%3A6%2C%22formattedWithUnit%22%3A%226%2C0%20hp%22%7D%2C%22startperiod%22%3A%7B%22code%22%3A%22VT2027%22%2C%22startDay%22%3A%222027-01-12%22%2C%22lastDay%22%3A%222027-05-31%22%2C%22inDigits%22%3A%2220271%22%7D%2C%22Tillfallesperioder%22%3A%5B%7B%22ForstaRegistreringsdatum%22%3A%222027-03-11%22%2C%22ForstaUndervisningsdatum%22%3A%222027-03-15%22%2C%22Lasperiodsfordelning%22%3A%5B%7B%22Lasperiodskod%22%3A%22P4%22%2C%22Omfattningsvarde%22%3A6%2C%22link%22%3A%5B%5D%7D%5D%2C%22Omfattningsvarde%22%3A6%2C%22SistaRegistreringsdatum%22%3A%222027-03-22%22%2C%22SistaUndervisningsdatum%22%3A%222027-05-31%22%7D%5D%2C%22kod%22%3A%22SF1861%22%2C%22benamning%22%3A%22Optimeringsl%C3%A4ra%22%2C%22Valvillkor%22%3A%22V%22%2C%22type%22%3A%22instance%22%7D%2C%7B%22utbildningsinstansUid%22%3A%22803d2109-73d8-11e8-afa7-8e408e694e54%22%2C%22uid%22%3A%22467a8263-d020-11f0-8398-f473a8a341d5%22%2C%22tillfalleskod%22%3A%2212390%22%2C%22status%22%3A%7B%22code%22%3A%22S2%22%2C%22nameSv%22%3A%22P%C3%A5b%C3%B6rjad%22%2C%22nameEn%22%3A%22Started%22%7D%2C%22utbildningstyp%22%3A%7B%22id%22%3A%2222%22%2C%22code%22%3A%222007GKURS%22%2C%22name%22%3A%22Kurs%2C%20grundniv%C3%A5%22%2C%22nameOther%22%3A%22Course%2C%20First-cycle%22%2C%22creditsUnit%22%3A%7B%22code%22%3A%22HP%22%2C%22sv%22%3A%22H%C3%B6gskolepo%C3%A4ng%22%2C%22en%22%3A%22Credits%22%7D%2C%22level%22%3A%7B%22code%22%3A%221%22%2C%22name%22%3A%22Grundniv%C3%A5%22%7D%7D%2C%22omfattning%22%3A%7B%22number%22%3A3%2C%22formattedWithUnit%22%3A%223%2C0%20hp%22%7D%2C%22startperiod%22%3A%7B%22code%22%3A%22VT2027%22%2C%22startDay%22%3A%222027-01-12%22%2C%22lastDay%22%3A%222027-05-31%22%2C%22inDigits%22%3A%2220271%22%7D%2C%22Tillfallesperioder%22%3A%5B%7B%22ForstaRegistreringsdatum%22%3A%222027-03-11%22%2C%22ForstaUndervisningsdatum%22%3A%222027-03-15%22%2C%22Lasperiodsfordelning%22%3A%5B%7B%22Lasperiodskod%22%3A%22P4%22%2C%22Omfattningsvarde%22%3A3%2C%22link%22%3A%5B%5D%7D%5D%2C%22Omfattningsvarde%22%3A3%2C%22SistaRegistreringsdatum%22%3A%222027-03-22%22%2C%22SistaUndervisningsdatum%22%3A%222027-05-31%22%7D%5D%2C%22kod%22%3A%22SF1904%22%2C%22benamning%22%3A%22Markovprocesser%2C%20grundkurs%22%2C%22Valvillkor%22%3A%22V%22%2C%22type%22%3A%22instance%22%7D%2C%7B%22utbildningsinstansUid%22%3A%2280854df8-73d8-11e8-b4e0-063f9afb40e3%22%2C%22uid%22%3A%22ccc72dd8-d04d-11f0-8398-f473a8a341d5%22%2C%22tillfalleskod%22%3A%2212420%22%2C%22status%22%3A%7B%22code%22%3A%22S2%22%2C%22nameSv%22%3A%22P%C3%A5b%C3%B6rjad%22%2C%22nameEn%22%3A%22Started%22%7D%2C%22utbildningstyp%22%3A%7B%22id%22%3A%2224%22%2C%22code%22%3A%222007AKURS%22%2C%22name%22%3A%22Kurs%2C%20avancerad%20niv%C3%A5%22%2C%22nameOther%22%3A%22Course%2C%20Second-cycle%22%2C%22creditsUnit%22%3A%7B%22code%22%3A%22HP%22%2C%22sv%22%3A%22H%C3%B6gskolepo%C3%A4ng%22%2C%22en%22%3A%22Credits%22%7D%2C%22level%22%3A%7B%22code%22%3A%222%22%2C%22name%22%3A%22Avancerad%20niv%C3%A5%22%7D%7D%2C%22omfattning%22%3A%7B%22number%22%3A7.5%2C%22formattedWithUnit%22%3A%227%2C5%20hp%22%7D%2C%22startperiod%22%3A%7B%22code%22%3A%22VT2027%22%2C%22startDay%22%3A%222027-01-12%22%2C%22lastDay%22%3A%222027-05-31%22%2C%22inDigits%22%3A%2220271%22%7D%2C%22Tillfallesperioder%22%3A%5B%7B%22ForstaRegistreringsdatum%22%3A%222027-03-11%22%2C%22ForstaUndervisningsdatum%22%3A%222027-03-15%22%2C%22Lasperiodsfordelning%22%3A%5B%7B%22Lasperiodskod%22%3A%22P4%22%2C%22Omfattningsvarde%22%3A7.5%2C%22link%22%3A%5B%5D%7D%5D%2C%22Omfattningsvarde%22%3A7.5%2C%22SistaRegistreringsdatum%22%3A%222027-03-22%22%2C%22SistaUndervisningsdatum%22%3A%222027-05-31%22%7D%5D%2C%22kod%22%3A%22SF2701%22%2C%22benamning%22%3A%22Finansiell%20matematik%2C%20grundkurs%22%2C%22Valvillkor%22%3A%22V%22%2C%22type%22%3A%22instance%22%7D%2C%7B%22utbildningsinstansUid%22%3A%2281278107-73d8-11e8-b4e0-063f9afb40e3%22%2C%22uid%22%3A%22aa906dff-c93f-11f0-a255-650837bd40cf%22%2C%22tillfalleskod%22%3A%2212459%22%2C%22status%22%3A%7B%22code%22%3A%22S2%22%2C%22nameSv%22%3A%22P%C3%A5b%C3%B6rjad%22%2C%22nameEn%22%3A%22Started%22%7D%2C%22utbildningstyp%22%3A%7B%22id%22%3A%2224%22%2C%22code%22%3A%222007AKURS%22%2C%22name%22%3A%22Kurs%2C%20avancerad%20niv%C3%A5%22%2C%22nameOther%22%3A%22Course%2C%20Second-cycle%22%2C%22creditsUnit%22%3A%7B%22code%22%3A%22HP%22%2C%22sv%22%3A%22H%C3%B6gskolepo%C3%A4ng%22%2C%22en%22%3A%22Credits%22%7D%2C%22level%22%3A%7B%22code%22%3A%222%22%2C%22name%22%3A%22Avancerad%20niv%C3%A5%22%7D%7D%2C%22omfattning%22%3A%7B%22number%22%3A7.5%2C%22formattedWithUnit%22%3A%227%2C5%20hp%22%7D%2C%22startperiod%22%3A%7B%22code%22%3A%22VT2027%22%2C%22startDay%22%3A%222027-01-12%22%2C%22lastDay%22%3A%222027-05-31%22%2C%22inDigits%22%3A%2220271%22%7D%2C%22Tillfallesperioder%22%3A%5B%7B%22ForstaRegistreringsdatum%22%3A%222027-01-07%22%2C%22ForstaUndervisningsdatum%22%3A%222027-01-12%22%2C%22Lasperiodsfordelning%22%3A%5B%7B%22Lasperiodskod%22%3A%22P3%22%2C%22Omfattningsvarde%22%3A7.5%2C%22link%22%3A%5B%5D%7D%5D%2C%22Omfattningsvarde%22%3A7.5%2C%22SistaRegistreringsdatum%22%3A%222027-01-18%22%2C%22SistaUndervisningsdatum%22%3A%222027-03-12%22%7D%5D%2C%22kod%22%3A%22SF2930%22%2C%22benamning%22%3A%22Regressionsanalys%22%2C%22Valvillkor%22%3A%22V%22%2C%22type%22%3A%22instance%22%7D%2C%7B%22utbildningsinstansUid%22%3A%2234c0c34e-969b-11ef-8f91-f98ca46144d5%22%2C%22uid%22%3A%22bf788dac-c536-11f0-905a-aee84a7a4808%22%2C%22tillfalleskod%22%3A%2210554%22%2C%22status%22%3A%7B%22code%22%3A%22S2%22%2C%22nameSv%22%3A%22P%C3%A5b%C3%B6rjad%22%2C%22nameEn%22%3A%22Started%22%7D%2C%22utbildningstyp%22%3A%7B%22id%22%3A%2224%22%2C%22code%22%3A%222007AKURS%22%2C%22name%22%3A%22Kurs%2C%20avancerad%20niv%C3%A5%22%2C%22nameOther%22%3A%22Course%2C%20Second-cycle%22%2C%22creditsUnit%22%3A%7B%22code%22%3A%22HP%22%2C%22sv%22%3A%22H%C3%B6gskolepo%C3%A4ng%22%2C%22en%22%3A%22Credits%22%7D%2C%22level%22%3A%7B%22code%22%3A%222%22%2C%22name%22%3A%22Avancerad%20niv%C3%A5%22%7D%7D%2C%22omfattning%22%3A%7B%22number%22%3A7.5%2C%22formattedWithUnit%22%3A%227%2C5%20hp%22%7D%2C%22startperiod%22%3A%7B%22code%22%3A%22VT2027%22%2C%22startDay%22%3A%222027-01-12%22%2C%22lastDay%22%3A%222027-05-31%22%2C%22inDigits%22%3A%2220271%22%7D%2C%22Tillfallesperioder%22%3A%5B%7B%22ForstaRegistreringsdatum%22%3A%222027-03-11%22%2C%22ForstaUndervisningsdatum%22%3A%222027-03-15%22%2C%22Lasperiodsfordelning%22%3A%5B%7B%22Lasperiodskod%22%3A%22P4%22%2C%22Omfattningsvarde%22%3A7.5%2C%22link%22%3A%5B%5D%7D%5D%2C%22Omfattningsvarde%22%3A7.5%2C%22SistaRegistreringsdatum%22%3A%222027-03-22%22%2C%22SistaUndervisningsdatum%22%3A%222027-05-31%22%7D%5D%2C%22kod%22%3A%22SH2404%22%2C%22benamning%22%3A%22Astrofysik%22%2C%22Valvillkor%22%3A%22V%22%2C%22type%22%3A%22instance%22%7D%2C%7B%22utbildningsinstansUid%22%3A%221cc67613-8f96-11f0-b29b-713806674b84%22%2C%22uid%22%3A%22d3987cf6-c540-11f0-905a-aee84a7a4808%22%2C%22tillfalleskod%22%3A%2260123%22%2C%22status%22%3A%7B%22code%22%3A%22S2%22%2C%22nameSv%22%3A%22P%C3%A5b%C3%B6rjad%22%2C%22nameEn%22%3A%22Started%22%7D%2C%22utbildningstyp%22%3A%7B%22id%22%3A%2222%22%2C%22code%22%3A%222007GKURS%22%2C%22name%22%3A%22Kurs%2C%20grundniv%C3%A5%22%2C%22nameOther%22%3A%22Course%2C%20First-cycle%22%2C%22creditsUnit%22%3A%7B%22code%22%3A%22HP%22%2C%22sv%22%3A%22H%C3%B6gskolepo%C3%A4ng%22%2C%22en%22%3A%22Credits%22%7D%2C%22level%22%3A%7B%22code%22%3A%221%22%2C%22name%22%3A%22Grundniv%C3%A5%22%7D%7D%2C%22omfattning%22%3A%7B%22number%22%3A3%2C%22formattedWithUnit%22%3A%223%2C0%20hp%22%7D%2C%22startperiod%22%3A%7B%22code%22%3A%22VT2027%22%2C%22startDay%22%3A%222027-01-12%22%2C%22lastDay%22%3A%222027-05-31%22%2C%22inDigits%22%3A%2220271%22%7D%2C%22Tillfallesperioder%22%3A%5B%7B%22ForstaRegistreringsdatum%22%3A%222027-03-11%22%2C%22ForstaUndervisningsdatum%22%3A%222027-03-15%22%2C%22Lasperiodsfordelning%22%3A%5B%7B%22Lasperiodskod%22%3A%22P4%22%2C%22Omfattningsvarde%22%3A3%2C%22link%22%3A%5B%5D%7D%5D%2C%22Omfattningsvarde%22%3A3%2C%22SistaRegistreringsdatum%22%3A%222027-03-22%22%2C%22SistaUndervisningsdatum%22%3A%222027-05-31%22%7D%5D%2C%22kod%22%3A%22SI1142%22%2C%22benamning%22%3A%22Fysikens%20matematiska%20metoder%2C%20till%C3%A4ggskurs%22%2C%22Valvillkor%22%3A%22V%22%2C%22type%22%3A%22instance%22%7D%2C%7B%22utbildningsinstansUid%22%3A%22841cf33a-73d8-11e8-b4e0-063f9afb40e3%22%2C%22uid%22%3A%22e33bc89e-c540-11f0-905a-aee84a7a4808%22%2C%22tillfalleskod%22%3A%2260163%22%2C%22status%22%3A%7B%22code%22%3A%22S2%22%2C%22nameSv%22%3A%22P%C3%A5b%C3%B6rjad%22%2C%22nameEn%22%3A%22Started%22%7D%2C%22utbildningstyp%22%3A%7B%22id%22%3A%2222%22%2C%22code%22%3A%222007GKURS%22%2C%22name%22%3A%22Kurs%2C%20grundniv%C3%A5%22%2C%22nameOther%22%3A%22Course%2C%20First-cycle%22%2C%22creditsUnit%22%3A%7B%22code%22%3A%22HP%22%2C%22sv%22%3A%22H%C3%B6gskolepo%C3%A4ng%22%2C%22en%22%3A%22Credits%22%7D%2C%22level%22%3A%7B%22code%22%3A%221%22%2C%22name%22%3A%22Grundniv%C3%A5%22%7D%7D%2C%22omfattning%22%3A%7B%22number%22%3A7.5%2C%22formattedWithUnit%22%3A%227%2C5%20hp%22%7D%2C%22startperiod%22%3A%7B%22code%22%3A%22VT2027%22%2C%22startDay%22%3A%222027-01-12%22%2C%22lastDay%22%3A%222027-05-31%22%2C%22inDigits%22%3A%2220271%22%7D%2C%22Tillfallesperioder%22%3A%5B%7B%22ForstaRegistreringsdatum%22%3A%222027-01-07%22%2C%22ForstaUndervisningsdatum%22%3A%222027-01-12%22%2C%22Lasperiodsfordelning%22%3A%5B%7B%22Lasperiodskod%22%3A%22P3%22%2C%22Omfattningsvarde%22%3A7.5%2C%22link%22%3A%5B%5D%7D%5D%2C%22Omfattningsvarde%22%3A7.5%2C%22SistaRegistreringsdatum%22%3A%222027-01-18%22%2C%22SistaUndervisningsdatum%22%3A%222027-03-12%22%7D%5D%2C%22kod%22%3A%22SI1162%22%2C%22benamning%22%3A%22Statistisk%20fysik%22%2C%22Valvillkor%22%3A%22V%22%2C%22type%22%3A%22instance%22%7D%2C%7B%22utbildningsinstansUid%22%3A%22c4c8cc60-8f98-11f0-b29b-713806674b84%22%2C%22uid%22%3A%22e0b723b9-c541-11f0-905a-aee84a7a4808%22%2C%22tillfalleskod%22%3A%2260925%22%2C%22status%22%3A%7B%22code%22%3A%22S2%22%2C%22nameSv%22%3A%22P%C3%A5b%C3%B6rjad%22%2C%22nameEn%22%3A%22Started%22%7D%2C%22utbildningstyp%22%3A%7B%22id%22%3A%2224%22%2C%22code%22%3A%222007AKURS%22%2C%22name%22%3A%22Kurs%2C%20avancerad%20niv%C3%A5%22%2C%22nameOther%22%3A%22Course%2C%20Second-cycle%22%2C%22creditsUnit%22%3A%7B%22code%22%3A%22HP%22%2C%22sv%22%3A%22H%C3%B6gskolepo%C3%A4ng%22%2C%22en%22%3A%22Credits%22%7D%2C%22level%22%3A%7B%22code%22%3A%222%22%2C%22name%22%3A%22Avancerad%20niv%C3%A5%22%7D%7D%2C%22omfattning%22%3A%7B%22number%22%3A7.5%2C%22formattedWithUnit%22%3A%227%2C5%20hp%22%7D%2C%22startperiod%22%3A%7B%22code%22%3A%22VT2027%22%2C%22startDay%22%3A%222027-01-12%22%2C%22lastDay%22%3A%222027-05-31%22%2C%22inDigits%22%3A%2220271%22%7D%2C%22Tillfallesperioder%22%3A%5B%7B%22ForstaRegistreringsdatum%22%3A%222027-03-11%22%2C%22ForstaUndervisningsdatum%22%3A%222027-03-15%22%2C%22Lasperiodsfordelning%22%3A%5B%7B%22Lasperiodskod%22%3A%22P4%22%2C%22Omfattningsvarde%22%3A7.5%2C%22link%22%3A%5B%5D%7D%5D%2C%22Omfattningsvarde%22%3A7.5%2C%22SistaRegistreringsdatum%22%3A%222027-03-22%22%2C%22SistaUndervisningsdatum%22%3A%222027-05-31%22%7D%5D%2C%22kod%22%3A%22SI2360%22%2C%22benamning%22%3A%22Analytisk%20mekanik%20och%20klassisk%20f%C3%A4ltteori%22%2C%22Valvillkor%22%3A%22V%22%2C%22type%22%3A%22instance%22%7D%2C%7B%22utbildningsinstansUid%22%3A%22209dbaf0-30e3-11ec-8540-ebd4d50c41d5%22%2C%22uid%22%3A%221b096278-c46b-11f0-ad17-5d9f656e4e41%22%2C%22tillfalleskod%22%3A%2260795%22%2C%22status%22%3A%7B%22code%22%3A%22S2%22%2C%22nameSv%22%3A%22P%C3%A5b%C3%B6rjad%22%2C%22nameEn%22%3A%22Started%22%7D%2C%22utbildningstyp%22%3A%7B%22id%22%3A%2224%22%2C%22code%22%3A%222007AKURS%22%2C%22name%22%3A%22Kurs%2C%20avancerad%20niv%C3%A5%22%2C%22nameOther%22%3A%22Course%2C%20Second-cycle%22%2C%22creditsUnit%22%3A%7B%22code%22%3A%22HP%22%2C%22sv%22%3A%22H%C3%B6gskolepo%C3%A4ng%22%2C%22en%22%3A%22Credits%22%7D%2C%22level%22%3A%7B%22code%22%3A%222%22%2C%22name%22%3A%22Avancerad%20niv%C3%A5%22%7D%7D%2C%22omfattning%22%3A%7B%22number%22%3A7.5%2C%22formattedWithUnit%22%3A%227%2C5%20hp%22%7D%2C%22startperiod%22%3A%7B%22code%22%3A%22VT2027%22%2C%22startDay%22%3A%222027-01-12%22%2C%22lastDay%22%3A%222027-05-31%22%2C%22inDigits%22%3A%2220271%22%7D%2C%22Tillfallesperioder%22%3A%5B%7B%22ForstaRegistreringsdatum%22%3A%222027-03-11%22%2C%22ForstaUndervisningsdatum%22%3A%222027-03-15%22%2C%22Lasperiodsfordelning%22%3A%5B%7B%22Lasperiodskod%22%3A%22P4%22%2C%22Omfattningsvarde%22%3A7.5%2C%22link%22%3A%5B%5D%7D%5D%2C%22Omfattningsvarde%22%3A7.5%2C%22SistaRegistreringsdatum%22%3A%222027-03-22%22%2C%22SistaUndervisningsdatum%22%3A%222027-05-31%22%7D%5D%2C%22kod%22%3A%22SK2712%22%2C%22benamning%22%3A%22Milj%C3%B6fysik%22%2C%22Valvillkor%22%3A%22V%22%2C%22type%22%3A%22instance%22%7D%2C%7B%22utbildningsinstansUid%22%3A%22e1fc939b-7e06-11e8-9a5f-3c9998814fb7%22%2C%22uid%22%3A%2207ecd378-cf80-11f0-9d49-fd72c5714a36%22%2C%22tillfalleskod%22%3A%2261171%22%2C%22status%22%3A%7B%22code%22%3A%22S2%22%2C%22nameSv%22%3A%22P%C3%A5b%C3%B6rjad%22%2C%22nameEn%22%3A%22Started%22%7D%2C%22utbildningstyp%22%3A%7B%22id%22%3A%2224%22%2C%22code%22%3A%222007AKURS%22%2C%22name%22%3A%22Kurs%2C%20avancerad%20niv%C3%A5%22%2C%22nameOther%22%3A%22Course%2C%20Second-cycle%22%2C%22creditsUnit%22%3A%7B%22code%22%3A%22HP%22%2C%22sv%22%3A%22H%C3%B6gskolepo%C3%A4ng%22%2C%22en%22%3A%22Credits%22%7D%2C%22level%22%3A%7B%22code%22%3A%222%22%2C%22name%22%3A%22Avancerad%20niv%C3%A5%22%7D%7D%2C%22omfattning%22%3A%7B%22number%22%3A7.5%2C%22formattedWithUnit%22%3A%227%2C5%20hp%22%7D%2C%22startperiod%22%3A%7B%22code%22%3A%22VT2027%22%2C%22startDay%22%3A%222027-01-12%22%2C%22lastDay%22%3A%222027-05-31%22%2C%22inDigits%22%3A%2220271%22%7D%2C%22Tillfallesperioder%22%3A%5B%7B%22ForstaRegistreringsdatum%22%3A%222027-03-11%22%2C%22ForstaUndervisningsdatum%22%3A%222027-03-15%22%2C%22Lasperiodsfordelning%22%3A%5B%7B%22Lasperiodskod%22%3A%22P4%22%2C%22Omfattningsvarde%22%3A7.5%2C%22link%22%3A%5B%5D%7D%5D%2C%22Omfattningsvarde%22%3A7.5%2C%22SistaRegistreringsdatum%22%3A%222027-03-22%22%2C%22SistaUndervisningsdatum%22%3A%222027-05-31%22%7D%5D%2C%22kod%22%3A%22AK2011%22%2C%22benamning%22%3A%22Teknik%20och%20etik%22%2C%22Valvillkor%22%3A%22V%22%2C%22type%22%3A%22instance%22%7D%2C%7B%22utbildningsinstansUid%22%3A%22b48a52a5-dd0c-11e8-bb7a-19f8cd1a470e%22%2C%22uid%22%3A%229849c2e2-cad9-11f0-a255-650837bd40cf%22%2C%22tillfalleskod%22%3A%2211788%22%2C%22status%22%3A%7B%22code%22%3A%22S2%22%2C%22nameSv%22%3A%22P%C3%A5b%C3%B6rjad%22%2C%22nameEn%22%3A%22Started%22%7D%2C%22utbildningstyp%22%3A%7B%22id%22%3A%2222%22%2C%22code%22%3A%222007GKURS%22%2C%22name%22%3A%22Kurs%2C%20grundniv%C3%A5%22%2C%22nameOther%22%3A%22Course%2C%20First-cycle%22%2C%22creditsUnit%22%3A%7B%22code%22%3A%22HP%22%2C%22sv%22%3A%22H%C3%B6gskolepo%C3%A4ng%22%2C%22en%22%3A%22Credits%22%7D%2C%22level%22%3A%7B%22code%22%3A%221%22%2C%22name%22%3A%22Grundniv%C3%A5%22%7D%7D%2C%22omfattning%22%3A%7B%22number%22%3A15%2C%22formattedWithUnit%22%3A%2215%2C0%20hp%22%7D%2C%22startperiod%22%3A%7B%22code%22%3A%22VT2027%22%2C%22startDay%22%3A%222027-01-12%22%2C%22lastDay%22%3A%222027-05-31%22%2C%22inDigits%22%3A%2220271%22%7D%2C%22Tillfallesperioder%22%3A%5B%7B%22ForstaRegistreringsdatum%22%3A%222027-01-07%22%2C%22ForstaUndervisningsdatum%22%3A%222027-01-12%22%2C%22Lasperiodsfordelning%22%3A%5B%7B%22Lasperiodskod%22%3A%22P4%22%2C%22Omfattningsvarde%22%3A7.5%2C%22link%22%3A%5B%5D%7D%2C%7B%22Lasperiodskod%22%3A%22P3%22%2C%22Omfattningsvarde%22%3A7.5%2C%22link%22%3A%5B%5D%7D%5D%2C%22Omfattningsvarde%22%3A15%2C%22SistaRegistreringsdatum%22%3A%222027-01-18%22%2C%22SistaUndervisningsdatum%22%3A%222027-05-31%22%7D%5D%2C%22kod%22%3A%22EF112X%22%2C%22benamning%22%3A%22Examensarbete%20inom%20elektroteknik%2C%20grundniv%C3%A5%22%2C%22Valvillkor%22%3A%22VV%22%2C%22type%22%3A%22instance%22%7D%2C%7B%22utbildningsinstansUid%22%3A%22f50679d1-969f-11ea-a1f9-cb69981448b1%22%2C%22uid%22%3A%22f507f86d-caca-11f0-a255-650837bd40cf%22%2C%22tillfalleskod%22%3A%2210259%22%2C%22status%22%3A%7B%22code%22%3A%22S2%22%2C%22nameSv%22%3A%22P%C3%A5b%C3%B6rjad%22%2C%22nameEn%22%3A%22Started%22%7D%2C%22utbildningstyp%22%3A%7B%22id%22%3A%2222%22%2C%22code%22%3A%222007GKURS%22%2C%22name%22%3A%22Kurs%2C%20grundniv%C3%A5%22%2C%22nameOther%22%3A%22Course%2C%20First-cycle%22%2C%22creditsUnit%22%3A%7B%22code%22%3A%22HP%22%2C%22sv%22%3A%22H%C3%B6gskolepo%C3%A4ng%22%2C%22en%22%3A%22Credits%22%7D%2C%22level%22%3A%7B%22code%22%3A%221%22%2C%22name%22%3A%22Grundniv%C3%A5%22%7D%7D%2C%22omfattning%22%3A%7B%22number%22%3A15%2C%22formattedWithUnit%22%3A%2215%2C0%20hp%22%7D%2C%22startperiod%22%3A%7B%22code%22%3A%22VT2027%22%2C%22startDay%22%3A%222027-01-12%22%2C%22lastDay%22%3A%222027-05-31%22%2C%22inDigits%22%3A%2220271%22%7D%2C%22Tillfallesperioder%22%3A%5B%7B%22ForstaRegistreringsdatum%22%3A%222027-01-07%22%2C%22ForstaUndervisningsdatum%22%3A%222027-01-12%22%2C%22Lasperiodsfordelning%22%3A%5B%7B%22Lasperiodskod%22%3A%22P4%22%2C%22Omfattningsvarde%22%3A7.5%2C%22link%22%3A%5B%5D%7D%2C%7B%22Lasperiodskod%22%3A%22P3%22%2C%22Omfattningsvarde%22%3A7.5%2C%22link%22%3A%5B%5D%7D%5D%2C%22Omfattningsvarde%22%3A15%2C%22SistaRegistreringsdatum%22%3A%222027-01-18%22%2C%22SistaUndervisningsdatum%22%3A%222027-05-31%22%7D%5D%2C%22kod%22%3A%22SA114X%22%2C%22benamning%22%3A%22Examensarbete%20inom%20teknisk%20fysik%2C%20grundniv%C3%A5%22%2C%22Valvillkor%22%3A%22VV%22%2C%22type%22%3A%22instance%22%7D%2C%7B%22utbildningsinstansUid%22%3A%22b12948ba-a34c-11f0-ac90-ac3a838f4dd7%22%2C%22uid%22%3A%22803c6558-cb96-11f0-a255-650837bd40cf%22%2C%22tillfalleskod%22%3A%2210914%22%2C%22status%22%3A%7B%22code%22%3A%22S3%22%2C%22nameSv%22%3A%22Komplett%22%2C%22nameEn%22%3A%22Complete%22%7D%2C%22utbildningstyp%22%3A%7B%22id%22%3A%2222%22%2C%22code%22%3A%222007GKURS%22%2C%22name%22%3A%22Kurs%2C%20grundniv%C3%A5%22%2C%22nameOther%22%3A%22Course%2C%20First-cycle%22%2C%22creditsUnit%22%3A%7B%22code%22%3A%22HP%22%2C%22sv%22%3A%22H%C3%B6gskolepo%C3%A4ng%22%2C%22en%22%3A%22Credits%22%7D%2C%22level%22%3A%7B%22code%22%3A%221%22%2C%22name%22%3A%22Grundniv%C3%A5%22%7D%7D%2C%22omfattning%22%3A%7B%22number%22%3A9%2C%22formattedWithUnit%22%3A%229%2C0%20hp%22%7D%2C%22startperiod%22%3A%7B%22code%22%3A%22HT2026%22%2C%22startDay%22%3A%222026-08-24%22%2C%22lastDay%22%3A%222027-01-11%22%2C%22inDigits%22%3A%2220262%22%7D%2C%22Tillfallesperioder%22%3A%5B%7B%22ForstaRegistreringsdatum%22%3A%222026-08-20%22%2C%22ForstaUndervisningsdatum%22%3A%222026-08-24%22%2C%22Lasperiodsfordelning%22%3A%5B%7B%22Lasperiodskod%22%3A%22P2%22%2C%22Omfattningsvarde%22%3A3%2C%22link%22%3A%5B%5D%7D%2C%7B%22Lasperiodskod%22%3A%22P1%22%2C%22Omfattningsvarde%22%3A6%2C%22link%22%3A%5B%5D%7D%5D%2C%22Omfattningsvarde%22%3A9%2C%22SistaRegistreringsdatum%22%3A%222026-08-31%22%2C%22SistaUndervisningsdatum%22%3A%222027-01-11%22%7D%5D%2C%22kod%22%3A%22EI1320%22%2C%22benamning%22%3A%22Teoretisk%20elektroteknik%22%2C%22Valvillkor%22%3A%22O%22%2C%22type%22%3A%22instance%22%7D%2C%7B%22utbildningsinstansUid%22%3A%2247f95ef1-9ebb-11eb-b121-4a7c58ae420f%22%2C%22uid%22%3A%22d5f7df70-cb7c-11f0-a255-650837bd40cf%22%2C%22tillfalleskod%22%3A%2211039%22%2C%22status%22%3A%7B%22code%22%3A%22S3%22%2C%22nameSv%22%3A%22Komplett%22%2C%22nameEn%22%3A%22Complete%22%7D%2C%22utbildningstyp%22%3A%7B%22id%22%3A%2222%22%2C%22code%22%3A%222007GKURS%22%2C%22name%22%3A%22Kurs%2C%20grundniv%C3%A5%22%2C%22nameOther%22%3A%22Course%2C%20First-cycle%22%2C%22creditsUnit%22%3A%7B%22code%22%3A%22HP%22%2C%22sv%22%3A%22H%C3%B6gskolepo%C3%A4ng%22%2C%22en%22%3A%22Credits%22%7D%2C%22level%22%3A%7B%22code%22%3A%221%22%2C%22name%22%3A%22Grundniv%C3%A5%22%7D%7D%2C%22omfattning%22%3A%7B%22number%22%3A6%2C%22formattedWithUnit%22%3A%226%2C0%20hp%22%7D%2C%22startperiod%22%3A%7B%22code%22%3A%22HT2026%22%2C%22startDay%22%3A%222026-08-24%22%2C%22lastDay%22%3A%222027-01-11%22%2C%22inDigits%22%3A%2220262%22%7D%2C%22Tillfallesperioder%22%3A%5B%7B%22ForstaRegistreringsdatum%22%3A%222026-08-20%22%2C%22ForstaUndervisningsdatum%22%3A%222026-08-24%22%2C%22Lasperiodsfordelning%22%3A%5B%7B%22Lasperiodskod%22%3A%22P1%22%2C%22Omfattningsvarde%22%3A6%2C%22link%22%3A%5B%5D%7D%5D%2C%22Omfattningsvarde%22%3A6%2C%22SistaRegistreringsdatum%22%3A%222026-08-31%22%2C%22SistaUndervisningsdatum%22%3A%222026-10-23%22%7D%5D%2C%22kod%22%3A%22EL1000%22%2C%22benamning%22%3A%22Reglerteknik%2C%20allm%C3%A4n%20kurs%22%2C%22Valvillkor%22%3A%22O%22%2C%22type%22%3A%22instance%22%7D%2C%7B%22utbildningsinstansUid%22%3A%22c91ecf3e-204f-11f0-a301-a2036b2340f3%22%2C%22uid%22%3A%226ef1465e-ceba-11f0-9d49-fd72c5714a36%22%2C%22tillfalleskod%22%3A%2211488%22%2C%22status%22%3A%7B%22code%22%3A%22S3%22%2C%22nameSv%22%3A%22Komplett%22%2C%22nameEn%22%3A%22Complete%22%7D%2C%22utbildningstyp%22%3A%7B%22id%22%3A%2222%22%2C%22code%22%3A%222007GKURS%22%2C%22name%22%3A%22Kurs%2C%20grundniv%C3%A5%22%2C%22nameOther%22%3A%22Course%2C%20First-cycle%22%2C%22creditsUnit%22%3A%7B%22code%22%3A%22HP%22%2C%22sv%22%3A%22H%C3%B6gskolepo%C3%A4ng%22%2C%22en%22%3A%22Credits%22%7D%2C%22level%22%3A%7B%22code%22%3A%221%22%2C%22name%22%3A%22Grundniv%C3%A5%22%7D%7D%2C%22omfattning%22%3A%7B%22number%22%3A4%2C%22formattedWithUnit%22%3A%224%2C0%20hp%22%7D%2C%22startperiod%22%3A%7B%22code%22%3A%22HT2026%22%2C%22startDay%22%3A%222026-08-24%22%2C%22lastDay%22%3A%222027-01-11%22%2C%22inDigits%22%3A%2220262%22%7D%2C%22Tillfallesperioder%22%3A%5B%7B%22ForstaRegistreringsdatum%22%3A%222026-10-22%22%2C%22ForstaUndervisningsdatum%22%3A%222026-10-26%22%2C%22Lasperiodsfordelning%22%3A%5B%7B%22Lasperiodskod%22%3A%22P2%22%2C%22Omfattningsvarde%22%3A4%2C%22link%22%3A%5B%5D%7D%5D%2C%22Omfattningsvarde%22%3A4%2C%22SistaRegistreringsdatum%22%3A%222026-11-02%22%2C%22SistaUndervisningsdatum%22%3A%222027-01-11%22%7D%5D%2C%22kod%22%3A%22SG1218%22%2C%22benamning%22%3A%22Str%C3%B6mningsmekanik%22%2C%22Valvillkor%22%3A%22O%22%2C%22type%22%3A%22instance%22%7D%2C%7B%22utbildningsinstansUid%22%3A%2282c467d5-73d8-11e8-b4e0-063f9afb40e3%22%2C%22uid%22%3A%221b1b209d-c530-11f0-905a-aee84a7a4808%22%2C%22tillfalleskod%22%3A%2251383%22%2C%22status%22%3A%7B%22code%22%3A%22S3%22%2C%22nameSv%22%3A%22Komplett%22%2C%22nameEn%22%3A%22Complete%22%7D%2C%22utbildningstyp%22%3A%7B%22id%22%3A%2222%22%2C%22code%22%3A%222007GKURS%22%2C%22name%22%3A%22Kurs%2C%20grundniv%C3%A5%22%2C%22nameOther%22%3A%22Course%2C%20First-cycle%22%2C%22creditsUnit%22%3A%7B%22code%22%3A%22HP%22%2C%22sv%22%3A%22H%C3%B6gskolepo%C3%A4ng%22%2C%22en%22%3A%22Credits%22%7D%2C%22level%22%3A%7B%22code%22%3A%221%22%2C%22name%22%3A%22Grundniv%C3%A5%22%7D%7D%2C%22omfattning%22%3A%7B%22number%22%3A5%2C%22formattedWithUnit%22%3A%225%2C0%20hp%22%7D%2C%22startperiod%22%3A%7B%22code%22%3A%22HT2026%22%2C%22startDay%22%3A%222026-08-24%22%2C%22lastDay%22%3A%222027-01-11%22%2C%22inDigits%22%3A%2220262%22%7D%2C%22Tillfallesperioder%22%3A%5B%7B%22ForstaRegistreringsdatum%22%3A%222026-08-20%22%2C%22ForstaUndervisningsdatum%22%3A%222026-08-24%22%2C%22Lasperiodsfordelning%22%3A%5B%7B%22Lasperiodskod%22%3A%22P1%22%2C%22Omfattningsvarde%22%3A3%2C%22link%22%3A%5B%5D%7D%2C%7B%22Lasperiodskod%22%3A%22P2%22%2C%22Omfattningsvarde%22%3A2%2C%22link%22%3A%5B%5D%7D%5D%2C%22Omfattningsvarde%22%3A5%2C%22SistaRegistreringsdatum%22%3A%222026-08-31%22%2C%22SistaUndervisningsdatum%22%3A%222027-01-11%22%7D%5D%2C%22kod%22%3A%22SH1015%22%2C%22benamning%22%3A%22Till%C3%A4mpad%20modern%20fysik%22%2C%22Valvillkor%22%3A%22O%22%2C%22type%22%3A%22instance%22%7D%2C%7B%22utbildningsinstansUid%22%3A%22842382f0-73d8-11e8-b4e0-063f9afb40e3%22%2C%22uid%22%3A%22b2a693c8-c090-11f0-be51-ac8de2c84290%22%2C%22tillfalleskod%22%3A%2210014%22%2C%22status%22%3A%7B%22code%22%3A%22S3%22%2C%22nameSv%22%3A%22Komplett%22%2C%22nameEn%22%3A%22Complete%22%7D%2C%22utbildningstyp%22%3A%7B%22id%22%3A%2222%22%2C%22code%22%3A%222007GKURS%22%2C%22name%22%3A%22Kurs%2C%20grundniv%C3%A5%22%2C%22nameOther%22%3A%22Course%2C%20First-cycle%22%2C%22creditsUnit%22%3A%7B%22code%22%3A%22HP%22%2C%22sv%22%3A%22H%C3%B6gskolepo%C3%A4ng%22%2C%22en%22%3A%22Credits%22%7D%2C%22level%22%3A%7B%22code%22%3A%221%22%2C%22name%22%3A%22Grundniv%C3%A5%22%7D%7D%2C%22omfattning%22%3A%7B%22number%22%3A6%2C%22formattedWithUnit%22%3A%226%2C0%20hp%22%7D%2C%22startperiod%22%3A%7B%22code%22%3A%22HT2026%22%2C%22startDay%22%3A%222026-08-24%22%2C%22lastDay%22%3A%222027-01-11%22%2C%22inDigits%22%3A%2220262%22%7D%2C%22Tillfallesperioder%22%3A%5B%7B%22ForstaRegistreringsdatum%22%3A%222026-10-22%22%2C%22ForstaUndervisningsdatum%22%3A%222026-10-26%22%2C%22Lasperiodsfordelning%22%3A%5B%7B%22Lasperiodskod%22%3A%22P2%22%2C%22Omfattningsvarde%22%3A6%2C%22link%22%3A%5B%5D%7D%5D%2C%22Omfattningsvarde%22%3A6%2C%22SistaRegistreringsdatum%22%3A%222026-11-02%22%2C%22SistaUndervisningsdatum%22%3A%222027-01-11%22%7D%5D%2C%22kod%22%3A%22SI1336%22%2C%22benamning%22%3A%22Simulering%20och%20modellering%22%2C%22Valvillkor%22%3A%22O%22%2C%22type%22%3A%22instance%22%7D%5D%2C%22freeTexts%22%3A%5B%5D%2C%22supplementaryInfo%22%3A%22%3Cp%3EP%C3%A5%20v%C3%A5ren%20i%20%C3%A5rskurs%203%20finns%20ett%20utrymme%20p%C3%A5%2015%20hp%20valfria%20kurser.%3C%2Fp%3E%22%2C%22conditionallyElectiveCoursesInfo%22%3A%22%3Cp%3EEn%20ska%20l%C3%A4sas.%3C%2Fp%3E%5Cn%3Cp%3EEF112X%20l%C3%A4ses%20%C3%A4ven%20av%20de%20som%20g%C3%B6r%20inom%20datalogi.%3C%2Fp%3E%22%7D%2C%7B%22yearNumber%22%3A4%2C%22courses%22%3A%5B%5D%2C%22freeTexts%22%3A%5B%5D%2C%22supplementaryInfo%22%3A%22%3Cp%3EUtbildningens%20tv%C3%A5%20sista%20%C3%A5r%20l%C3%A4ses%20inom%20ramen%20f%C3%B6r%20ett%20masterprogram.%3C%2Fp%3E%5Cn%3Cp%3EF%C3%B6r%20kurser%20inom%20%C3%A5rskurs%204%2C%20se%20l%C3%A4s%C3%A5rsplan%20f%C3%B6r%20%C3%A5rskurs%201%20inom%20det%20masterprogram%20du%20har%20valt.%3C%2Fp%3E%5Cn%3Cp%3EValbara%20masterprogram%20som%20leder%20till%20civilingenj%C3%B6rsexamen%20i%20Teknisk%20fysik%20%C3%A4r%3A%3C%2Fp%3E%5Cn%3Cp%3ETeknisk%20fysik%3C%2Fp%3E%5Cn%3Cp%3EMatematik%3C%2Fp%3E%5Cn%3Cp%3ETill%C3%A4mpad%20matematik%20och%20ber%C3%A4kningsmatematik%3C%2Fp%3E%5Cn%3Cp%3ETeknisk%20mekanik%3C%2Fp%3E%5Cn%3Cp%3EK%C3%A4rnenergiteknik%3C%2Fp%3E%5Cn%3Cp%3EDatalogi%3C%2Fp%3E%5Cn%3Cp%3EElektromagnetism%2C%20fusion%20och%20rymdteknik%3C%2Fp%3E%5Cn%3Cp%3EFlyg-%20och%20rymdteknik%3C%2Fp%3E%5Cn%3Cp%3EFordonsteknik%3C%2Fp%3E%5Cn%3Cp%3EInformation%20och%20n%C3%A4tverksteknologi%3C%2Fp%3E%5Cn%3Cp%3ENanoteknik%3C%2Fp%3E%5Cn%3Cp%3EMarina%20system%20(ej%20sp%C3%A5r%20Management)%3C%2Fp%3E%5Cn%3Cp%3EMaskininl%C3%A4rning%3C%2Fp%3E%5Cn%3Cp%3ESystemteknik%20och%20robotik%3C%2Fp%3E%5Cn%3Cp%3ECybers%C3%A4kerhet%3C%2Fp%3E%5Cn%3Cp%3EBiostatistik%20och%20datavetenskap%3C%2Fp%3E%22%7D%2C%7B%22yearNumber%22%3A5%2C%22courses%22%3A%5B%5D%2C%22freeTexts%22%3A%5B%5D%2C%22supplementaryInfo%22%3A%22%3Cp%3EUtbildningens%20tv%C3%A5%20sista%20%C3%A5r%20l%C3%A4ses%20inom%20ramen%20f%C3%B6r%20ett%20masterprogram.%3C%2Fp%3E%5Cn%3Cp%3EF%C3%B6r%20kurser%20inom%20%C3%A5rskurs%205%2C%20se%20l%C3%A4s%C3%A5rsplan%20f%C3%B6r%20%C3%A5rskurs%202%20inom%20det%20masterprogram%20du%20har%20valt.%3C%2Fp%3E%5Cn%3Cp%3EValbara%20masterprogram%20som%20leder%20till%20civilingenj%C3%B6rsexamen%20i%20Teknisk%20fysik%20%C3%A4r%3A%3C%2Fp%3E%5Cn%3Cp%3ETeknisk%20fysik%3C%2Fp%3E%5Cn%3Cp%3EMatematik%3C%2Fp%3E%5Cn%3Cp%3ETill%C3%A4mpad%20matematik%20och%20ber%C3%A4kningsmatematik%3C%2Fp%3E%5Cn%3Cp%3ETeknisk%20mekanik%3C%2Fp%3E%5Cn%3Cp%3EK%C3%A4rnenergiteknik%3C%2Fp%3E%5Cn%3Cp%3EDatalogi%3C%2Fp%3E%5Cn%3Cp%3EElektromagnetism%2C%20fusion%20och%20rymdteknik%3C%2Fp%3E%5Cn%3Cp%3EFlyg-%20och%20rymdteknik%3C%2Fp%3E%5Cn%3Cp%3EFordonsteknik%3C%2Fp%3E%5Cn%3Cp%3EInformation%20och%20n%C3%A4tverksteknologi%3C%2Fp%3E%5Cn%3Cp%3ENanoteknik%3C%2Fp%3E%5Cn%3Cp%3EMarina%20system%20(ej%20sp%C3%A5r%20Management)%3C%2Fp%3E%5Cn%3Cp%3EMaskininl%C3%A4rning%3C%2Fp%3E%5Cn%3Cp%3ESystemteknik%20och%20robotik%3C%2Fp%3E%22%7D%5D%7D%5D%2C%22errorType%22%3A%7B%22MISSING_ADMISSION%22%3A%22missing_admission%22%7D%2C%22error%22%3Anull%2C%22curriculumInfos%22%3A%5B%7B%22code%22%3A%22%22%2C%22specializationName%22%3Anull%2C%22isCommon%22%3Atrue%2C%22participations%22%3A%7B%22V%22%3A%5B%7B%22course%22%3A%7B%22courseCode%22%3A%22AK2014%22%2C%22title%22%3A%22Beslutsteori%22%2C%22credits%22%3A7.5%2C%22formattedCredits%22%3A%227%2C5%20hp%22%2C%22educationalLevel%22%3A%22Avancerad%20niv%C3%A5%22%2C%22electiveCondition%22%3A%22V%22%2C%22status%22%3A%7B%22code%22%3A%22S2%22%2C%22nameSv%22%3A%22P%C3%A5b%C3%B6rjad%22%2C%22nameEn%22%3A%22Started%22%7D%7D%2C%22applicationCode%22%3A%2212018%22%2C%22term%22%3A%2220271%22%2C%22creditsPerPeriod%22%3A%5B0%2C0%2C0%2C7.5%2C0%2C0%5D%7D%2C%7B%22course%22%3A%7B%22courseCode%22%3A%22DD1380%22%2C%22title%22%3A%22Javaprogrammering%20f%C3%B6r%20Pythonprogrammerare%22%2C%22credits%22%3A1.5%2C%22formattedCredits%22%3A%221%2C5%20hp%22%2C%22educationalLevel%22%3A%22Grundniv%C3%A5%22%2C%22electiveCondition%22%3A%22V%22%2C%22status%22%3A%7B%22code%22%3A%22S2%22%2C%22nameSv%22%3A%22P%C3%A5b%C3%B6rjad%22%2C%22nameEn%22%3A%22Started%22%7D%7D%2C%22applicationCode%22%3A%2211765%22%2C%22term%22%3A%2220271%22%2C%22creditsPerPeriod%22%3A%5B0%2C0%2C0%2C1.5%2C0%2C0%5D%7D%2C%7B%22course%22%3A%7B%22courseCode%22%3A%22DD2352%22%2C%22title%22%3A%22Algoritmer%20och%20komplexitet%22%2C%22credits%22%3A7.5%2C%22formattedCredits%22%3A%227%2C5%20hp%22%2C%22educationalLevel%22%3A%22Avancerad%20niv%C3%A5%22%2C%22electiveCondition%22%3A%22V%22%2C%22status%22%3A%7B%22code%22%3A%22S2%22%2C%22nameSv%22%3A%22P%C3%A5b%C3%B6rjad%22%2C%22nameEn%22%3A%22Started%22%7D%7D%2C%22applicationCode%22%3A%2211549%22%2C%22term%22%3A%2220271%22%2C%22creditsPerPeriod%22%3A%5B0%2C0%2C0%2C3%2C4.5%2C0%5D%7D%2C%7B%22course%22%3A%7B%22courseCode%22%3A%22DD2421%22%2C%22title%22%3A%22Maskininl%C3%A4rning%22%2C%22credits%22%3A7.5%2C%22formattedCredits%22%3A%227%2C5%20hp%22%2C%22educationalLevel%22%3A%22Avancerad%20niv%C3%A5%22%2C%22electiveCondition%22%3A%22V%22%2C%22status%22%3A%7B%22code%22%3A%22S2%22%2C%22nameSv%22%3A%22P%C3%A5b%C3%B6rjad%22%2C%22nameEn%22%3A%22Started%22%7D%7D%2C%22applicationCode%22%3A%2211803%22%2C%22term%22%3A%2220271%22%2C%22creditsPerPeriod%22%3A%5B0%2C0%2C0%2C7.5%2C0%2C0%5D%7D%2C%7B%22course%22%3A%7B%22courseCode%22%3A%22EQ1120%22%2C%22title%22%3A%22Tidsdiskreta%20signaler%20och%20system%22%2C%22credits%22%3A6%2C%22formattedCredits%22%3A%226%2C0%20hp%22%2C%22educationalLevel%22%3A%22Grundniv%C3%A5%22%2C%22electiveCondition%22%3A%22V%22%2C%22status%22%3A%7B%22code%22%3A%22S2%22%2C%22nameSv%22%3A%22P%C3%A5b%C3%B6rjad%22%2C%22nameEn%22%3A%22Started%22%7D%7D%2C%22applicationCode%22%3A%2212088%22%2C%22term%22%3A%2220271%22%2C%22creditsPerPeriod%22%3A%5B0%2C0%2C0%2C0%2C6%2C0%5D%7D%2C%7B%22course%22%3A%7B%22courseCode%22%3A%22MH1023%22%2C%22title%22%3A%22Praktiskt%20j%C3%A4mst%C3%A4lldhets-%20och%20m%C3%A5ngfaldsarbete%20i%20vetenskapliga%2C%20tekniska%20och%20industriella%20milj%C3%B6er%22%2C%22credits%22%3A6%2C%22formattedCredits%22%3A%226%2C0%20hp%22%2C%22educationalLevel%22%3A%22Grundniv%C3%A5%22%2C%22electiveCondition%22%3A%22V%22%2C%22status%22%3A%7B%22code%22%3A%22S2%22%2C%22nameSv%22%3A%22P%C3%A5b%C3%B6rjad%22%2C%22nameEn%22%3A%22Started%22%7D%7D%2C%22applicationCode%22%3A%2210924%22%2C%22term%22%3A%2220271%22%2C%22creditsPerPeriod%22%3A%5B0%2C0%2C0%2C3%2C3%2C0%5D%7D%2C%7B%22course%22%3A%7B%22courseCode%22%3A%22SF1677%22%2C%22title%22%3A%22Analysens%20grunder%22%2C%22credits%22%3A7.5%2C%22formattedCredits%22%3A%227%2C5%20hp%22%2C%22educationalLevel%22%3A%22Grundniv%C3%A5%22%2C%22electiveCondition%22%3A%22V%22%2C%22status%22%3A%7B%22code%22%3A%22S2%22%2C%22nameSv%22%3A%22P%C3%A5b%C3%B6rjad%22%2C%22nameEn%22%3A%22Started%22%7D%7D%2C%22applicationCode%22%3A%2212370%22%2C%22term%22%3A%2220271%22%2C%22creditsPerPeriod%22%3A%5B0%2C0%2C0%2C3.7%2C3.8%2C0%5D%7D%2C%7B%22course%22%3A%7B%22courseCode%22%3A%22SF1678%22%2C%22title%22%3A%22Grupper%20och%20ringar%22%2C%22credits%22%3A7.5%2C%22formattedCredits%22%3A%227%2C5%20hp%22%2C%22educationalLevel%22%3A%22Grundniv%C3%A5%22%2C%22electiveCondition%22%3A%22V%22%2C%22status%22%3A%7B%22code%22%3A%22S2%22%2C%22nameSv%22%3A%22P%C3%A5b%C3%B6rjad%22%2C%22nameEn%22%3A%22Started%22%7D%7D%2C%22applicationCode%22%3A%2212371%22%2C%22term%22%3A%2220271%22%2C%22creditsPerPeriod%22%3A%5B0%2C0%2C0%2C3.7%2C3.8%2C0%5D%7D%2C%7B%22course%22%3A%7B%22courseCode%22%3A%22SF1679%22%2C%22title%22%3A%22Diskret%20matematik%22%2C%22credits%22%3A7.5%2C%22formattedCredits%22%3A%227%2C5%20hp%22%2C%22educationalLevel%22%3A%22Grundniv%C3%A5%22%2C%22electiveCondition%22%3A%22V%22%2C%22status%22%3A%7B%22code%22%3A%22S2%22%2C%22nameSv%22%3A%22P%C3%A5b%C3%B6rjad%22%2C%22nameEn%22%3A%22Started%22%7D%7D%2C%22applicationCode%22%3A%2212373%22%2C%22term%22%3A%2220271%22%2C%22creditsPerPeriod%22%3A%5B0%2C0%2C0%2C7.5%2C0%2C0%5D%7D%2C%7B%22course%22%3A%7B%22courseCode%22%3A%22SF1691%22%2C%22title%22%3A%22Komplex%20analys%22%2C%22credits%22%3A7.5%2C%22formattedCredits%22%3A%227%2C5%20hp%22%2C%22educationalLevel%22%3A%22Grundniv%C3%A5%22%2C%22electiveCondition%22%3A%22V%22%2C%22status%22%3A%7B%22code%22%3A%22S2%22%2C%22nameSv%22%3A%22P%C3%A5b%C3%B6rjad%22%2C%22nameEn%22%3A%22Started%22%7D%7D%2C%22applicationCode%22%3A%2212383%22%2C%22term%22%3A%2220271%22%2C%22creditsPerPeriod%22%3A%5B0%2C0%2C0%2C3.7%2C3.8%2C0%5D%7D%2C%7B%22course%22%3A%7B%22courseCode%22%3A%22SF1861%22%2C%22title%22%3A%22Optimeringsl%C3%A4ra%22%2C%22credits%22%3A6%2C%22formattedCredits%22%3A%226%2C0%20hp%22%2C%22educationalLevel%22%3A%22Grundniv%C3%A5%22%2C%22electiveCondition%22%3A%22V%22%2C%22status%22%3A%7B%22code%22%3A%22S2%22%2C%22nameSv%22%3A%22P%C3%A5b%C3%B6rjad%22%2C%22nameEn%22%3A%22Started%22%7D%7D%2C%22applicationCode%22%3A%2212388%22%2C%22term%22%3A%2220271%22%2C%22creditsPerPeriod%22%3A%5B0%2C0%2C0%2C0%2C6%2C0%5D%7D%2C%7B%22course%22%3A%7B%22courseCode%22%3A%22SF1904%22%2C%22title%22%3A%22Markovprocesser%2C%20grundkurs%22%2C%22credits%22%3A3%2C%22formattedCredits%22%3A%223%2C0%20hp%22%2C%22educationalLevel%22%3A%22Grundniv%C3%A5%22%2C%22electiveCondition%22%3A%22V%22%2C%22status%22%3A%7B%22code%22%3A%22S2%22%2C%22nameSv%22%3A%22P%C3%A5b%C3%B6rjad%22%2C%22nameEn%22%3A%22Started%22%7D%7D%2C%22applicationCode%22%3A%2212390%22%2C%22term%22%3A%2220271%22%2C%22creditsPerPeriod%22%3A%5B0%2C0%2C0%2C0%2C3%2C0%5D%7D%2C%7B%22course%22%3A%7B%22courseCode%22%3A%22SF2701%22%2C%22title%22%3A%22Finansiell%20matematik%2C%20grundkurs%22%2C%22credits%22%3A7.5%2C%22formattedCredits%22%3A%227%2C5%20hp%22%2C%22educationalLevel%22%3A%22Avancerad%20niv%C3%A5%22%2C%22electiveCondition%22%3A%22V%22%2C%22status%22%3A%7B%22code%22%3A%22S2%22%2C%22nameSv%22%3A%22P%C3%A5b%C3%B6rjad%22%2C%22nameEn%22%3A%22Started%22%7D%7D%2C%22applicationCode%22%3A%2212420%22%2C%22term%22%3A%2220271%22%2C%22creditsPerPeriod%22%3A%5B0%2C0%2C0%2C0%2C7.5%2C0%5D%7D%2C%7B%22course%22%3A%7B%22courseCode%22%3A%22SF2930%22%2C%22title%22%3A%22Regressionsanalys%22%2C%22credits%22%3A7.5%2C%22formattedCredits%22%3A%227%2C5%20hp%22%2C%22educationalLevel%22%3A%22Avancerad%20niv%C3%A5%22%2C%22electiveCondition%22%3A%22V%22%2C%22status%22%3A%7B%22code%22%3A%22S2%22%2C%22nameSv%22%3A%22P%C3%A5b%C3%B6rjad%22%2C%22nameEn%22%3A%22Started%22%7D%7D%2C%22applicationCode%22%3A%2212459%22%2C%22term%22%3A%2220271%22%2C%22creditsPerPeriod%22%3A%5B0%2C0%2C0%2C7.5%2C0%2C0%5D%7D%2C%7B%22course%22%3A%7B%22courseCode%22%3A%22SH2404%22%2C%22title%22%3A%22Astrofysik%22%2C%22credits%22%3A7.5%2C%22formattedCredits%22%3A%227%2C5%20hp%22%2C%22educationalLevel%22%3A%22Avancerad%20niv%C3%A5%22%2C%22electiveCondition%22%3A%22V%22%2C%22status%22%3A%7B%22code%22%3A%22S2%22%2C%22nameSv%22%3A%22P%C3%A5b%C3%B6rjad%22%2C%22nameEn%22%3A%22Started%22%7D%7D%2C%22applicationCode%22%3A%2210554%22%2C%22term%22%3A%2220271%22%2C%22creditsPerPeriod%22%3A%5B0%2C0%2C0%2C0%2C7.5%2C0%5D%7D%2C%7B%22course%22%3A%7B%22courseCode%22%3A%22SI1142%22%2C%22title%22%3A%22Fysikens%20matematiska%20metoder%2C%20till%C3%A4ggskurs%22%2C%22credits%22%3A3%2C%22formattedCredits%22%3A%223%2C0%20hp%22%2C%22educationalLevel%22%3A%22Grundniv%C3%A5%22%2C%22electiveCondition%22%3A%22V%22%2C%22status%22%3A%7B%22code%22%3A%22S2%22%2C%22nameSv%22%3A%22P%C3%A5b%C3%B6rjad%22%2C%22nameEn%22%3A%22Started%22%7D%7D%2C%22applicationCode%22%3A%2260123%22%2C%22term%22%3A%2220271%22%2C%22creditsPerPeriod%22%3A%5B0%2C0%2C0%2C0%2C3%2C0%5D%7D%2C%7B%22course%22%3A%7B%22courseCode%22%3A%22SI1162%22%2C%22title%22%3A%22Statistisk%20fysik%22%2C%22credits%22%3A7.5%2C%22formattedCredits%22%3A%227%2C5%20hp%22%2C%22educationalLevel%22%3A%22Grundniv%C3%A5%22%2C%22electiveCondition%22%3A%22V%22%2C%22status%22%3A%7B%22code%22%3A%22S2%22%2C%22nameSv%22%3A%22P%C3%A5b%C3%B6rjad%22%2C%22nameEn%22%3A%22Started%22%7D%7D%2C%22applicationCode%22%3A%2260163%22%2C%22term%22%3A%2220271%22%2C%22creditsPerPeriod%22%3A%5B0%2C0%2C0%2C7.5%2C0%2C0%5D%7D%2C%7B%22course%22%3A%7B%22courseCode%22%3A%22SI2360%22%2C%22title%22%3A%22Analytisk%20mekanik%20och%20klassisk%20f%C3%A4ltteori%22%2C%22credits%22%3A7.5%2C%22formattedCredits%22%3A%227%2C5%20hp%22%2C%22educationalLevel%22%3A%22Avancerad%20niv%C3%A5%22%2C%22electiveCondition%22%3A%22V%22%2C%22status%22%3A%7B%22code%22%3A%22S2%22%2C%22nameSv%22%3A%22P%C3%A5b%C3%B6rjad%22%2C%22nameEn%22%3A%22Started%22%7D%7D%2C%22applicationCode%22%3A%2260925%22%2C%22term%22%3A%2220271%22%2C%22creditsPerPeriod%22%3A%5B0%2C0%2C0%2C0%2C7.5%2C0%5D%7D%2C%7B%22course%22%3A%7B%22courseCode%22%3A%22SK2712%22%2C%22title%22%3A%22Milj%C3%B6fysik%22%2C%22credits%22%3A7.5%2C%22formattedCredits%22%3A%227%2C5%20hp%22%2C%22educationalLevel%22%3A%22Avancerad%20niv%C3%A5%22%2C%22electiveCondition%22%3A%22V%22%2C%22status%22%3A%7B%22code%22%3A%22S2%22%2C%22nameSv%22%3A%22P%C3%A5b%C3%B6rjad%22%2C%22nameEn%22%3A%22Started%22%7D%7D%2C%22applicationCode%22%3A%2260795%22%2C%22term%22%3A%2220271%22%2C%22creditsPerPeriod%22%3A%5B0%2C0%2C0%2C0%2C7.5%2C0%5D%7D%2C%7B%22course%22%3A%7B%22courseCode%22%3A%22AK2011%22%2C%22title%22%3A%22Teknik%20och%20etik%22%2C%22credits%22%3A7.5%2C%22formattedCredits%22%3A%227%2C5%20hp%22%2C%22educationalLevel%22%3A%22Avancerad%20niv%C3%A5%22%2C%22electiveCondition%22%3A%22V%22%2C%22status%22%3A%7B%22code%22%3A%22S2%22%2C%22nameSv%22%3A%22P%C3%A5b%C3%B6rjad%22%2C%22nameEn%22%3A%22Started%22%7D%7D%2C%22applicationCode%22%3A%2261171%22%2C%22term%22%3A%2220271%22%2C%22creditsPerPeriod%22%3A%5B0%2C0%2C0%2C0%2C7.5%2C0%5D%7D%5D%2C%22VV%22%3A%5B%7B%22course%22%3A%7B%22courseCode%22%3A%22EF112X%22%2C%22title%22%3A%22Examensarbete%20inom%20elektroteknik%2C%20grundniv%C3%A5%22%2C%22credits%22%3A15%2C%22formattedCredits%22%3A%2215%2C0%20hp%22%2C%22educationalLevel%22%3A%22Grundniv%C3%A5%22%2C%22electiveCondition%22%3A%22VV%22%2C%22status%22%3A%7B%22code%22%3A%22S2%22%2C%22nameSv%22%3A%22P%C3%A5b%C3%B6rjad%22%2C%22nameEn%22%3A%22Started%22%7D%7D%2C%22applicationCode%22%3A%2211788%22%2C%22term%22%3A%2220271%22%2C%22creditsPerPeriod%22%3A%5B0%2C0%2C0%2C7.5%2C7.5%2C0%5D%7D%2C%7B%22course%22%3A%7B%22courseCode%22%3A%22SA114X%22%2C%22title%22%3A%22Examensarbete%20inom%20teknisk%20fysik%2C%20grundniv%C3%A5%22%2C%22credits%22%3A15%2C%22formattedCredits%22%3A%2215%2C0%20hp%22%2C%22educationalLevel%22%3A%22Grundniv%C3%A5%22%2C%22electiveCondition%22%3A%22VV%22%2C%22status%22%3A%7B%22code%22%3A%22S2%22%2C%22nameSv%22%3A%22P%C3%A5b%C3%B6rjad%22%2C%22nameEn%22%3A%22Started%22%7D%7D%2C%22applicationCode%22%3A%2210259%22%2C%22term%22%3A%2220271%22%2C%22creditsPerPeriod%22%3A%5B0%2C0%2C0%2C7.5%2C7.5%2C0%5D%7D%5D%2C%22O%22%3A%5B%7B%22course%22%3A%7B%22courseCode%22%3A%22EI1320%22%2C%22title%22%3A%22Teoretisk%20elektroteknik%22%2C%22credits%22%3A9%2C%22formattedCredits%22%3A%229%2C0%20hp%22%2C%22educationalLevel%22%3A%22Grundniv%C3%A5%22%2C%22electiveCondition%22%3A%22O%22%2C%22status%22%3A%7B%22code%22%3A%22S3%22%2C%22nameSv%22%3A%22Komplett%22%2C%22nameEn%22%3A%22Complete%22%7D%7D%2C%22applicationCode%22%3A%2210914%22%2C%22term%22%3A%2220262%22%2C%22creditsPerPeriod%22%3A%5B0%2C6%2C3%2C0%2C0%2C0%5D%7D%2C%7B%22course%22%3A%7B%22courseCode%22%3A%22EL1000%22%2C%22title%22%3A%22Reglerteknik%2C%20allm%C3%A4n%20kurs%22%2C%22credits%22%3A6%2C%22formattedCredits%22%3A%226%2C0%20hp%22%2C%22educationalLevel%22%3A%22Grundniv%C3%A5%22%2C%22electiveCondition%22%3A%22O%22%2C%22status%22%3A%7B%22code%22%3A%22S3%22%2C%22nameSv%22%3A%22Komplett%22%2C%22nameEn%22%3A%22Complete%22%7D%7D%2C%22applicationCode%22%3A%2211039%22%2C%22term%22%3A%2220262%22%2C%22creditsPerPeriod%22%3A%5B0%2C6%2C0%2C0%2C0%2C0%5D%7D%2C%7B%22course%22%3A%7B%22courseCode%22%3A%22SG1218%22%2C%22title%22%3A%22Str%C3%B6mningsmekanik%22%2C%22credits%22%3A4%2C%22formattedCredits%22%3A%224%2C0%20hp%22%2C%22educationalLevel%22%3A%22Grundniv%C3%A5%22%2C%22electiveCondition%22%3A%22O%22%2C%22status%22%3A%7B%22code%22%3A%22S3%22%2C%22nameSv%22%3A%22Komplett%22%2C%22nameEn%22%3A%22Complete%22%7D%7D%2C%22applicationCode%22%3A%2211488%22%2C%22term%22%3A%2220262%22%2C%22creditsPerPeriod%22%3A%5B0%2C0%2C4%2C0%2C0%2C0%5D%7D%2C%7B%22course%22%3A%7B%22courseCode%22%3A%22SH1015%22%2C%22title%22%3A%22Till%C3%A4mpad%20modern%20fysik%22%2C%22credits%22%3A5%2C%22formattedCredits%22%3A%225%2C0%20hp%22%2C%22educationalLevel%22%3A%22Grundniv%C3%A5%22%2C%22electiveCondition%22%3A%22O%22%2C%22status%22%3A%7B%22code%22%3A%22S3%22%2C%22nameSv%22%3A%22Komplett%22%2C%22nameEn%22%3A%22Complete%22%7D%7D%2C%22applicationCode%22%3A%2251383%22%2C%22term%22%3A%2220262%22%2C%22creditsPerPeriod%22%3A%5B0%2C3%2C2%2C0%2C0%2C0%5D%7D%2C%7B%22course%22%3A%7B%22courseCode%22%3A%22SI1336%22%2C%22title%22%3A%22Simulering%20och%20modellering%22%2C%22credits%22%3A6%2C%22formattedCredits%22%3A%226%2C0%20hp%22%2C%22educationalLevel%22%3A%22Grundniv%C3%A5%22%2C%22electiveCondition%22%3A%22O%22%2C%22status%22%3A%7B%22code%22%3A%22S3%22%2C%22nameSv%22%3A%22Komplett%22%2C%22nameEn%22%3A%22Complete%22%7D%7D%2C%22applicationCode%22%3A%2210014%22%2C%22term%22%3A%2220262%22%2C%22creditsPerPeriod%22%3A%5B0%2C0%2C6%2C0%2C0%2C0%5D%7D%5D%7D%2C%22supplementaryInformation%22%3A%22%3Cp%3EP%C3%A5%20v%C3%A5ren%20i%20%C3%A5rskurs%203%20finns%20ett%20utrymme%20p%C3%A5%2015%20hp%20valfria%20kurser.%3C%2Fp%3E%22%2C%22conditionallyElectiveCoursesInformation%22%3A%22%3Cp%3EEn%20ska%20l%C3%A4sas.%3C%2Fp%3E%5Cn%3Cp%3EEF112X%20l%C3%A4ses%20%C3%A4ven%20av%20de%20som%20g%C3%B6r%20inom%20datalogi.%3C%2Fp%3E%22%2C%22isFirstSpec%22%3Afalse%2C%22hasInfo%22%3Atrue%2C%22freeTexts%22%3A%5B%5D%7D%5D%2C%22lengthInStudyYears%22%3A5%2C%22thisHostBaseUrl%22%3Anull%7D";</script>
+
+<!---->
+
+  <div id="app"></div>
+    </div>
+  </div>
+  <!--indexOff: all-->
+  <!-- add "scroll-to-top" button when scrolled down -->
+  <div id="back-to-top" role="link" aria-label="Till sidans topp"></div>
+  <footer class="kth-footer student-web">
+      <div class="kth-footer__content">
+              
+  
+  
+  
+  
+    <div class="columnSplitterWrapper" data-cid="1.1066523" lang="sv">
+      
+      <div class="columnSplitter  using4Columns ">
+        <div class="col c1">
+          
+  
+  
+  
+  
+    <div class="block list links" data-cid="1.1066524" lang="sv">
+      <h2>Studentwebben</h2>
+      
+      <ul>
+        <li><a href="/student/studier">Studier</a></li>
+        <li><a href="/student/stod">Stöd och vägledning</a></li>
+        <li><a href="/student/it">IT och digitala tjänster</a></li>
+        <li><a href="/student/kontakt">Kontakt</a></li>
+      </ul>
+    </div>
+  
+  
+  
+        </div>
+        <div class="col c2">
+          
+  
+  
+  
+  
+    <div class="block list links" data-cid="1.1066531" lang="sv">
+      <h2>Tjänster</h2>
+      
+      <ul>
+        <li><a href="/student/studier/schema">Schema</a></li>
+        <li><a href="https://canvas.kth.se/">Canvas</a></li>
+        <li><a href="http://webmail.kth.se">Webbmejl</a></li>
+        <li><a href="/student/it/studenttjanster/personligamenyn">Personliga menyn</a></li>
+        <li><a href="https://www.student.ladok.se/student/app/studentwebb/">Ladok för studenter</a></li>
+      </ul>
+    </div>
+  
+  
+  
+        </div>
+        <div class="col c3">
+          
+  
+  
+  
+  
+    <div class="block list links" data-cid="1.1066534" lang="sv">
+      <h2>Kontakt</h2>
+      
+      <ul>
+        <li><a href="/student/kontakt/kontaktuppgifter/kontakta-utbildningsprogram-1.1170401">Kontakta utbildningsprogram</a></li>
+        <li><a href="/student/kontakt/kontaktuppgifter/kontakta-kurs-1.1171899">Kontakta kurs</a></li>
+        <li><a href="/student/it/contact">IT-support</a></li>
+        <li><a href="/student/kontakt/campus/kth-entre">KTH Entré</a></li>
+        <li><a href="/student/kontakt/campus/kth-biblioteket-1.2479">KTH Biblioteket</a></li>
+      </ul>
+    </div>
+  
+  
+  
+        </div>
+        <div class="col c4">
+          
+  
+  
+  
+  
+    <article class="block teaser top white" data-cid="1.1083631" lang="sv">
+      
+      <div class="teaserBody   ">
+        
+        
+        <div class="lead">
+          
+          
+        
+          
+          <p><strong>KTH</strong><br> <em>100 44 Stockholm<br> +46 8 790 60 00<br>
+        
+      
+        
+          
+  
+  
+  
+  
+    <a class="block link" data-cid="1.1083633" lang="sv" href="mailto:info@kth.se">info@kth.se</a>
+  
+  
+  
+          
+        
+      
+        
+          
+          </em><br> &nbsp;</p>
+        
+      
+        </div>
+        
+      </div>
+    </article>
+  
+  
+  
+        </div>
+      </div>
+    </div>
+  
+  
+  
+      </div>
+  </footer>
+  <!--indexOn: all-->  <script src="/student/kurser/static/app.js?v=2.0.0-20260427.1_59b0"></script>
+</body>
+
+</html>

--- a/tests/test_eligibility_fallback.py
+++ b/tests/test_eligibility_fallback.py
@@ -1,0 +1,297 @@
+"""Regression tests for the cross-cohort eligibility-block fallback.
+
+Background: KTH's per-programme study-plan pages sometimes carry a
+"behörighetsgivande kurser per masterprogram" block that maps each target
+master to the courses a student must complete to qualify. The block is
+critical for "what year-3 electives qualify me for the X master?" questions,
+but its presence varies across cohorts (CTFYS HT2023 has it, HT2024 does not)
+and across programmes (CFATE has it, CELTE does not).
+
+These tests pin the three behaviours we rely on:
+
+- Extractor finds the block in CTFYS HT2023 and CFATE HT2023, returns None
+  for CTFYS HT2024 (block was dropped) and CELTE HT2023 (programme never
+  carried it).
+- When the requested term carries the block, _studyplan_chunks_from_html
+  emits it as a dedicated, citable chunk.
+- When the requested term lacks the block, _maybe_emit_fallback_eligibility
+  fetches a prior term and surfaces a labeled, caveated chunk pointing back
+  at the prior cohort. No fallback fires when the current term already has
+  one — and no fallback chunk is added when no prior term has one either.
+
+Fixtures are real KTH HTML captured 2026-05-10 under tests/fixtures/. Refresh
+by re-fetching the same URLs if KTH's structure ever changes.
+"""
+
+from __future__ import annotations
+
+import time
+from pathlib import Path
+
+import pytest
+
+import student_bot.bot.web_retrieval as wr
+from student_bot.config import get_config
+
+
+FIXTURES = Path(__file__).parent / "fixtures"
+
+
+def _load(name: str) -> str:
+    return (FIXTURES / name).read_text(encoding="utf-8")
+
+
+# Map of URL -> fixture filename. Used by the stubbed _fetch_html so the
+# fallback path can resolve "prior-term" fetches without hitting the network.
+_URL_FIXTURES = {
+    "https://www.kth.se/student/kurser/program/CTFYS/20232/arskurs3": "program_CTFYS_20232_arskurs3.html",
+    "https://www.kth.se/student/kurser/program/CTFYS/20242/arskurs3": "program_CTFYS_20242_arskurs3.html",
+    "https://www.kth.se/student/kurser/program/CFATE/20232/arskurs3": "program_CFATE_20232_arskurs3.html",
+    "https://www.kth.se/student/kurser/program/CELTE/20232/arskurs3": "program_CELTE_20232_arskurs3.html",
+}
+
+
+@pytest.fixture
+def cfg():
+    return get_config()
+
+
+@pytest.fixture
+def patterns(cfg):
+    return wr._compiled_patterns(cfg)
+
+
+@pytest.fixture
+def stub_network(monkeypatch):
+    """Replace network primitives with fixture-backed equivalents.
+
+    `_fetch_html` resolves URLs from `_URL_FIXTURES`; unknown URLs raise so a
+    test never silently passes by hitting the real network. `_is_allowed_url`
+    is bypassed because the fixture URLs are stable and we don't want allowlist
+    drift to bleed into eligibility-fallback tests.
+    """
+
+    def _stub_fetch(url, _cfg):
+        name = _URL_FIXTURES.get(url)
+        if not name:
+            raise FileNotFoundError(f"no fixture registered for {url}")
+        return url, _load(name)
+
+    monkeypatch.setattr(wr, "_fetch_html", _stub_fetch)
+    monkeypatch.setattr(wr, "_is_allowed_url", lambda u, c, p: True)
+
+
+class _FakeCache:
+    """No-op stand-in for WebCache — the eligibility chunk path only ever
+    `put`s, never reads. Tests don't assert on cache state."""
+
+    def put(self, *_a, **_k):
+        return None
+
+    def get(self, *_a, **_k):
+        return None
+
+
+# -----------------------------------------------------------------------------
+# Extractor: _eligibility_text_from_store
+# -----------------------------------------------------------------------------
+
+
+def _store_for(name: str):
+    return wr._compressed_application_store(_load(name))
+
+
+def test_extractor_finds_block_in_ctfys_ht2023():
+    text = wr._eligibility_text_from_store(_store_for("program_CTFYS_20232_arskurs3.html"))
+    assert text is not None
+    # The Datalogi entry (with KTH's own typo) must appear, with all three
+    # required courses, so retrieval has the answer the bot needs.
+    assert "Datatologi" in text or "datalogi" in text.lower()
+    assert "DD2352" in text
+    assert "SF1679" in text
+    assert "DD1380" in text
+
+
+def test_extractor_finds_block_in_cfate_ht2023():
+    text = wr._eligibility_text_from_store(_store_for("program_CFATE_20232_arskurs3.html"))
+    assert text is not None
+    # CFATE uses a different format ("Behörighetsgivande kurser till
+    # masterprogram" header + master codes in parens). TTFYM (Teknisk fysik)
+    # eligibility must surface — that's the user's example.
+    assert "TTFYM" in text
+    assert "SI1146" in text
+    assert "SH1014" in text
+
+
+def test_extractor_returns_none_for_ctfys_ht2024():
+    # KTH dropped the block from CTFYS HT2024. Without this returning None,
+    # the cross-cohort fallback would never fire.
+    assert wr._eligibility_text_from_store(_store_for("program_CTFYS_20242_arskurs3.html")) is None
+
+
+def test_extractor_returns_none_for_celte_ht2023():
+    # CELTE never carries the block at all. The fallback can't help here;
+    # this test pins that the extractor doesn't false-positive on adjacent
+    # text like "behörighet" without "behörighetsgivande".
+    assert wr._eligibility_text_from_store(_store_for("program_CELTE_20232_arskurs3.html")) is None
+
+
+# -----------------------------------------------------------------------------
+# Term-label helper
+# -----------------------------------------------------------------------------
+
+
+def test_term_label_sv_decodes_kth_term_codes():
+    assert wr._term_label_sv("20232") == "HT2023"
+    assert wr._term_label_sv("20241") == "VT2024"
+    # Junk passes through unchanged so callers don't have to defend against
+    # malformed inputs from upstream JSON.
+    assert wr._term_label_sv("not-a-term") == "not-a-term"
+
+
+# -----------------------------------------------------------------------------
+# Current-term emission via _studyplan_chunks_from_html
+# -----------------------------------------------------------------------------
+
+
+def _eligibility_chunks(chunks):
+    return [c for c in chunks if "behörighetsgivande" in (c.section_path or "").lower()]
+
+
+def test_current_term_emits_eligibility_chunk_when_block_present():
+    html = _load("program_CTFYS_20232_arskurs3.html")
+    url = "https://www.kth.se/student/kurser/program/CTFYS/20232/arskurs3"
+    chunks = wr._studyplan_chunks_from_html(html, final_url=url, fetched_at=int(time.time()))
+    elig = _eligibility_chunks(chunks)
+    assert len(elig) == 1, "exactly one eligibility chunk should be emitted"
+    c = elig[0]
+    assert "behorighet-master" in (c.chunk_id or ""), "chunk-id fragment is the dedup key"
+    assert c.section_path.startswith("Årskurs 3"), c.section_path
+    assert "DD2352" in c.text
+    assert "SF1679" in c.text
+    assert "DD1380" in c.text
+
+
+def test_current_term_emits_no_eligibility_chunk_when_block_missing():
+    html = _load("program_CTFYS_20242_arskurs3.html")
+    url = "https://www.kth.se/student/kurser/program/CTFYS/20242/arskurs3"
+    chunks = wr._studyplan_chunks_from_html(html, final_url=url, fetched_at=int(time.time()))
+    assert _eligibility_chunks(chunks) == []
+
+
+# -----------------------------------------------------------------------------
+# Cross-cohort fallback: _maybe_emit_fallback_eligibility
+# -----------------------------------------------------------------------------
+
+
+def test_fallback_fills_missing_block_from_prior_cohort(stub_network, cfg, patterns):
+    """Requested term is HT2024 (no block); prior HT2023 has it. The fallback
+    must emit one chunk, point back at HT2023, and carry the OBS! caveat so
+    the LLM (and the user) can see this isn't current-cohort content."""
+    html = _load("program_CTFYS_20242_arskurs3.html")
+    url = "https://www.kth.se/student/kurser/program/CTFYS/20242/arskurs3"
+    structured = wr._studyplan_chunks_from_html(html, final_url=url, fetched_at=int(time.time()))
+    assert _eligibility_chunks(structured) == []
+
+    chunks: list = list(structured)
+    source_urls: list = []
+    visited: set = {url}
+
+    wr._maybe_emit_fallback_eligibility(
+        html=html,
+        final_url=url,
+        structured=structured,
+        cfg=cfg,
+        patterns=patterns,
+        cache=_FakeCache(),
+        visited=visited,
+        chunks=chunks,
+        source_urls=source_urls,
+    )
+
+    fallback = [c for c in chunks if "fallback" in (c.chunk_id or "")]
+    assert len(fallback) == 1
+    c = fallback[0]
+    # Citation hygiene: the section_path and doc_title must name the prior
+    # cohort so the user knows which läsår the answer was sourced from.
+    assert "HT2023" in c.section_path
+    assert "HT2023" in c.doc_title
+    # Caveat must be in the chunk text — it's what the LLM reproduces.
+    assert "OBS!" in c.text
+    assert "HT2023" in c.text and "HT2024" in c.text
+    assert "studievägledaren" in c.text.lower()
+    # The user-facing source URL points at the *prior* cohort so click-through
+    # lands on the actual page that has the block.
+    assert c.source_url == "https://www.kth.se/student/kurser/program/CTFYS/20232/arskurs3"
+    # And the eligibility data itself made it through extraction.
+    assert "DD2352" in c.text
+    assert "SF1679" in c.text
+    assert "DD1380" in c.text
+
+
+def test_fallback_noop_when_current_term_already_has_block(stub_network, cfg, patterns):
+    """HT2023 carries the block natively — the fallback path must not stack
+    a redundant prior-term chunk on top."""
+    html = _load("program_CTFYS_20232_arskurs3.html")
+    url = "https://www.kth.se/student/kurser/program/CTFYS/20232/arskurs3"
+    structured = wr._studyplan_chunks_from_html(html, final_url=url, fetched_at=int(time.time()))
+    assert len(_eligibility_chunks(structured)) == 1
+
+    chunks: list = list(structured)
+    source_urls: list = []
+    visited: set = {url}
+
+    wr._maybe_emit_fallback_eligibility(
+        html=html,
+        final_url=url,
+        structured=structured,
+        cfg=cfg,
+        patterns=patterns,
+        cache=_FakeCache(),
+        visited=visited,
+        chunks=chunks,
+        source_urls=source_urls,
+    )
+
+    fallback = [c for c in chunks if "fallback" in (c.chunk_id or "")]
+    assert fallback == []
+
+
+def test_fallback_noop_when_no_prior_term_has_block(stub_network, cfg, patterns, monkeypatch):
+    """CELTE never carries the block. The fallback must give up cleanly
+    rather than, say, raising or attaching the wrong programme's data."""
+
+    # Drop the prior-term URLs to a single CELTE candidate so the helper
+    # only has the one (also-empty) page to try. This isolates the
+    # "tried, none had block" path from the cap-on-attempts logic.
+    def _only_one_celte_prior(_code, _term, _year, _store, *, limit=3):
+        return ["https://www.kth.se/student/kurser/program/CELTE/20232/arskurs3"]
+
+    monkeypatch.setattr(wr, "_prior_term_year_urls", _only_one_celte_prior)
+
+    html = _load("program_CELTE_20232_arskurs3.html")
+    # Pretend we requested a non-existent CELTE/20242 URL so the regex
+    # accepts it. Helper extracts programme code and year from the URL,
+    # not from the HTML.
+    url = "https://www.kth.se/student/kurser/program/CELTE/20242/arskurs3"
+    structured = wr._studyplan_chunks_from_html(html, final_url=url, fetched_at=int(time.time()))
+
+    chunks: list = list(structured)
+    source_urls: list = []
+    visited: set = {url}
+
+    wr._maybe_emit_fallback_eligibility(
+        html=html,
+        final_url=url,
+        structured=structured,
+        cfg=cfg,
+        patterns=patterns,
+        cache=_FakeCache(),
+        visited=visited,
+        chunks=chunks,
+        source_urls=source_urls,
+    )
+
+    # No fallback chunk added; original structured chunk count unchanged.
+    assert len(chunks) == len(structured)
+    assert all("fallback" not in (c.chunk_id or "") for c in chunks)


### PR DESCRIPTION
# Conversation export, header polish, Docker version, cross-cohort eligibility fallback
Closes #34.

## Summary
Three logically distinct strands landed on this branch:
1. **Issue #34** — Markdown export of web-UI conversations, plus a handful of header / About-page cosmetic items the issue bundled with the feature.
2. **Docker version plumbing** — `STUDENT_BOT_VERSION` now flows from the host shell through `docker compose build` into the container so the About page shows a commit hash inside Docker (it was always empty before because `.git/` isn't copied into the image).
3. **Cross-cohort eligibility fallback** — for "what year-3 courses do I need to qualify for the X master?" questions, the bot now falls back to a prior cohort's study plan when the requested term's KTH page is missing the *"behörighetsgivande kurser per masterprogram"* block, with a clear caveat. Direction is the original spirit of #26.

## Markdown export (#34)
- **Client-side thread capture.** New `state.thread = []` in `app.js`. User turns are appended on submit; bot turns are pre-allocated when `appendBot()` runs and filled in by `decorateBot` with body, sources, jargon prefix, confidence label. 👍/👎 click handlers stamp `reaction` onto the active turn.
- **Export button** in the composer toolbar next to "New thread". Hidden when the thread is empty; cleared on Reset.
- **Output format.** One `### Speaker · YYYY-MM-DD HH:MM[ · _Confidence_]` heading per turn, body verbatim (Markdown links preserved), 👍 / 👎 line only when the user actually reacted, numbered **Sources** list with URLs after each bot turn, `---` between turns. Literacy footer (`Tip:` / `Tips:`) is explicitly stripped per the issue.
- **Filename** is `student-bot-conversation-YYYY-MM-DD-HHMM.md` from the first turn's timestamp.
## Header / About-page cosmetics (#34)
- **Clickable brand title.** `_HEADER_HTML` and `static/index.html` wrap the brand text in `<a class="brand-link">` pointing at the chat home. Title color is KTH blue, hover/focus animates to KTH sky-blue.
- **Logos +40%**: `.logo` 40 → 56 px, `.logo-fyssek` 44 → 62 px.
- **Tagline dropped CTFYS** in both sv and en so the bot reads as "Administrativ Q&A-bot för KTH" — scope will broaden beyond CTFYS.
- **About page version inline.** GitHub repo link and version are now on a single row, separated by ` · `. Version sits in a `<span class="version">` styled in `--muted` so it's discoverable but doesn't compete with the repo link. Empty case renders nothing — no dangling separator.

## Docker version plumbing
- `Dockerfile`: new `ARG STUDENT_BOT_VERSION=""` + `ENV STUDENT_BOT_VERSION=${STUDENT_BOT_VERSION}` between `WORKDIR /app` and the runtime stage.
- `docker-compose.yml`: both `bot` and `beta-web` services pick up `build.args.STUDENT_BOT_VERSION: ${STUDENT_BOT_VERSION:-}`.
Result: either `STUDENT_BOT_VERSION=$(git rev-parse --short HEAD) docker compose build` or `docker compose build --build-arg STUDENT_BOT_VERSION=$(git rev-parse --short HEAD)` now bakes the version into the image, and the About page renders it.

## Cross-cohort eligibility fallback (#26 follow-up)
The on-call diagnostic that motivated this: a CTFYS HT2024 student asked which year-3 courses qualify them for the Datalogi master. The bot's `web_live` retrieval correctly fetched `/program/CTFYS/20242/arskurs3`, but that page is missing the *"behörighetsgivande kurser per masterprogram"* block that the HT2023 cohort's plan has. The model received the right page, found no specific eligibility list in it, and gave a generic deflection.

The fix walks both layers:
- **Detection + structured chunk for current-term content.** `_eligibility_text_from_store` scans the decoded SPA store for `behörighetsgivande kurs[er|en]` (case- and ö/o-insensitive — both observed KTH formats match). When found, `_studyplan_chunks_from_year_page` now emits the block as a dedicated chunk with `section_path = "Årskurs N –
behörighetsgivande kurser per masterprogram"`, separate from the per-Valvillkor course tables so retrieval doesn't bury it.
- **Cross-cohort fallback.** `_maybe_emit_fallback_eligibility` runs after the structured-chunk pass for any `/arskursN` page. If no eligibility chunk emerged, it walks `programmeTerms` (or steps the term back heuristically), fetches prior terms in most-recent-first order, and surfaces the first one that has the block as a chunk with:
  - Bold **OBS!** preamble naming both cohorts and the studievägledare.
  - `section_path` / `doc_title` carrying the prior cohort label, so the citation reads "(läsår HT2023)" right in the link text.
  - `source_url` pointing at the prior-cohort page so click-through lands on the original page.
Capped at one successful fallback fetch per query; failed fetches log and move on.
Live test (CTFYS HT2024 question, Datalogi eligibility) now produces a cited answer with all three required courses (DD2352, SF1679, DD1380) and reproduces the caveat to the user verbatim.

### Known limitations
- Programmes that never carry the block (e.g. CELTE) — the fallback gives up cleanly but the corpus gap remains. These need either KTH-side page updates or curated corpus content.
- The `web_live` retrieval path still uses a synthetic `rerank_top1=3.5` (and hence the "Hög" confidence badge) — a separate concern not addressed here.

## Tests
New `tests/test_eligibility_fallback.py` — 10 cases, all backed by real KTH HTML captured under `tests/fixtures/`:
- Extractor: hits on CTFYS HT2023 (two formats represented across fixtures), misses on CTFYS HT2024 and CELTE HT2023.
- `_term_label_sv`: 5-digit term decoding + garbage pass-through.
- Current-term emission: exactly one eligibility chunk when the block is present; zero when absent.
- Fallback: emits HT2023-sourced chunk for HT2024 request with OBS! caveat and prior `source_url`; no-op when current term already has the block; no-op when no prior term has it.

A `stub_network` pytest fixture replaces `_fetch_html` and `_is_allowed_url` per-test via `monkeypatch`, so the fallback path resolves "prior term" lookups offline. Unknown URLs raise — a test can never silently pass by hitting the real network.
## Files
| File | Why |
|---|---|
| `Dockerfile`, `docker-compose.yml` | `STUDENT_BOT_VERSION` ARG/ENV + compose `build.args`. |
| `src/student_bot/web/app.py` | `_HEADER_HTML` takes a new `{home}` slot, every `.format()` site updated; About-page version moved inline + muted. |
| `src/student_bot/web/static/index.html` | Brand text wrapped in `<a class="brand-link">`; new "Export" button. |
| `src/student_bot/web/static/app.js` | `state.thread`, capture hooks in submit / `decorateBot` / feedback handlers, `exportThreadMarkdown()`, button wiring. |
| `src/student_bot/web/static/style.css` | `.brand-link` colors + hover, logo sizes, `.github-link .version`. |
| `src/student_bot/web/static/i18n.js` | sv/en tagline drops CTFYS; new `chat.export*` / `export.*` keys. |
| `src/student_bot/bot/web_retrieval.py` | `_eligibility_text_from_store`, `_term_label_sv`, `_prior_term_year_urls`, `_maybe_emit_fallback_eligibility`, plus eligibility-chunk emission in `_studyplan_chunks_from_year_page`. |
| `tests/test_eligibility_fallback.py`, `tests/fixtures/*.html` | Regression test + 4 captured KTH fixtures. |
## Verification
- `uv run pytest tests/` — 58 passing (48 prior + 10 new).
- `uv run ruff check . && uv run ruff format --check .` — clean.
- Web UI: smoke-tested `/`, `/about`, `/stats`, `/glossary` — all 200; clicking the brand title returns to chat; PNG export, range/log toggles, channel filter all behave; new "Export" button writes a `.md` matching the format spec.
- Live CLI replay of the failing CTFYS HT2024 / Datalogi question now produces a cited answer with the three correct courses and the explicit "fetched from HT2023, verify with the counselor" caveat.
- `docker compose build --build-arg STUDENT_BOT_VERSION=$(git rev-parse --short HEAD)` produces an image whose `/about` page shows the commit hash.
