### PR TITLE
Masking secrets from logs, towards #18

### DIFF
--- a/src/student_bot/web/app.py
+++ b/src/student_bot/web/app.py
@@ -17,6 +17,7 @@ import asyncio
 import json
 import logging
 import os
+import re
 import secrets
 import subprocess
 import threading
@@ -54,6 +55,24 @@ from student_bot.web.md_render import render_file
 
 
 log = logging.getLogger("student_bot.web")
+
+
+def _mask_secret(value: str, *, keep: int = 6) -> str:
+    """Return a log-safe rendering of a token-like secret.
+
+    Shows the first `keep` characters followed by an ellipsis when the value
+    is long enough to be a real secret. Operators can recognise *which*
+    token is configured (matching `.env`) without leaking enough to hijack
+    a session. Empty / short values are surfaced as `<unset>` /
+    `<short>` so an accidental log line still shows that something's wrong
+    without revealing the actual value.
+    """
+    if not value:
+        return "<unset>"
+    if len(value) <= keep:
+        return "<short>"
+    return f"{value[:keep]}…"
+
 
 WEB_PKG_DIR = Path(__file__).resolve().parent
 STATIC_DIR = WEB_PKG_DIR / "static"
@@ -1165,6 +1184,26 @@ def main(host: str | None, port: int | None, reload: bool):
 
         logging.getLogger("uvicorn.access").addFilter(_SuppressSystemLoadAccessLog())
 
+    # When a user follows the capability URL `?access=<WEB_ACCESS_TOKEN>`,
+    # uvicorn writes the full request line — including the token — to its
+    # access log. Mask the token so logs and log shipments can't be used to
+    # hijack a session. Applied unconditionally; there's no operator benefit
+    # to seeing the full token in the access log.
+    class _RedactAccessTokenAccessLog(logging.Filter):
+        _ACCESS_QS_RE = re.compile(r"(access=)[^&\s\"'\\]+")
+
+        def filter(self, record: logging.LogRecord) -> bool:
+            msg = record.getMessage()
+            redacted = self._ACCESS_QS_RE.sub(r"\1<redacted>", msg)
+            if redacted != msg:
+                # Replace msg+args so any later formatting doesn't reapply
+                # the original arguments (which would re-leak the token).
+                record.msg = redacted
+                record.args = ()
+            return True
+
+    logging.getLogger("uvicorn.access").addFilter(_RedactAccessTokenAccessLog())
+
     cfg = get_config()
     bind_host = host or cfg.web.bind_host
     bind_port = port or cfg.web.port
@@ -1183,7 +1222,12 @@ def main(host: str | None, port: int | None, reload: bool):
             )
             raise SystemExit(2)
         token = os.environ.get("WEB_ACCESS_TOKEN", "")
-        log.info("auth enabled. login URL: http://%s:%s/?access=%s", bind_host, bind_port, token)
+        log.info(
+            "auth enabled. login URL: http://%s:%s/?access=%s",
+            bind_host,
+            bind_port,
+            _mask_secret(token),
+        )
     else:
         log.info("auth disabled. binding to http://%s:%s", bind_host, bind_port)
         if bind_host != "127.0.0.1":

