### PR TITLE
Fix for #36, allowing to scroll up also during answer is streamed

### DIFF
--- a/src/student_bot/web/static/app.js
+++ b/src/student_bot/web/static/app.js
@@ -142,14 +142,16 @@ composer.addEventListener("submit", async (e) => {
             firstToken = false;
             firstTokenAt = performance.now();
           }
+          const stick = nearBottom();
           botMsg.body.appendChild(document.createTextNode(data));
-          messages.scrollTop = messages.scrollHeight;
+          if (stick) messages.scrollTop = messages.scrollHeight;
         } else if (event === "jargon") {
           const prefixEl = botMsg.body.querySelector(".msg-prefix");
           if (prefixEl) {
+            const stick = nearBottom();
             prefixEl.appendChild(document.createTextNode(data));
+            if (stick) messages.scrollTop = messages.scrollHeight;
           }
-          messages.scrollTop = messages.scrollHeight;
         } else if (event === "thinking") {
           // Show "<bot> funderar…" beside the dots while the model is in
           // its <think>...</think> phase. Cleared on "end" or when the
@@ -191,7 +193,9 @@ composer.addEventListener("submit", async (e) => {
       finalMeta.client_ttft_ms = Math.max(0, Math.round(firstTokenAt - reqStartedAt));
       finalMeta.client_tps = tokEst / genSecs;
     }
+    const stick = nearBottom();
     decorateBot(botMsg, finalMeta);
+    if (stick) messages.scrollTop = messages.scrollHeight;
     if (perfEnabled) updatePerfPanel(finalMeta);
   }
 });
@@ -292,6 +296,16 @@ function parseSSE(block) {
     else if (line.startsWith("data:")) data += line.slice(5).replace(/^\s/, "") + "\n";
   }
   return { event, data: data.replace(/\n$/, "") };
+}
+
+// True if the message list is scrolled to (or within a small slop of) the
+// bottom. Streaming-time appends consult this before pinning the scroll so
+// the user can scroll up to read earlier parts of a long reply without each
+// new token yanking them back down. Evaluate BEFORE appending content —
+// once the new node is in the DOM, scrollHeight grows and the predicate
+// returns false even though the user was at the bottom a moment ago.
+function nearBottom() {
+  return messages.scrollHeight - messages.scrollTop - messages.clientHeight < 40;
 }
 
 function appendUser(text) {


### PR DESCRIPTION
## Summary
Fixes #36 — scrolling up during a long streaming reply no longer gets yanked back to the bottom on every token.
A new `nearBottom()` predicate (40 px slop) is captured **before** each streaming-time append. The auto-scroll only fires if the user was already near the bottom; otherwise their reading position is preserved. Applied at three sites in the `composer` submit handler:
- the `token` SSE event (per-character streaming),
- the `jargon` SSE event (jargon transparency prefix),
- the post-stream `decorateBot` call, which re-renders the body with markdown, sources, and the literacy tip — height can shift, so the same rule applies.

Now `appendUser` and `appendBot` keep their unconditional scroll: the user just hit Enter and expects to see the new bubble. 

Implementation note: `nearBottom()` must be evaluated **before** the new node is in the DOM. Once `appendChild` runs, `scrollHeight` grows and the predicate flips to false even though the user was at the bottom a moment ago.

## Test plan
- [x] `node --check src/student_bot/web/static/app.js` — clean.
- [x] Manual: ask a question whose reply spans more than one screen; while it streams, scroll up and read the early sentences — the scroll should not snap back.
- [x] Manual: stay at the bottom while a short reply streams — auto-scroll should still pin you to the bottom as before.
- [x] Manual: scroll up during streaming, then scroll back down to the bottom — subsequent tokens should resume pinning.
- [x] Manual: after the stream ends (sources block + tip appended via `decorateBot`), scroll behaviour follows the same rule: at-bottom users stay pinned, scrolled-up users stay put.
