### PR TITLE
Improving context bloat from web fetch issues described in #53

### DIFF
--- a/scripts/debug_diff_omfattning_genomforande.py
+++ b/scripts/debug_diff_omfattning_genomforande.py
@@ -1,0 +1,69 @@
+"""Compare chunks emitted from /omfattning vs /genomforande for CTFYS HT2023.
+Hypothesis: the SPA serves the same __compressedApplicationStore__ JSON to both
+routes, and the chunker walks that JSON rather than the rendered DOM — so it
+emits the same chunks regardless of which sidebar sub-page was fetched.
+"""
+
+from __future__ import annotations
+import hashlib
+
+from student_bot.bot.web_retrieval import (
+    _fetch_html,
+    _studyplan_chunks_from_html,
+    _compressed_application_store,
+)
+from student_bot.config import get_config
+
+cfg = get_config()
+URLS = [
+    "https://www.kth.se/student/kurser/program/CTFYS/20232/omfattning",
+    "https://www.kth.se/student/kurser/program/CTFYS/20232/genomforande",
+]
+
+
+def store_hash(html: str) -> str:
+    store = _compressed_application_store(html)
+    if store is None:
+        return "no-store"
+    # Stable hash over the studyProgramme subtree only (the field the chunker reads).
+    import json
+    sp = store.get("studyProgramme", {})
+    return hashlib.sha1(
+        json.dumps(sp, sort_keys=True, ensure_ascii=False).encode("utf-8")
+    ).hexdigest()[:12]
+
+
+data = {}
+for url in URLS:
+    final_url, html = _fetch_html(url, cfg)
+    chunks = _studyplan_chunks_from_html(html, final_url=final_url, fetched_at=0, lang="sv")
+    data[url] = {
+        "store_hash": store_hash(html),
+        "html_size": len(html),
+        "chunks": chunks,
+    }
+
+print(f"\n{'URL':80} store_hash  html_kb  n_chunks")
+for url, d in data.items():
+    short = url.replace("https://www.kth.se", "")
+    print(f"{short:80} {d['store_hash']}  {len(d['chunks']):3d}        {d['html_size']//1024} kB")
+
+print("\nSection paths emitted (sorted, deduped):")
+sections = {url: sorted({c.section_path for c in d["chunks"]}) for url, d in data.items()}
+all_sections = sorted(set().union(*sections.values()))
+header = ["section_path", *[u.split("/")[-1] for u in URLS]]
+print(f"\n{header[0]:80} {header[1]:>12} {header[2]:>12}")
+for s in all_sections:
+    flags = [("✓" if s in sections[u] else "·") for u in URLS]
+    print(f"{s:80} {flags[0]:>12} {flags[1]:>12}")
+
+# Are the chunk *texts* identical, in order?
+o = data[URLS[0]]["chunks"]
+g = data[URLS[1]]["chunks"]
+matched_pairs = 0
+for c1 in o:
+    for c2 in g:
+        if c1.section_path == c2.section_path and c1.text == c2.text:
+            matched_pairs += 1
+            break
+print(f"\nByte-identical (section_path, text) pairs: {matched_pairs} of {len(o)} from /omfattning matched in /genomforande")

