### PR TITLE
Cite sources of right language

### DIFF
--- a/eval/run_eval.py
+++ b/eval/run_eval.py
@@ -87,7 +87,7 @@ def main(eval_file: Path, show_failures: bool):
             q_used, _ = jargon.expand_query(q, lang=entry.get("lang"))
         else:
             q_used = q
-        result = retrieve(cfg, q_used)
+        result = retrieve(cfg, q_used, query_language=entry.get("lang"))
         gate = evaluate_gate(cfg, result)
 
         if kind == "in_domain":

--- a/src/student_bot/bot/pipeline.py
+++ b/src/student_bot/bot/pipeline.py
@@ -417,7 +417,12 @@ def answer(
         )
     else:
         corpus_terms = corpus_programme_substrings_for_query(expanded_q)
-        retrieval = retrieve(cfg, expanded_q, corpus_programme_substrings=corpus_terms)
+        retrieval = retrieve(
+            cfg,
+            expanded_q,
+            corpus_programme_substrings=corpus_terms,
+            query_language=lang,
+        )
         gate = evaluate_gate(cfg, retrieval)
 
     if not gate.passed:

--- a/src/student_bot/bot/retrieval.py
+++ b/src/student_bot/bot/retrieval.py
@@ -57,6 +57,7 @@ def retrieve(
     cfg: Config,
     query: str,
     corpus_programme_substrings: frozenset[str] | None = None,
+    query_language: str | None = None,
 ) -> RetrievalResult:
     coll = get_chroma_collection(cfg)
     qvec = encode_query(cfg, query).tolist()