--- a/tests/test_log_redaction.py
+++ b/tests/test_log_redaction.py
@@ -1,0 +1,125 @@
+"""Tests for log-time secret redaction (#18).
+
+`_mask_secret` is a small pure helper, exercised directly. The uvicorn
+access-log filter is built locally inside `web.app.main` so we can't import
+it; we replicate the regex contract here and assert it matches the
+production behaviour.
+"""
+
+from __future__ import annotations
+
+import logging
+import re
+
+import pytest
+
+from student_bot.web.app import _mask_secret
+
+
+# Mirror of the regex inside `_RedactAccessTokenAccessLog.filter`. If the
+# production regex changes, this assertion list must move with it — the
+# duplication is intentional so the test fails when the contract drifts.
+_ACCESS_QS_RE = re.compile(r"(access=)[^&\s\"'\\]+")
+
+
+def _redact(msg: str) -> str:
+    return _ACCESS_QS_RE.sub(r"\1<redacted>", msg)
+
+
+class TestMaskSecret:
+    def test_long_secret_keeps_only_prefix(self):
+        # Default keep=6; long secret → first 6 + ellipsis.
+        assert _mask_secret("abcdef1234567890XYZ") == "abcdef…"
+
+    def test_short_secret_does_not_partial_leak(self):
+        # Anything ≤ keep is replaced wholesale — partial value would leak
+        # too much when the secret itself is short.
+        assert _mask_secret("abc123") == "<short>"
+        assert _mask_secret("abc") == "<short>"
+
+    def test_empty_secret_surfaces_unset(self):
+        assert _mask_secret("") == "<unset>"
+        assert _mask_secret(None) == "<unset>"  # type: ignore[arg-type]
+
+    def test_custom_keep_length(self):
+        assert _mask_secret("abcdef1234567890", keep=3) == "abc…"
+
+
+class TestAccessTokenAccessLogRedaction:
+    """Verify the regex used by `_RedactAccessTokenAccessLog`."""
+
+    def test_redacts_token_in_request_line(self):
+        original = '127.0.0.1:54321 - "GET /?access=secrettoken123 HTTP/1.1" 200 OK'
+        assert _redact(original) == ('127.0.0.1:54321 - "GET /?access=<redacted> HTTP/1.1" 200 OK')
+
+    def test_redacts_token_when_followed_by_other_params(self):
+        original = "GET /?access=secrettoken123&debug=1 HTTP/1.1"
+        # Token stops at `&`; the rest of the query string is preserved.
+        assert _redact(original) == "GET /?access=<redacted>&debug=1 HTTP/1.1"
+
+    def test_redacts_url_with_path_and_token(self):
+        original = 'GET /subpath/?access=ABCdef123_XYZ HTTP/1.1" 200 OK'
+        assert "ABCdef123_XYZ" not in _redact(original)
+        assert "<redacted>" in _redact(original)
+
+    def test_does_not_touch_unrelated_lines(self):
+        original = 'GET /api/health HTTP/1.1" 200 OK'
+        assert _redact(original) == original
+
+    def test_does_not_touch_word_succeeded_by_access_substring(self):
+        # The regex requires `access=` literally, so words containing "access"
+        # without the `=` are not redacted.
+        original = 'GET /access HTTP/1.1" 200 OK'
+        assert _redact(original) == original
+
+
+class TestFilterMutatesRecordArgs:
+    """End-to-end shape: the filter resets `record.args` after redacting so
+    the handler can't reapply the original arguments and re-leak the token.
+    Re-implements the filter inline to avoid relying on `main()` being
+    callable at test time."""
+
+    @pytest.fixture
+    def filter_obj(self):
+        class _F(logging.Filter):
+            _RE = _ACCESS_QS_RE
+
+            def filter(self, record):
+                msg = record.getMessage()
+                redacted = self._RE.sub(r"\1<redacted>", msg)
+                if redacted != msg:
+                    record.msg = redacted
+                    record.args = ()
+                return True
+
+        return _F()
+
+    def test_record_msg_no_longer_contains_token(self, filter_obj):
+        record = logging.LogRecord(
+            name="uvicorn.access",
+            level=logging.INFO,
+            pathname=__file__,
+            lineno=1,
+            msg='%s - "%s" %s OK',
+            args=("127.0.0.1", "GET /?access=secretXYZ HTTP/1.1", 200),
+            exc_info=None,
+        )
+        filter_obj.filter(record)
+        assert "secretXYZ" not in record.getMessage()
+        assert "<redacted>" in record.getMessage()
+        # Args were cleared so any re-formatting can't reintroduce the token.
+        assert record.args == ()
+
+    def test_record_untouched_when_no_token(self, filter_obj):
+        record = logging.LogRecord(
+            name="uvicorn.access",
+            level=logging.INFO,
+            pathname=__file__,
+            lineno=1,
+            msg='%s - "%s" %s OK',
+            args=("127.0.0.1", "GET /api/health HTTP/1.1", 200),
+            exc_info=None,
+        )
+        filter_obj.filter(record)
+        # No mutation — args preserved, message format intact.
+        assert record.args == ("127.0.0.1", "GET /api/health HTTP/1.1", 200)


### PR DESCRIPTION
## Summary
Fixes #18 — log lines were leaking the full `WEB_ACCESS_TOKEN` in two places:
1. The startup banner in `web.app.main()` printed the entire token at every process start.
2. Uvicorn's access log captured `"GET /?access=<TOKEN> HTTP/1.1"` on every first-visit click.

Now masked / redacted, respectively:
- A new `_mask_secret(value, *, keep=6)` helper renders long secrets as `prefix…`, with `<short>` and `<unset>` sentinels so an operator can still tell which token is configured (matching their `.env`) without enough material to hijack a session.
- A new `_RedactAccessTokenAccessLog` `logging.Filter` is installed on the `uvicorn.access` logger. It rewrites `access=<token>` to `access=<redacted>` in the formatted message and clears `record.args` so any downstream re-format can't reintroduce the original argument tuple.

No other env vars (`MATTERMOST_TOKEN`, `USER_ID_HASH_SALT`, `WEB_SESSION_SECRET`, `HF_TOKEN`) are logged anywhere I found, so nothing else needs masking right now.

## Test plan
- [x] `uv run pytest tests/` — 78 passed (11 new in `tests/test_log_redaction.py`).
- [x] `uv run ruff check src/ tests/` — clean.
- [x] Manual smoke: synthetic uvicorn access-log records confirm the filter redacts the token, preserves the rest of the query string, and clears args.
- [ ] Manual on a real server start: confirm the banner now reads `?access=<prefix>…` and that visiting the capability URL emits `?access=<redacted>` in the access log.
