### PR TITLE
Improving program name matching, in response to #39

### DIFF
--- a/data/program_nicknames.json
+++ b/data/program_nicknames.json
@@ -1,6 +1,6 @@
 {
   "version": 1,
-  "_comment": "Curated colloquial program names. Each entry maps a phrase to the candidate program codes a current student could plausibly mean. Used as a backstop when alias scoring in web_retrieval.py fails to narrow to a single code. Add entries when conversation logs surface a recurring informal term that the official KTH alias list cannot resolve cleanly.",
+  "_comment": "Curated colloquial program names. Each entry maps a phrase to the candidate program codes a current student could plausibly mean. When a phrase appears in the query, its candidate codes override alias scoring: any alias-only matches outside the curated set are dropped (verbatim-typed codes are kept). Add entries when conversation logs surface a recurring informal term that alias scoring can't resolve cleanly.",
   "entries": {
     "teknisk fysik": {
       "candidates": ["CTFYS", "TTFYM"],
@@ -11,6 +11,16 @@
       "candidates": ["CTFYS", "TTFYM"],
       "lang": "en",
       "note": "Usually the 5-year civilingenjör (CTFYS) or the 2-year master (TTFYM). TFEPM (nuclear fusion science and engineering physics) was discontinued in 2010."
+    },
+    "teknisk matematik": {
+      "candidates": ["CTMAT"],
+      "lang": "sv",
+      "note": "Civilingenjörsprogrammet i teknisk matematik (CTMAT). Utan denna override drog alias-scoring in TMTHM (masterprogram, matematik — sista intag 2012) som spurious candidate, eftersom dess enda strong-token \"matematik\" matchade fullt ut."
+    },
+    "engineering mathematics": {
+      "candidates": ["CTMAT"],
+      "lang": "en",
+      "note": "Civilingenjör programme in engineering mathematics (CTMAT)."
     }
   }
 }