--- a/scripts/debug_inspect_studyplan_chunks.py
+++ b/scripts/debug_inspect_studyplan_chunks.py
@@ -1,0 +1,88 @@
+"""Ad-hoc: dump the structured chunks the dynamic-web path would emit for
+CTFYS HT2023, so we can eyeball size, content, and where the budget goes.
+
+Run: `uv run python scripts/inspect_studyplan_chunks.py`
+"""
+
+from __future__ import annotations
+
+from student_bot.bot.web_retrieval import (
+    _fetch_html,
+    _programme_term_bundle_urls,
+    _studyplan_chunks_from_html,
+    _truncate_web_chunk_text,
+    _programme_page_text_with_store,
+    _sanitize_to_text,
+)
+from student_bot.config import get_config
+
+cfg = get_config()
+
+PROGRAM_TERM_URL = "https://www.kth.se/student/kurser/program/CTFYS/20232"
+
+urls = _programme_term_bundle_urls(PROGRAM_TERM_URL)
+print(f"Bundle for CTFYS HT2023 has {len(urls)} URLs:")
+for u in urls:
+    print(f"  {u}")
+print()
+
+# Approximate 4 chars per token (matches pipeline._estimate_tokens).
+def est_tokens(s: str) -> int:
+    return max(0, len(s or "") // 4)
+
+
+totals_structured = 0
+totals_legacy = 0
+per_page_summary = []
+
+for url in urls:
+    try:
+        final_url, html = _fetch_html(url, cfg)
+    except Exception as e:
+        print(f"FETCH FAILED {url}: {e}")
+        continue
+
+    title, visible = _sanitize_to_text(html)
+    if "/student/kurser/program/" in final_url:
+        legacy_content = _programme_page_text_with_store(html, visible, final_url)
+    else:
+        legacy_content = visible
+    legacy_content = _truncate_web_chunk_text(legacy_content)
+    legacy_chars = len(legacy_content)
+    legacy_tokens = est_tokens(legacy_content)
+
+    structured = _studyplan_chunks_from_html(
+        html, final_url=final_url, fetched_at=0, lang="sv"
+    )
+
+    page_struct_chars = sum(len(c.text) for c in structured)
+    page_struct_tokens = est_tokens("".join(c.text for c in structured))
+    totals_structured += page_struct_tokens
+    totals_legacy += legacy_tokens
+    per_page_summary.append(
+        (final_url, len(structured), page_struct_chars, page_struct_tokens, legacy_chars, legacy_tokens)
+    )
+
+    print(f"\n=== {final_url} ===")
+    print(f"  title: {title!r}")
+    print(f"  structured chunks: {len(structured)}  total {page_struct_chars} chars (~{page_struct_tokens} tok)")
+    print(f"  legacy single-blob: {legacy_chars} chars (~{legacy_tokens} tok)")
+    for i, c in enumerate(structured, 1):
+        section = (c.section_path or "").strip() or "-"
+        preview = c.text.replace("\n", " / ").strip()
+        if len(preview) > 220:
+            preview = preview[:220] + "…"
+        print(
+            f"   [{i:2}] {len(c.text):5d} ch  rerank={c.rerank_score:.2f}  "
+            f"section={section!r}"
+        )
+        print(f"        {preview}")
+
+print("\n=================================================")
+print("Per-page summary  (chunks, struct_chars, struct_tok, legacy_chars, legacy_tok)")
+for u, n, sc, st, lc, lt in per_page_summary:
+    short = u.replace("https://www.kth.se/student/kurser/program/", "")
+    print(f"  {short:40} n={n:3d}  struct={sc:6d}ch/{st:5d}tok  legacy={lc:6d}ch/{lt:5d}tok")
+print(f"\nTOTAL structured tokens across bundle: ~{totals_structured}")
+print(f"TOTAL legacy single-blob tokens:       ~{totals_legacy}")
+print(f"LLM num_ctx budget:                    {cfg.llm.num_ctx}")

--- a/scripts/debug_measure_token_savings.py
+++ b/scripts/debug_measure_token_savings.py
@@ -1,0 +1,58 @@
+"""End-to-end token-usage measurement for representative CTFYS HT2023 queries
+before vs after the rerank/dedup changes. Calls maybe_fetch_dynamic_web and
+the pipeline's web-chunk reranker, measuring chunks-in vs chunks-out and the
+prompt-token estimate going to the LLM.
+"""
+
+from __future__ import annotations
+
+from student_bot.bot.pipeline import _rerank_web_chunks, _estimate_tokens
+from student_bot.bot.prompts import compose_messages
+from student_bot.bot.web_retrieval import maybe_fetch_dynamic_web
+from student_bot.config import get_config
+
+cfg = get_config()
+
+QUERIES = [
+    "Vilka valfria kurser är listade för årskurs 3 för CTFYS HT2023?",
+    "Vilka masterprogram kan jag välja mellan på CTFYS HT2023?",
+    "Vad är betygsskalan på CTFYS-programmet HT2023?",
+    "Hur stor är CTFYS HT2023 och vilken examen ger det?",
+]
+
+
+def measure(query: str) -> None:
+    print(f"\n=== {query!r} ===")
+    web = maybe_fetch_dynamic_web(cfg, query, "sv")
+    if not web or not web.chunks:
+        print("  (no web result)")
+        return
+
+    raw_chunks = list(web.chunks)
+    raw_chars = sum(len(c.text) for c in raw_chunks)
+    raw_tokens = _estimate_tokens("".join(c.text for c in raw_chunks))
+
+    # Mirror pipeline.answer() behaviour (rerank + cap to top-K).
+    reranked = _rerank_web_chunks(cfg, query, "sv", list(raw_chunks))
+    rr_chars = sum(len(c.text) for c in reranked)
+    rr_tokens = _estimate_tokens("".join(c.text for c in reranked))
+
+    # Build the user message both ways to see real prompt-token deltas.
+    msgs_before = compose_messages(cfg, "sv", [], raw_chunks, query)
+    msgs_after = compose_messages(cfg, "sv", [], reranked, query)
+    pt_before = sum(_estimate_tokens(m.get("content", "")) for m in msgs_before)
+    pt_after = sum(_estimate_tokens(m.get("content", "")) for m in msgs_after)
+
+    print(f"  chunks: {len(raw_chunks)} -> {len(reranked)}  "
+          f"(chars {raw_chars} -> {rr_chars}; chunk tokens {raw_tokens} -> {rr_tokens})")
+    print(f"  full prompt tokens: {pt_before} -> {pt_after}  "
+          f"(save {pt_before - pt_after}, ctx limit {cfg.llm.num_ctx})")
+    print(f"  top-{cfg.reranker.keep} sections (rerank logit, chars):")
+    for c in reranked:
+        sec = (c.section_path or "-").strip()
+        sec = sec[:78] + "…" if len(sec) > 78 else sec
+        print(f"    {c.rerank_score:7.3f}  {len(c.text):5d} ch  {sec}")
+
+
+for q in QUERIES:
+    measure(q)

--- a/src/student_bot/bot/pipeline.py
+++ b/src/student_bot/bot/pipeline.py
@@ -38,7 +38,7 @@ from student_bot.bot.prompts import (
     llm_unavailable_message,
     refusal_message,
 )
-from student_bot.bot.retrieval import RetrievalResult, RetrievedChunk, retrieve
+from student_bot.bot.retrieval import RetrievalResult, RetrievedChunk, get_reranker, retrieve
 from student_bot.bot.web_retrieval import (
     corpus_programme_substrings_for_query,
     history_without_programme_clarification_tail,
@@ -172,6 +172,44 @@ def _estimate_context_tokens(messages: list[dict]) -> int:
         total += _estimate_tokens(m.get("content", ""))
         total += 3  # rough message framing overhead
     return total
+
+
+def _rerank_web_chunks(
+    cfg: Config, query: str, query_language: str, chunks: list[RetrievedChunk]
+) -> list[RetrievedChunk]:
+    """Score web-fetched chunks with the cross-encoder and return top-K.
+
+    Web fetches (esp. studyplan bundles) can produce 30+ chunks per page with
+    a flat synthetic rerank_score; without this step every chunk would be
+    stuffed into the prompt, regularly overrunning ``num_ctx``. Reranker
+    failure is non-fatal: we fall back to the original order and the
+    top-``cfg.reranker.keep`` slice.
+    """
+    if not chunks:
+        return []
+    keep = max(1, cfg.reranker.keep)
+    try:
+        pairs = [(query, c.text) for c in chunks]
+        scores = get_reranker(cfg).predict(pairs).tolist()
+        for c, s in zip(chunks, scores):
+            c.rerank_score = float(s)
+        if query_language and cfg.reranker.language_bonus:
+            for c in chunks:
+                if c.language and c.language == query_language:
+                    c.rerank_score += cfg.reranker.language_bonus
+        chunks.sort(key=lambda c: c.rerank_score, reverse=True)
+    except Exception as e:
+        log.warning("dynamic-web rerank failed, keeping original order: %s", e)
+    reranked = chunks[:keep]
+    if len(chunks) > keep:
+        top1 = reranked[0].rerank_score if reranked else 0.0
+        log.info(
+            "dynamic-web: reranked %d -> %d chunks (top1=%.3f)",
+            len(chunks),
+            len(reranked),
+            top1,
+        )
+    return reranked
 
 
 # --- Per-key rate limiter (simple sliding window over the last 60 s) ---
@@ -403,15 +441,20 @@ def answer(
             jargon_hits=jargon_hits,
         )
     if web_result and web_result.chunks:
+        web_candidates = list(web_result.chunks)
+        reranked_web = _rerank_web_chunks(cfg, expanded_q, lang, web_candidates)
         retrieval = RetrievalResult(
-            query=expanded_q, candidates=web_result.chunks, reranked=web_result.chunks
+            query=expanded_q, candidates=web_candidates, reranked=reranked_web
         )
+        # Preserve the synthetic web gate (web-fetched content always passes);
+        # the 3.5/2.5 values feed the confidence badge and are intentionally
+        # independent of the per-chunk rerank logits.
         gate = GateDecision(
             True,
             "web_cache" if web_result.used_stale_cache else "web_live",
             3.5 if not web_result.used_stale_cache else 2.5,
             3.5 if not web_result.used_stale_cache else 2.5,
-            len({c.rel_source for c in web_result.chunks}),
+            len({c.rel_source for c in reranked_web}),
         )
         source_urls = list(web_result.source_urls)
         if web_result.used_stale_cache:

--- a/src/student_bot/bot/web_retrieval.py
+++ b/src/student_bot/bot/web_retrieval.py
@@ -64,6 +64,15 @@ _PROGRAM_SIDEBAR_SLUGS = (
     "inriktningar",
 )
 
+# Sidebar slugs that contribute *zero unique chunks* once `/omfattning` is in
+# the queue. KTH study-plan pages are a SPA: every sidebar URL ships the same
+# `__compressedApplicationStore__.studyProgramme` JSON. `/genomforande` is
+# byte-identical to `/omfattning`. `/mal`, `/behorighet`, `/kurslista` are not
+# routed through the structured chunker, so they only contribute the empty
+# legacy-blob fallback (~640 chars of page chrome). Excluded from the default
+# bundle *and* from link-discovery to keep prompt tokens bounded.
+_PROGRAM_SIDEBAR_SLUGS_REDUNDANT = frozenset({"mal", "behorighet", "genomforande", "kurslista"})
+
 # Human-readable sidebar labels for programme study-plan URLs (path segment after
 # /program/<CODE>/<TERM>/...).
 _PROGRAM_URL_SECTION_LABELS_SV: dict[str, str] = {
@@ -2319,9 +2328,12 @@ def _programme_term_bundle_urls(url: str) -> list[str]:
     ``max_pages_per_query``. ``/omfattning`` carries the full
     ``studyProgramme.*`` payload that the per-section chunker expands into
     ~25 small chunks, so it comes right after the base term page. Year
-    pages follow with their concrete Valvillkor data. ``/genomforande``
-    embeds the same ``studyProgramme`` object as ``/omfattning`` and is
-    placed late as a defensive fallback only.
+    pages follow with their concrete Valvillkor data. ``/inriktningar``
+    uses a separate chunker path for specialisations.
+
+    Redundant slugs (``/genomforande``, ``/mal``, ``/behorighet``,
+    ``/kurslista``) are intentionally omitted — see
+    ``_PROGRAM_SIDEBAR_SLUGS_REDUNDANT``.
     """
     path = urlsplit(_canonicalize(url)).path
     m = _PROGRAM_TERM_RE.fullmatch(path)
@@ -2329,13 +2341,32 @@ def _programme_term_bundle_urls(url: str) -> list[str]:
         return [_canonicalize(url)]
     code, term, _year = m.group(1).upper(), m.group(2), m.group(3)
     base = _canonicalize(f"https://{_KTH_HOST}/student/kurser/program/{code}/{term}")
+    kept_sidebar = tuple(
+        slug for slug in _PROGRAM_SIDEBAR_SLUGS if slug not in _PROGRAM_SIDEBAR_SLUGS_REDUNDANT
+    )
     primary_sidebar = ("omfattning",)
-    other_sidebar = tuple(slug for slug in _PROGRAM_SIDEBAR_SLUGS if slug not in primary_sidebar)
+    other_sidebar = tuple(slug for slug in kept_sidebar if slug not in primary_sidebar)
     out: list[str] = [base]
     out.extend([f"{base}/{slug}" for slug in primary_sidebar])
     out.extend([f"{base}/arskurs{n}" for n in range(1, 6)])
     out.extend([f"{base}/{slug}" for slug in other_sidebar])
     return _dedupe_urls(out)
+
+
+def _is_redundant_sidebar_url(url: str) -> bool:
+    """True if `url` is a /program/<CODE>/<TERM>/<slug> page whose chunks
+    duplicate (or are subsumed by) /omfattning. Used to keep link discovery
+    from re-injecting the slugs we pruned from the default bundle."""
+    path = urlsplit(_canonicalize(url)).path
+    parts = [p for p in path.split("/") if p]
+    if len(parts) < 5:
+        return False
+    # parts: ["student", "kurser", "program", CODE, TERM, slug?]
+    if parts[:3] != ["student", "kurser", "program"]:
+        return False
+    if len(parts) < 6:
+        return False
+    return parts[5] in _PROGRAM_SIDEBAR_SLUGS_REDUNDANT
 
 
 def corpus_programme_substrings_for_query(q: str) -> frozenset[str] | None:
@@ -2590,6 +2621,8 @@ def maybe_fetch_dynamic_web(
                 for u in _program_links(html, final_url):
                     if len(queue) + len(visited) >= max_pages:
                         break
+                    if _is_redundant_sidebar_url(u):
+                        continue
                     if u not in visited and _is_allowed_url(u, cfg, patterns):
                         log.info("dynamic-web: discovered linked program page %s", u)
                         queue.append(u)


### PR DESCRIPTION
## Summary
Fixes #53. The Sunday May 10 deploy introduced a structured study-plan chunker that, combined with an unbounded web-chunk path, made prompt tokens grow by ~500-1000× on study-plan turns and routinely overrun `num_ctx=16384`. This PR trims the redundant pages from the study-plan bundle and runs web-fetched chunks through the cross-encoder reranker before they hit the prompt.

## Diagnosis
KTH study-plan pages are a single-page-app: every sidebar URL ships the same `__compressedApplicationStore__.studyProgramme` JSON in its HTML. The structured chunker added in `8d7b61c` walks that JSON regardless of route, so `/omfattning` and `/genomforande` emit **byte-identical** chunks (verified — same store hash, 27/27 matching). `/mal`, `/behorighet`, `/kurslista` aren't routed through the structured chunker at all and only contribute ~640 chars of legacy page chrome. On top of that, all web chunks were dumped straight into `retrieval.reranked` with a flat synthetic `rerank_score=3.5`, bypassing the top-K=5 cap that the normal RAG path honours.

The fingerprint in `qa_log`:
| Date            | Turns | Avg prompt tokens | > 16k ctx |
| --------------- | ----- | ----------------- | --------- |
| 2026-05-02…09   | 49–57 | 9–22              | 0         |
| 2026-05-10      | 32    | **8,889**         | 4         |
| 2026-05-11      | 68    | **11,256**        | 12        |
On May 11, `web_live` turns averaged **16,437** prompt tokens — over the context limit. The peak `HT2024`-style follow-up turn hit **25,260** tokens.

## How this likely degraded answer quality
Once the prompt exceeded `num_ctx=16384`, Ollama silently truncated. The prompt layout in `compose_messages` puts the user message (context block + `---` + actual question) last, so the truncation either dropped the system prompt's grounding rules or chopped off the tail of the context block. Either failure mode produces the exact symptoms reported on the issue: confidently wrong answers, lost inline-citation tags, and weird "off-prompt" responses on study-plan follow-ups.

## Changes
**`src/student_bot/bot/web_retrieval.py`**
- New `_PROGRAM_SIDEBAR_SLUGS_REDUNDANT = {"mal", "behorighet", "genomforande", "kurslista"}`.
- `_programme_term_bundle_urls` now emits 8 URLs (base + `/omfattning` + `/arskurs1..5` + `/inriktningar`) instead of 12. `/genomforande` is dropped because it's a byte-identical duplicate of `/omfattning`; the other three contribute no structured chunks.
- New `_is_redundant_sidebar_url` filters link discovery so the dropped slugs can't sneak back in via HTML link crawling.
**`src/student_bot/bot/pipeline.py`**
- New `_rerank_web_chunks` runs the cross-encoder against `expanded_q`, applies `cfg.reranker.language_bonus`, sorts, and caps to `cfg.reranker.keep`. Reranker failure is non-fatal (falls back to original order + top-K slice).
- Wired into the `web_result.chunks` branch. The synthetic `web_live` / `web_cache` gate is preserved so study-plan questions still pass — only the chunks fed to the LLM are narrowed.

## Quantitative impact
End-to-end measurement on representative CTFYS HT2023 queries (script: `scripts/measure_token_savings.py`):

| Query                                                  | chunks (raw → kept) | prompt tokens (before → after) |   saved |
| ------------------------------------------------------ | ------------------- | ------------------------------ | ------: |
| Vilka valfria kurser är listade för årskurs 3?         | 41 → 5              | 11,590 → **2,180**             | **-81%** |
| Vilka masterprogram kan jag välja mellan?              | 41 → 5              | 11,589 → **2,896**             | **-75%** |
| Vad är betygsskalan på CTFYS-programmet HT2023?        | 41 → 5              | 11,586 → **2,715**             | **-77%** |
| Hur stor är CTFYS HT2023 och vilken examen ger det?    | 41 → 5              | 11,588 → **2,767**             | **-76%** |

All four are now comfortably inside `num_ctx=16384`, with ~13 k tokens of headroom for system prompt + history + glossary.

## Test plan
- [x] `uv run pytest tests/ eval/test_program_resolution.py` — 98/98 pass.
- [x] `uv run python -m eval.run_eval` — recall@5 61%, in-domain gate 81%, OOD refuse 93% (unchanged; eval doesn't exercise the dynamic-web path).
- [x] Manual: `scripts/inspect_studyplan_chunks.py`, `scripts/diff_omfattning_genomforande.py`, `scripts/measure_token_savings.py`.
- [ ] Watch the prompt-token graph for 24 h after deploy; expect `web_live` turns to drop from ~16 k → ~3 k average.

## Follow-ups (not in this PR)
- The "behörighetsgivande kurser per masterprogram" text repeats verbatim across `/arskurs1..5`, so several top-K slots can land on duplicate chunks. Dedup-by-text in the chunker would help.
- `cfg.reranker.keep=5` is tight for studyplan bundles — bumping to 8 would still leave plenty of context headroom and reduce the risk of the reranker dropping a relevant chunk on narrow factual questions (e.g. "betygsskalan").
- The dynamic-web trigger (`_extract_targets_with_cfg`) still fires on bare "program" / "curriculum" mentions; question-aware URL narrowing within the bundle is the next big win.