@@ -110,6 +111,16 @@ def retrieve(
     scores = get_reranker(cfg).predict(pairs).tolist()
     for c, s in zip(candidates, scores):
         c.rerank_score = float(s)
+
+    # Soft language preference. Adds `language_bonus` to chunks tagged with
+    # the same language as the query before the final sort, so parallel SV/EN
+    # sources that the reranker scores near each other resolve to the user's
+    # language. Chunks with no language tag (older ingest, web-fetched paths)
+    # are not penalised — they just don't get the bonus.
+    if query_language and cfg.reranker.language_bonus:
+        for c in candidates:
+            if c.language and c.language == query_language:
+                c.rerank_score += cfg.reranker.language_bonus
 
     candidates.sort(key=lambda c: c.rerank_score, reverse=True)
     reranked = candidates[: cfg.reranker.keep]

--- a/src/student_bot/config.py
+++ b/src/student_bot/config.py
@@ -56,6 +56,13 @@ class RerankerConfig(BaseModel):
     device: str = "cpu"
     candidates: int = 20
     keep: int = 5
+    # Soft preference for chunks whose language matches the query language.
+    # Added to the cross-encoder logit AFTER reranking, before sorting and
+    # before the gate. Small enough that a clearly better cross-language
+    # chunk still wins; large enough to break ties between near-equal
+    # parallel SV/EN sources. Set to 0 to disable. Tune via `eval/run_eval.py`
+    # if you change embedding/reranker or the corpus language mix.
+    language_bonus: float = 0.5
 
 
 class GateConfig(BaseModel):

--- a/tests/test_retrieval_language_bonus.py
+++ b/tests/test_retrieval_language_bonus.py
@@ -1,0 +1,138 @@
+"""Unit tests for the language-bonus reranker bias added for #3.
+
+The bonus is applied after the cross-encoder scores all candidates, so we can
+exercise it in isolation by stubbing the Chroma query and the cross-encoder.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+
+import student_bot.bot.retrieval as ret
+from student_bot.config import get_config
+
+
+class _FakeReranker:
+    """Returns a fixed score per text. Indexed by the text snippet."""
+
+    def __init__(self, score_by_text: dict[str, float]):
+        self._score_by_text = score_by_text
+
+    def predict(self, pairs):
+        # pairs is list[(query, text)] — we score by text. Returns ndarray
+        # to match the real CrossEncoder.predict() interface (callers do
+        # `.tolist()` on the result).
+        return np.array([self._score_by_text.get(text, 0.0) for _q, text in pairs])
+
+
+def _stub_chroma_query(rows: list[dict]):
+    """rows: each {id, text, rel_source, language, distance}. Returns the
+    payload Chroma's `collection.query(...)` produces."""
+    return {
+        "ids": [[r["id"] for r in rows]],
+        "documents": [[r["text"] for r in rows]],
+        "metadatas": [
+            [
+                {
+                    "rel_source": r["rel_source"],
+                    "doc_title": r.get("doc_title", r["rel_source"]),
+                    "doc_type": "md",
+                    "language": r["language"],
+                    "section_path": "",
+                    "chunk_index": 0,
+                    "page_start": 0,
+                    "source_url": "",
+                }
+                for r in rows
+            ]
+        ],
+        "distances": [[r.get("distance", 0.0) for r in rows]],
+    }
+
+
+def _patch(monkeypatch, rows: list[dict], score_by_text: dict[str, float]):
+    class _Coll:
+        def query(self, **_kwargs):
+            return _stub_chroma_query(rows)
+
+    monkeypatch.setattr(ret, "get_chroma_collection", lambda _cfg: _Coll())
+    monkeypatch.setattr(ret, "encode_query", lambda _cfg, _q: np.zeros(1))
+    monkeypatch.setattr(ret, "get_reranker", lambda _cfg: _FakeReranker(score_by_text))
+
+
+def test_language_bonus_breaks_ties_in_favour_of_query_language(monkeypatch):
+    """Two parallel SV/EN chunks that the cross-encoder scores identically:
+    the SV chunk wins for a Swedish query, the EN chunk wins for an English one."""
+    rows = [
+        {"id": "sv1", "text": "T1", "rel_source": "kursval-sv.md", "language": "sv"},
+        {"id": "en1", "text": "T2", "rel_source": "kursval-en.md", "language": "en"},
+    ]
+    cfg = get_config()
+    _patch(monkeypatch, rows, {"T1": 1.0, "T2": 1.0})
+    sv = ret.retrieve(cfg, "kursval", query_language="sv")
+    assert sv.reranked[0].chunk_id == "sv1"
+
+    _patch(monkeypatch, rows, {"T1": 1.0, "T2": 1.0})
+    en = ret.retrieve(cfg, "course selection", query_language="en")
+    assert en.reranked[0].chunk_id == "en1"
+
+
+def test_language_bonus_does_not_override_clearly_better_other_language(monkeypatch):
+    """If the cross-encoder scores the cross-language chunk much higher, the
+    bonus is too small to flip ranking. Tunable via `reranker.language_bonus`."""
+    rows = [
+        {"id": "sv1", "text": "T1", "rel_source": "weak-sv.md", "language": "sv"},
+        {"id": "en1", "text": "T2", "rel_source": "strong-en.md", "language": "en"},
+    ]
+    cfg = get_config()
+    # Default bonus is 0.5; the gap between -0.3 and +2.0 (== 2.3) is well
+    # beyond it, so the EN chunk still leads even on a Swedish query.
+    _patch(monkeypatch, rows, {"T1": -0.3, "T2": 2.0})
+    sv = ret.retrieve(cfg, "kursval", query_language="sv")
+    assert sv.reranked[0].chunk_id == "en1"
+
+
+def test_language_bonus_skipped_for_untagged_chunks(monkeypatch):
+    """Chunks with empty `language` metadata get no bonus and no penalty —
+    they sort by raw rerank score. (Old ingests / web-fetched chunks fall
+    into this category.)"""
+    rows = [
+        {"id": "u1", "text": "T1", "rel_source": "untagged.md", "language": ""},
+        {"id": "sv1", "text": "T2", "rel_source": "swedish.md", "language": "sv"},
+    ]
+    cfg = get_config()
+    # Untagged chunk scores 0.6, Swedish scores 0.2. With bonus 0.5, Swedish
+    # would climb to 0.7 and lead. (This documents the intended behaviour:
+    # untagged chunks lose ties but not large-margin races to tagged chunks.)
+    _patch(monkeypatch, rows, {"T1": 0.6, "T2": 0.2})
+    sv = ret.retrieve(cfg, "kursval", query_language="sv")
+    assert sv.reranked[0].chunk_id == "sv1"
+
+
+def test_language_bonus_disabled_when_no_query_language(monkeypatch):
+    """When the caller passes `query_language=None`, no bonus is applied
+    regardless of the chunks' language tags — falls back to raw rerank
+    sort, matching pre-#3 behaviour."""
+    rows = [
+        {"id": "sv1", "text": "T1", "rel_source": "sv.md", "language": "sv"},
+        {"id": "en1", "text": "T2", "rel_source": "en.md", "language": "en"},
+    ]
+    cfg = get_config()
+    _patch(monkeypatch, rows, {"T1": 0.3, "T2": 0.4})
+    out = ret.retrieve(cfg, "kursval", query_language=None)
+    # EN chunk wins on raw score; SV bonus is not applied.
+    assert out.reranked[0].chunk_id == "en1"
+
+
+def test_language_bonus_zero_config_disables_bias(monkeypatch):
+    """Operators who want the old behaviour can set `language_bonus: 0` and
+    queries pass through unchanged even with `query_language` set."""
+    rows = [
+        {"id": "sv1", "text": "T1", "rel_source": "sv.md", "language": "sv"},
+        {"id": "en1", "text": "T2", "rel_source": "en.md", "language": "en"},
+    ]
+    cfg = get_config()
+    cfg.reranker.language_bonus = 0.0
+    _patch(monkeypatch, rows, {"T1": 0.3, "T2": 0.4})
+    out = ret.retrieve(cfg, "kursval", query_language="sv")
+    assert out.reranked[0].chunk_id == "en1"


### PR DESCRIPTION
## Summary
Fixes #3 — when the corpus has parallel SV/EN copies of a document, citations now follow the user's language. A Swedish question gets Swedish sources; an English question gets English ones. Implemented as a soft post-rerank bias: each chunk's cross-encoder score gets `reranker.language_bonus` (default 0.5) added when the chunk's `language` metadata matches the detected query language. Chunks with no language tag (older ingest, web-fetched paths) are unaffected. The bonus is small enough that a clearly higher-scoring cross-language chunk still wins — so a Swedish query about a topic that's only documented in English still gets the English answer rather than a refusal.

The gate's top-1 score sees the bonused value, which slightly raises in-domain pass-rate. A/B eval at the current thresholds:
| metric | bonus=0 | bonus=0.5 |
|---|---|---|
| recall@5 (in-domain) | 22/36 | 22/36 |
| in-domain gate pass-rate | 28/36 | **29/36** |
| OOD gate refuse-rate | 14/15 | 14/15 |

The OOD refuse-rate is unchanged, so the bot's deliberate false-refuse bias survives.

The dynamic-web path is out of scope: it hard-codes `language="sv"` for now (study-plan scraping is Swedish-only).

## Test plan
- [x] `uv run pytest tests/` — 67 passed (5 new in `tests/test_retrieval_language_bonus.py`).
- [x] `uv run ruff check src/ tests/ eval/` — clean.
- [x] `uv run python -m eval.run_eval` — recall and refuse-rate hold; pass-rate +1.
- [ ] Manual: ask the same question in Swedish and English; verify the Sources block on each reply uses the matching-language page when both exist in the corpus.
- [ ] Manual: ask a Swedish question whose answer is only documented in English — verify the bot still answers (with English sources) rather than refusing.