--- a/src/student_bot/bot/web_retrieval.py
+++ b/src/student_bot/bot/web_retrieval.py
@@ -107,9 +107,17 @@ _GENERIC_ALIAS_TOKENS = {
     "programme",
     "utbildning",
     "utbildningsplan",
+    # Both ö- and o-forms: the alias file uses "civilingenjör…" (with ö) but
+    # earlier versions of this blocklist only had the ASCII spelling, so the
+    # generic prefix wasn't being filtered out of real aliases — which
+    # silently inflated `_alias_strong_tokens` denominators and skewed
+    # `_alias_score` against the longer (more specific) civilingenjör aliases.
     "civilingenjorsutbildning",
+    "civilingenjörsutbildning",
     "civilingenjorsprogram",
+    "civilingenjörsprogram",
     "civilingenjor",
+    "civilingenjör",
     "kth",
     "the",
     "and",
@@ -570,11 +578,38 @@ def _alias_strong_tokens(alias: str) -> set[str]:
     return {t for t in tokens if len(t) >= 4 and t not in _GENERIC_ALIAS_TOKENS}
 
 
-def _alias_score(alias: str, qn: str, q_tokens: set[str]) -> tuple[float, bool]:
+def _alias_token_frequency(aliases: dict[str, str]) -> dict[str, int]:
+    """How many distinct aliases each strong token appears in.
+
+    Used by the historical-program rescue logic to require at least one
+    *rare* matched token before keeping a discontinued candidate in
+    disambiguation. A common subject token like `matematik` (present in many
+    aliases) shouldn't be enough on its own to rescue an extinct master from
+    the recency drop — but a rare token like `fusionsenergi` (1 alias)
+    should still rescue TFEPM when the user types it explicitly.
+    """
+    freq: dict[str, int] = {}
+    for alias in aliases:
+        for t in _alias_strong_tokens(alias):
+            freq[t] = freq.get(t, 0) + 1
+    return freq
+
+
+def _alias_score(
+    alias: str, qn: str, q_tokens: set[str], q_strong_tokens: set[str]
+) -> tuple[float, bool]:
     """Score a normalised alias against a normalised question.
 
-    Score = fraction of the alias's discriminative ('strong') tokens present
-    in the question, plus 0.5 if the full alias phrase appears verbatim.
+    Combines two coverages so an alias has to match a meaningful fraction of
+    *both* sides — the alias's strong tokens AND the user's strong tokens —
+    before it scores well. Without the query-side factor, a one-token alias
+    like "masterprogram, matematik" gets coverage=1.0 from any query that
+    mentions "matematik", overshadowing the more specific match for queries
+    like "teknisk matematik" → "civilingenjörsutbildning i teknisk matematik".
+
+    Score = (alias_coverage * query_coverage) + 0.5 if the full alias phrase
+    appears verbatim in the question.
+
     Returns (score, verbatim_phrase_present). Score 0 = no match.
     """
     if not alias:
@@ -587,9 +622,13 @@ def _alias_score(alias: str, qn: str, q_tokens: set[str]) -> tuple[float, bool]:
     inter = strong & q_tokens
     if not inter:
         return 0.0, False
-    coverage = len(inter) / len(strong)
+    alias_coverage = len(inter) / len(strong)
+    # Query-side coverage. If the user typed no strong tokens at all (very
+    # short query like "ctfys" with only the code), default to 1.0 so we
+    # don't penalise short verbatim-code queries that route through here.
+    query_coverage = len(inter) / len(q_strong_tokens) if q_strong_tokens else 1.0
     verbatim = alias in qn
-    return coverage + (0.5 if verbatim else 0.0), verbatim
+    return alias_coverage * query_coverage + (0.5 if verbatim else 0.0), verbatim
 
 
 def _program_level(code: str) -> str:
@@ -716,6 +755,7 @@ def _extract_program_candidates(
     }
     qn = _norm(question)
     q_tokens = set(re.findall(r"[a-z0-9åäö]+", qn))
+    q_strong_tokens = {t for t in q_tokens if len(t) >= 4 and t not in _GENERIC_ALIAS_TOKENS}
 
     verbatim_codes: list[str] = []
     for code in _PROGRAM_CODE_RE.findall(question):
@@ -736,7 +776,7 @@ def _extract_program_candidates(
         # verbatim-codes pass above handles those.
         if alias and alias.upper() == code:
             continue
-        score, verbatim = _alias_score(alias, qn, q_tokens)
+        score, verbatim = _alias_score(alias, qn, q_tokens, q_strong_tokens)
         if score < min_score:
             continue
         prev = by_code.get(code)
@@ -750,20 +790,39 @@ def _extract_program_candidates(
         elif verbatim and not prev.verbatim:
             prev.verbatim = True
 
-    if not by_code:
-        # Backstop: curated colloquial names ("teknisk fysik" -> [CTFYS, TTFYM])
-        nicknames = _load_program_nicknames(cfg)
-        for phrase, codes in nicknames.items():
-            if phrase and phrase in qn:
-                for c in codes:
-                    if c not in by_code:
-                        by_code[c] = _ProgramCandidate(
-                            code=c,
-                            score=0.8,
-                            matched_alias=f"<nickname:{phrase}>",
-                            verbatim=False,
-                        )
-                break  # one nickname phrase is enough; avoid stacking entries
+    # Curated colloquial-name override. If a phrase from
+    # `data/program_nicknames.json` appears in the query, treat its candidate
+    # codes as authoritative: keep verbatim-typed codes, keep the nickname
+    # codes themselves (boosting them if they were below threshold), and drop
+    # alias-only matches that aren't in the curated set. Lets the operator
+    # pin a high-traffic colloquial phrase like "teknisk matematik" to CTMAT
+    # without having to re-derive it via alias scoring.
+    nicknames = _load_program_nicknames(cfg)
+    nickname_codes: list[str] = []
+    matched_phrase = ""
+    for phrase, codes in nicknames.items():
+        if phrase and phrase in qn:
+            nickname_codes = [c for c in codes if c not in nickname_codes]
+            matched_phrase = phrase
+            break
+    if nickname_codes:
+        verbatim_set = set(verbatim_codes)
+        kept: dict[str, _ProgramCandidate] = {}
+        for code in nickname_codes:
+            existing = by_code.get(code)
+            if existing is not None:
+                kept[code] = existing
+            else:
+                kept[code] = _ProgramCandidate(
+                    code=code,
+                    score=0.8,
+                    matched_alias=f"<nickname:{matched_phrase}>",
+                    verbatim=False,
+                )
+        for code, cand in by_code.items():
+            if code in verbatim_set:
+                kept.setdefault(code, cand)
+        by_code = kept
 
     if not by_code and program_prior and re.fullmatch(r"[A-Z]{5}", program_prior):
         # Conversation prior: use the last resolved program when the current
@@ -794,6 +853,47 @@ def _extract_program_candidates(
                 c for c in candidates if c.verbatim and c.code not in {n.code for n in narrowed}
             ]
             candidates = narrowed + verbatim_extras
+
+    # Recency penalty: programmes whose most recent intake is older than
+    # `historical_program_years` (default 8) get their score halved and may
+    # fall below the alias threshold. Skipped for verbatim-typed codes (the
+    # user explicitly named it) and for nickname-listed codes (the operator
+    # explicitly chose to keep them in the candidate pool). Uses the cached
+    # term list (6h TTL) — only fires for candidates that already survived
+    # alias scoring, so it doesn't slow down the typical single-candidate
+    # path. Last-resort safety: any exception keeps the candidate in.
+    if len(candidates) > 1:
+        cutoff_year = _current_calendar_year() - cfg.dynamic_web.historical_program_years
+        nickname_set = set(nickname_codes)
+        kept_after_recency: list[_ProgramCandidate] = []
+        for cand in candidates:
+            if cand.verbatim or cand.code in nickname_set:
+                kept_after_recency.append(cand)
+                continue
+            try:
+                terms = _cached_terms_for_code(cfg, cand.code)
+            except Exception:
+                kept_after_recency.append(cand)
+                continue
+            bounds = _intake_year_bounds_from_terms(terms)
+            if bounds is None:
+                kept_after_recency.append(cand)
+                continue
+            if bounds[1] < cutoff_year:
+                cand.score *= 0.5
+                if cand.score < min_score:
+                    log.info(
+                        "dynamic-web: dropping %s after recency penalty "
+                        "(last intake %d < cutoff %d, score %.2f < min %.2f)",
+                        cand.code,
+                        bounds[1],
+                        cutoff_year,
+                        cand.score,
+                        min_score,
+                    )
+                    continue
+            kept_after_recency.append(cand)
+        candidates = kept_after_recency
 
     candidates.sort(key=lambda c: (-c.score, c.code))
     return candidates, verbatim_codes
@@ -2018,19 +2118,30 @@ def _resolve_multi_program_candidates(
     has_current = any(is_current(t) for _, t, _ in candidates)
 
     verbatim_typed = set(_PROGRAM_CODE_RE.findall(question))
+    token_freq = _alias_token_frequency(aliases)
+    rare_token_threshold = cfg.dynamic_web.discriminator_rare_token_max_aliases
 
     def discriminator_present(code: str) -> bool:
-        """User typed at least one of the alias's discriminative tokens.
+        """User typed enough discriminative tokens to override the
+        historical-program suppression.
 
-        Used to override the historical-program suppression: e.g. typing
-        'fusionsenergi' keeps TFEPM in the disambiguation list even though
-        its last intake is older than the cutoff.
+        Requires: full match of an alias's strong-token set AND at least one
+        of those matched tokens being *rare* across the alias corpus
+        (appearing in ≤ `discriminator_rare_token_max_aliases` aliases). The
+        rarity gate stops a discontinued programme from being rescued by a
+        query that only mentions a common subject term like `matematik` —
+        but `fusionsenergi` (unique to TFEPM) still rescues that one.
         """
         for alias, c in aliases.items():
             if c != code or not alias:
                 continue
             strong = _alias_strong_tokens(alias)
-            if strong and len(strong & q_tokens) == len(strong):
+            if not strong:
+                continue
+            matched = strong & q_tokens
+            if len(matched) != len(strong):
+                continue
+            if any(token_freq.get(t, 0) <= rare_token_threshold for t in matched):
                 return True
         return False
 

--- a/src/student_bot/config.py
+++ b/src/student_bot/config.py
@@ -180,6 +180,14 @@ class DynamicWebConfig(BaseModel):
     # Minimum alias score (coverage of discriminative tokens) required to
     # treat a program alias as a candidate match.
     alias_min_score: float = 0.6
+    # In `_resolve_multi_program_candidates`, a historical (older than
+    # historical_program_years) candidate is rescued only if the user's
+    # query contains all of an alias's strong tokens AND at least one of
+    # those tokens is *rare* — appearing in this many aliases or fewer
+    # across the whole alias set. Keeps common subject terms like
+    # `matematik` from trivially rescuing extinct masters; lets unique
+    # discriminators like `fusionsenergi` still rescue TFEPM.
+    discriminator_rare_token_max_aliases: int = 3
 
 
 class UrlIngestConfig(BaseModel):

--- a/tests/test_dynamic_web.py
+++ b/tests/test_dynamic_web.py
@@ -186,6 +186,8 @@ def test_extract_targets_does_not_match_generic_masterprogram_alias(monkeypatch)
             "civilingenjorsutbildning i teknisk fysik": "CTFYS",
         },
     )
+    # Isolate from curated nicknames so this test verifies alias scoring only.
+    monkeypatch.setattr(wr, "_load_program_nicknames", lambda _cfg: {})
     q = "Vad ar programkoden for masterprogrammet i teknisk fysik?"
     out = _extract_targets_with_cfg(q, cfg)
     assert "https://www.kth.se/student/kurser/program/CTFYS" in out
@@ -202,10 +204,128 @@ def test_extract_targets_prefers_multiword_program_alias_over_single_subject(mon
             "civilingenjorsutbildning i teknisk fysik": "CTFYS",
         },
     )
+    # Isolate from curated nicknames so this test verifies alias scoring only.
+    monkeypatch.setattr(wr, "_load_program_nicknames", lambda _cfg: {})
     q = "Vad har masterprogrammet i teknisk fysik for programkod?"
     out = _extract_targets_with_cfg(q, cfg)
     assert "https://www.kth.se/student/kurser/program/CTFYS" in out
     assert "https://www.kth.se/student/kurser/program/FYSIK" not in out
+
+
+def test_extract_targets_teknisk_matematik_drops_master_math_via_query_coverage(monkeypatch):
+    """Regression for #39 — query 'teknisk matematik' must not pull a master
+    program that only matches 'matematik' through the alias scoring asymmetry.
+
+    The civilingenjör alias has both 'teknisk' and 'matematik' as strong
+    tokens (CTMAT); the master-math alias has only 'matematik'. Pre-fix, both
+    scored 1.0 by alias-side coverage alone. With the query-coverage factor
+    now multiplied in, the master alias drops to 0.5 (1 of 2 query strong
+    tokens explained) — below the 0.6 threshold — and never reaches
+    disambiguation."""
+    cfg = get_config()
+    monkeypatch.setattr(
+        wr,
+        "_get_program_aliases",
+        lambda _cfg: {
+            "civilingenjörsutbildning i teknisk matematik": "CTMAT",
+            "masterprogram, matematik": "TMTHM",
+        },
+    )
+    monkeypatch.setattr(wr, "_load_program_nicknames", lambda _cfg: {})
+    out = _extract_targets_with_cfg("utbildningsplan för teknisk matematik", cfg)
+    assert "https://www.kth.se/student/kurser/program/CTMAT" in out
+    assert "https://www.kth.se/student/kurser/program/TMTHM" not in out
+
+
+def test_extract_targets_teknisk_matematik_nickname_override(monkeypatch):
+    """The curated nickname override in `data/program_nicknames.json` pins
+    'teknisk matematik' to CTMAT even when other math-flavoured aliases
+    happen to score above threshold."""
+    cfg = get_config()
+    monkeypatch.setattr(
+        wr,
+        "_get_program_aliases",
+        lambda _cfg: {
+            "civilingenjörsutbildning i teknisk matematik": "CTMAT",
+            "masterprogram, ingenjörstillämpad matematik": "TITMM",
+            # Add a same-token decoy so alias scoring alone would still surface
+            # other candidates.
+            "matematik och teknik": "FAKE1",
+        },
+    )
+    monkeypatch.setattr(
+        wr,
+        "_load_program_nicknames",
+        lambda _cfg: {"teknisk matematik": ["CTMAT"]},
+    )
+    out = _extract_targets_with_cfg("utbildningsplan för teknisk matematik", cfg)
+    assert "https://www.kth.se/student/kurser/program/CTMAT" in out
+    # Other math-flavoured candidates should not survive the nickname override.
+    assert "https://www.kth.se/student/kurser/program/TITMM" not in out
+    assert "https://www.kth.se/student/kurser/program/FAKE1" not in out
+
+
+def test_extract_targets_recency_penalty_drops_discontinued_program(monkeypatch):
+    """A historical program (no intake since 2012) gets its alias score
+    halved and falls below the 0.6 threshold, even when the alias scoring
+    alone would otherwise rank it equally with a current civilingenjör
+    candidate. Two aliases that both match the query's strong tokens fully:
+    only recency should distinguish them."""
+    cfg = get_config()
+    monkeypatch.setattr(
+        wr,
+        "_get_program_aliases",
+        lambda _cfg: {
+            "civilingenjörsutbildning i teknisk matematik": "CTMAT",
+            # Hypothetical alias that matches the query exactly the same way
+            # as the CTMAT alias — both have strong tokens {teknisk, matematik}
+            # and score 1.0 against "teknisk matematik". Without recency,
+            # this would force a disambiguation prompt.
+            "masterprogram i teknisk matematik": "TMTHM",
+        },
+    )
+    monkeypatch.setattr(wr, "_load_program_nicknames", lambda _cfg: {})
+    # Stub the term fetcher: CTMAT current, TMTHM last took students in 2012.
+    monkeypatch.setattr(
+        wr,
+        "_cached_terms_for_code",
+        lambda _cfg, code: {"CTMAT": ["20242"], "TMTHM": ["20122"]}.get(code, []),
+    )
+    out = _extract_targets_with_cfg("utbildningsplan för teknisk matematik", cfg)
+    assert "https://www.kth.se/student/kurser/program/CTMAT" in out
+    assert "https://www.kth.se/student/kurser/program/TMTHM" not in out
+
+
+def test_discriminator_rare_token_required_for_historical_rescue(monkeypatch):
+    """Historical-program rescue in disambiguation requires a *rare*
+    matched token (≤ 3 aliases). 'matematik' is common (4 aliases here) so
+    a discontinued master with only that token should NOT be rescued."""
+    cfg = get_config()
+    aliases = {
+        "civilingenjörsutbildning i teknisk matematik": "CTMAT",
+        "masterprogram, matematik": "TMTHM",
+        "masterprogram, ingenjörstillämpad matematik": "TITMM",
+        "masterprogram, tillämpad matematik och beräkningsmatematik": "TTMAM",
+        # 4 aliases all contain "matematik" → not rare → not a rescue token.
+    }
+    monkeypatch.setattr(wr, "_get_program_aliases", lambda _cfg: aliases)
+    # Stub terms: CTMAT current, TMTHM historical (last 2012).
+    monkeypatch.setattr(
+        wr,
+        "_cached_terms_for_code",
+        lambda _cfg, code: {"CTMAT": ["20242"], "TMTHM": ["20122"]}.get(code, []),
+    )
+    resolution = wr._resolve_multi_program_candidates(
+        cfg,
+        "teknisk matematik",
+        [
+            "https://www.kth.se/student/kurser/program/CTMAT",
+            "https://www.kth.se/student/kurser/program/TMTHM",
+        ],
+    )
+    # CTMAT current + TMTHM historical → without a rare discriminator,
+    # TMTHM is suppressed and the resolver returns just CTMAT.
+    assert resolution.resolved_code == "CTMAT"
 
 
 def test_build_doc_url_keeps_absolute_web_urls():


### PR DESCRIPTION
## Summary
Fixes #39 — "teknisk matematik" now resolves cleanly to CTMAT without the spurious CTMAT-vs-master-math disambiguation prompt that janden saw. Four interlocking changes; the first two are the ones that actually fix the reported case, the others harden adjacent failure modes.

1. **Query-coverage factor in `_alias_score`** — combine alias-side coverage with how much of the user's strong tokens the alias explains. Without this, a one-token alias like `"masterprogram, matematik"` gets coverage 1.0 against any query mentioning `matematik`, drowning out the longer, more specific civilingenjör alias.
2. **Curated nickname override** — `data/program_nicknames.json` entries now act as overrides (not just backstops). Adds explicit `"teknisk matematik" → CTMAT` so the most common phrasing is pinned regardless of which math aliases happen to score above threshold.
3. **Recency penalty in alias scoring** — when more than one candidate survives alias scoring, fetch each program's term list and halve the score of any candidate with no intake since `current_year - historical_program_years`. Verbatim-typed and nickname-listed codes bypass the penalty. Uses the existing 6h-cached `_cached_terms_for_code`; gated on `len(candidates) > 1` to avoid network calls on the typical single-candidate path.
4. **Token-rarity gate on historical rescue** — `discriminator_present` in `_resolve_multi_program_candidates` now requires at least one matched strong token to be *rare* (≤ `discriminator_rare_token_max_aliases`, default 3, appearances across the alias set). Common subject tokens like `matematik` no longer trivially rescue a discontinued master; rare tokens like `fusionsenergi` (TFEPM's discriminator) still do.

Latent bug found along the way: `_GENERIC_ALIAS_TOKENS` listed `civilingenjor` (ASCII) but not `civilingenjör` (with `ö`), so the live alias data — which uses `ö` — wasn't getting its generic prefix filtered. CTMAT was previously scoring 0.67 against "teknisk matematik" instead of 1.0 because its `civilingenjörsutbildning` token inflated the strong-token denominator. Both spellings are now blocklisted.

## Test plan
- [x] `uv run pytest tests/` — 62 passed (4 new regression tests).
- [x] `uv run ruff check src/ tests/` — clean.
- [x] End-to-end simulation against the real `data/program_aliases.json`: `"teknisk matematik"` and its variants now resolve uniquely to CTMAT; `"masterprogram i matematik"` still resolves to TMTHM (explicit master phrasing); `"teknisk fysik"` cases unchanged.
- [x] Manual: ask the bot "Vad gäller för teknisk matematik?" / "utbildningsplan för teknisk matematik" — should answer with CTMAT context, no disambiguation prompt.
- [ ] Manual: keep an eye on the `dynamic-web` logs for the new "dropping <code> after recency penalty" lines to confirm the penalty fires for the right programs.