### PR TITLE
Implementing stream-time markdown formating

### DIFF
--- a/src/student_bot/web/static/app.js
+++ b/src/student_bot/web/static/app.js
@@ -884,6 +884,8 @@ function renderMarkdown(text) {
   // Small markdown subset used in chat:
   // - paragraphs + hard line breaks
   // - unordered + ordered lists
+  // - ATX headings (# .. ######)
+  // - horizontal rules (--- / *** / ___ on a line of their own)
   // - **bold**, _italic_, links
   //
   // Intentionally *not* a full markdown parser; keep deterministic and safe.
@@ -926,8 +928,29 @@ function renderMarkdown(text) {
 
   for (const rawLine of lines) {
     const line = rawLine.replace(/\s+$/, ""); // trim end only
+    // Headings: `#` to `######` followed by a space and content. Check
+    // before list/hr so a `# heading` line doesn't get re-parsed as text.
+    const heading = line.match(/^(#{1,6})\s+(.+)$/);
+    // Horizontal rule: a line that is ONLY 3+ of `-`, `*`, or `_`. The
+    // anchored `\s*$` keeps `***bold***` and `- list item` out.
+    const hr = line.match(/^\s*(?:-{3,}|\*{3,}|_{3,})\s*$/);
     const ul = line.match(/^\s*[*-]\s+(.+)$/);
     const ol = line.match(/^\s*(\d+)\.\s+(.+)$/);
+
+    if (heading) {
+      flushPara();
+      flushList();
+      const level = heading[1].length;
+      html += `<h${level}>${renderInline(heading[2])}</h${level}>`;
+      continue;
+    }
+
+    if (hr) {
+      flushPara();
+      flushList();
+      html += "<hr>";
+      continue;
+    }
 
     if (ul || ol) {
       flushPara();

--- a/src/student_bot/web/static/app.js
+++ b/src/student_bot/web/static/app.js
@@ -128,7 +128,9 @@ composer.addEventListener("submit", async (e) => {
       }),
     });
     if (!resp.ok || !resp.body) {
-      botMsg.body.textContent = `[error ${resp.status}]`;
+      const tw = botMsg.body.querySelector(".thinking-wrap");
+      if (tw) tw.remove();
+      botMsg.render.textContent = `[error ${resp.status}]`;
       return;
     }
     const reader = resp.body.getReader();
@@ -149,9 +151,8 @@ composer.addEventListener("submit", async (e) => {
             firstToken = false;
             firstTokenAt = performance.now();
           }
-          const stick = nearBottom();
-          botMsg.body.appendChild(document.createTextNode(data));
-          if (stick) messages.scrollTop = messages.scrollHeight;
+          botMsg.entry.raw += data;
+          scheduleRender(botMsg);
         } else if (event === "jargon") {
           const prefixEl = botMsg.body.querySelector(".msg-prefix");
           if (prefixEl) {
@@ -182,9 +183,8 @@ composer.addEventListener("submit", async (e) => {
   } catch (err) {
     const tw = botMsg.body.querySelector(".thinking-wrap");
     if (tw) tw.remove();
-    botMsg.body.appendChild(
-      document.createTextNode(`\n[stream error: ${err.message}]`)
-    );
+    if (botMsg.entry) botMsg.entry.raw += `\n[stream error: ${err.message}]`;
+    scheduleRender(botMsg);
     firstToken = false;
   } finally {
     el("#send").disabled = false;
@@ -194,8 +194,9 @@ composer.addEventListener("submit", async (e) => {
     if (Object.prototype.hasOwnProperty.call(finalMeta, "performance_panel_enabled")) {
       setPerfEnabled(!!finalMeta.performance_panel_enabled);
     }
-    if (firstTokenAt && botMsg.body.textContent) {
-      const tokEst = estimateTokens(botMsg.body.textContent);
+    const rawText = botMsg.entry?.raw || "";
+    if (firstTokenAt && rawText) {
+      const tokEst = estimateTokens(rawText);
       const genSecs = Math.max(0.001, (performance.now() - firstTokenAt) / 1000);
       finalMeta.client_ttft_ms = Math.max(0, Math.round(firstTokenAt - reqStartedAt));
       finalMeta.client_tps = tokEst / genSecs;
@@ -346,13 +347,35 @@ function appendBot() {
       "<span></span><span></span><span></span>" +
     "</span>" +
     '<span class="thinking-label" hidden></span>';
+  // Live-rendered markdown container. Streamed tokens accumulate in
+  // botMsg.entry.raw and are re-rendered here on each animation frame so
+  // the user sees formatting (bold, lists, links) as the answer arrives
+  // rather than only after decorateBot runs at end-of-stream.
+  const render = document.createElement("div");
+  render.className = "msg-render";
   body.appendChild(prefix);
   body.appendChild(thinking);
+  body.appendChild(render);
   wrap.appendChild(meta);
   wrap.appendChild(body);
   messages.appendChild(wrap);
   messages.scrollTop = messages.scrollHeight;
-  return { wrap, meta, body };
+  return { wrap, meta, body, render };
+}
+
+// Coalesce per-token markdown re-renders to ~60Hz via requestAnimationFrame.
+// After decorateBot runs, further schedules are no-ops — the final pass owns
+// the rendered HTML (with numbered citations, sources block, and tip).
+function scheduleRender(botMsg) {
+  if (!botMsg || !botMsg.render || !botMsg.entry) return;
+  if (botMsg._decorated || botMsg._renderRaf) return;
+  botMsg._renderRaf = requestAnimationFrame(() => {
+    botMsg._renderRaf = 0;
+    if (botMsg._decorated) return;
+    const stick = nearBottom();
+    botMsg.render.innerHTML = renderMarkdown(botMsg.entry.raw || "");
+    if (stick) messages.scrollTop = messages.scrollHeight;
+  });
 }
 
 function decorateBot(botMsg, meta) {
@@ -374,9 +397,15 @@ function decorateBot(botMsg, meta) {
   // [doc · section] markers the LLM emitted; only sources that were
   // actually cited inline appear in the references list, renumbered
   // in order of first appearance.
-  const raw = botMsg.body.textContent;
   const prefixEl = botMsg.body.querySelector(".msg-prefix");
   const jargonText = (prefixEl?.textContent || "").trim();
+  // Mirror the pre-live-render behaviour: merge the jargon prefix into the
+  // raw text fed to splitMessage so it gets markdown-rendered alongside the
+  // body (e.g. `_Tolkar X._` becomes italic). No separator between prefix
+  // and body matches the old `body.textContent` concatenation. The prefix
+  // div is emptied below so the jargon isn't shown twice.
+  const streamedRaw = botMsg.entry?.raw || "";
+  const raw = (prefixEl?.textContent || "") + (streamedRaw || botMsg.body.textContent);
   const { body, sources: allSources, tip } = splitMessage(raw);
   const serverSources = Array.isArray(meta.sources) ? meta.sources : [];
   const sourceCandidates = Array.isArray(meta.source_candidates) ? meta.source_candidates : [];
@@ -402,7 +431,19 @@ function decorateBot(botMsg, meta) {
     html += renderSources(serverSources, meta.lang || "sv");
   }
   if (tip) html += renderTip(tip);
-  botMsg.body.innerHTML = html;
+  // Cancel any pending live re-render and target the live element so the
+  // jargon prefix (.msg-prefix) stays in place. Falls back to replacing
+  // the whole body if .msg-render is somehow missing.
+  if (botMsg._renderRaf) {
+    cancelAnimationFrame(botMsg._renderRaf);
+    botMsg._renderRaf = 0;
+  }
+  botMsg._decorated = true;
+  const renderTarget = botMsg.render || botMsg.body;
+  renderTarget.innerHTML = html;
+  // Empty the prefix since its content was merged into the rendered body
+  // above; otherwise the jargon line would appear twice.
+  if (prefixEl) prefixEl.textContent = "";
 
   // Snapshot the parts of the answer we want to keep in the exportable
   // thread log. `body` retains markdown links and inline citation markers;

--- a/src/student_bot/web/static/style.css
+++ b/src/student_bot/web/static/style.css
@@ -158,6 +158,30 @@ button:disabled { opacity: 0.5; cursor: progress; }
 .msg .body li { margin: 2px 0; }
 .msg.bot .body ul,
 .msg.bot .body ol { white-space: normal; }
+/* Headings rendered from the LLM-emitted `#`..`######` markdown. Kept
+   close to body-text size so a structured reply doesn't dominate the
+   chat bubble; browser defaults would render h1/h2 as banner-sized. */
+.msg .body h1,
+.msg .body h2,
+.msg .body h3,
+.msg .body h4,
+.msg .body h5,
+.msg .body h6 {
+  margin: 12px 0 4px;
+  line-height: 1.25;
+  font-weight: 600;
+}
+.msg .body h1 { font-size: 1.15em; }
+.msg .body h2 { font-size: 1.10em; }
+.msg .body h3 { font-size: 1.05em; }
+.msg .body h4,
+.msg .body h5,
+.msg .body h6 { font-size: 1em; }
+.msg .body hr {
+  border: 0;
+  border-top: 1px solid var(--border);
+  margin: 12px 0;
+}
 /* Jargon / transparency note streamed before answer tokens (SSE event `jargon`). */
 .msg .body .msg-prefix {
   display: block;


### PR DESCRIPTION
## Summary
Fixes #37 — bot replies now render with markdown formatting (bold, italic, lists, links) **as they stream**, not only at end-of-stream.

The body element now contains a new `.msg-render` child alongside the existing `.msg-prefix` and `.thinking-wrap`. Streamed tokens accumulate in `botMsg.entry.raw` (a field that was already declared on the thread entry, previously only filled at decorate time) and a `requestAnimationFrame`-coalesced re-render writes `renderMarkdown(raw)` into `.msg-render` on each frame — capped at ~60 Hz to avoid layout thrash on fast streams.

`decorateBot` keeps ownership of the *final* render (numbered citations, sources block, literacy tip): it cancels any pending rAF, sets a `_decorated` flag so further schedules are no-ops, and writes its HTML into `.msg-render` only — leaving `.msg-prefix` in place. To preserve the pre-existing "jargon merged into body markdown" semantics, the prefix's text content is prepended to raw before `splitMessage`, then the prefix div is emptied so the line isn't shown twice.

The `nearBottom()` scroll-stickiness pattern from #36 is wired into the live re-render path too, so scrolling up during streaming still works.

## What you'll see
- Bold/italic/links/lists appear formatted as the answer streams.
- Mid-stream partials (unclosed `**`, dangling link `[label](http…`) stay as plain text until the closing marker arrives, then snap into place — no broken markup.
- `[Title · Section]` inline citations stay as plain text during streaming and become numbered `[N]` anchor links once the stream ends (`decorateBot` owns that pass).
- The sources block at the very end of the stream briefly renders as a markdown bold + ordered list for a frame or two before `decorateBot` re-renders it as the styled references list. Cosmetic; alternative would be a "swallow trailing sources block" detector in the live renderer if it bothers anyone.

## Test plan
- [x] `node --check src/student_bot/web/static/app.js` — clean.
- [x] `uv run pytest tests/` — 58 passed.
- [x] `uv run python -c "from student_bot.web.app import create_app; create_app()"` — app loads.
- [x] Manual: ask a question that elicits bold, lists, and links — verify they render as the stream progresses, not in one jump at the end.
- [x] Manual: long reply, scroll up during streaming — reading position holds (scroll-stickiness from #36 still works).
- [ ] Manual: jargon-bearing question (e.g. "KEX?") — italic prefix during stream, properly merged into rendered body after decorate, no duplication.
- [ ] Manual: question that triggers a refusal / empty answer / stream error — UI handles the error string cleanly in `.msg-render`.
