### PR TITLE
Adding support for models via LiteLLM

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -37,6 +37,7 @@ WEB_ACCESS_TOKEN=
 #   LLM_ACTIVE=ollama/gemma-4-E4B-it-GGUF:UD-Q4_K_XL
 #   LLM_ACTIVE=berget/meta-llama/Llama-3.3-70B-Instruct
 #   LLM_ACTIVE=berget/deepseek-ai/DeepSeek-R1
+#   LLM_ACTIVE=litellm/qwen3.6
 # LLM_ACTIVE=
 #
 # Per-provider API keys. The env var name for each provider is declared in
@@ -45,6 +46,9 @@ WEB_ACCESS_TOKEN=
 # stay redacted in any accidental config dump.
 # BERGET_API_KEY=
 # OPENROUTER_API_KEY=
+# LiteLLM gateway virtual key (provider `litellm`). Retrieve/rotate from the
+# LiteLLM UI → Virtual Keys → student-chatbot. Sent as `Authorization: Bearer`.
+# LITELLM_API_KEY=
 #
 # When the active model has provider_kind=openai_compatible, the bot
 # surfaces a "don't post sensitive personal information" notice in

--- a/.env.example
+++ b/.env.example
@@ -38,6 +38,7 @@ WEB_ACCESS_TOKEN=
 #   LLM_ACTIVE=berget/meta-llama/Llama-3.3-70B-Instruct
 #   LLM_ACTIVE=berget/deepseek-ai/DeepSeek-R1
 #   LLM_ACTIVE=litellm/qwen3.6
+#   LLM_ACTIVE=litellm/gemma4-31b   (current default in config.yaml)
 # LLM_ACTIVE=
 #
 # Per-provider API keys. The env var name for each provider is declared in

--- a/README.md
+++ b/README.md
@@ -190,6 +190,10 @@ Docker Desktop runs Linux in a **VM**: total Docker RAM in Activity Monitor is o
 - The Dockerfile installs **`torch`** from **CPU-only** wheels for Linux (see **`pyproject.toml`** **`[tool.uv.sources]`** / PyTorch CPU index) so the image does not pull NVIDIA CUDA packages.
 - **`topics.yaml`** and **`data/dictionary.json`** are **`COPY`**’d into the image as a fallback for non-compose runs. Compose host-mounts **`config.yaml`**, **`./data`** (which contains the dictionary, proposals, logs, Chroma + index, and web users), and the corpus on top, so jargon proposals submitted via the running bot/web and the host’s **`student-bot-jargon`** CLI share the same files.
 
+### Public hosting (reverse proxy, TLS, Tailscale)
+
+The container binds **`127.0.0.1:8000`** only; a **reverse proxy (nginx)** terminates TLS and serves the public **`/betabot/`** URL. Host-level setup — the nginx config, why nginx must run **as root** to bind 443, the recurring **Tailscale ↔ port-443 clash** (and its one-line fix), the **LiteLLM gateway** provider, and a **new-host checklist** — lives in **[`docs/DEPLOY.md`](docs/DEPLOY.md)**.
+
 ---
 
 ## Design considerations & decisions

--- a/config.yaml
+++ b/config.yaml
@@ -52,7 +52,7 @@ llm:
   # FIRST slash — Ollama tags use `:` and Berget/HF model IDs use additional
   # `/`, so first-slash splitting handles both. Switch models by changing
   # this one field, or override via `LLM_ACTIVE` in `.env`.
-  active: ollama/gemma-4-E4B-it-GGUF:UD-Q4_K_XL
+  active: litellm/gemma4-31b
 
   # Backends. Each entry declares how to reach a hosting service. Multiple
   # models can share one provider — Berget hosts dozens of models behind
@@ -149,6 +149,35 @@ llm:
     "litellm/qwen3.6-think":
       num_ctx: 40960
       temperature: 0.3
+      max_tokens: 2048
+      thinking: true
+      thinking_style: openai_reasoning_field
+    # Gemma 4 on the Spark via LiteLLM. The non-think aliases have no reasoning
+    # channel (thinking_style: none). The `-think` aliases stream chain-of-thought
+    # as `delta.reasoning_content` (verified — LiteLLM normalizes it the same way
+    # as Qwen, NOT as inline `<|channel>` blocks), so `openai_reasoning_field`
+    # filters it out correctly.
+    "litellm/gemma4-31b":
+      num_ctx: 65536
+      temperature: 0.2
+      max_tokens: 2048
+      thinking: false
+      thinking_style: none
+    "litellm/gemma4-31b-think":
+      num_ctx: 65536
+      temperature: 0.2
+      max_tokens: 2048
+      thinking: true
+      thinking_style: openai_reasoning_field
+    "litellm/gemma4-26b":
+      num_ctx: 65536
+      temperature: 0.2
+      max_tokens: 2048
+      thinking: false
+      thinking_style: none
+    "litellm/gemma4-26b-think":
+      num_ctx: 65536
+      temperature: 0.2
       max_tokens: 2048
       thinking: true
       thinking_style: openai_reasoning_field

--- a/config.yaml
+++ b/config.yaml
@@ -75,6 +75,24 @@ llm:
       display_name: OpenRouter
       api_key_env: OPENROUTER_API_KEY
       timeout_seconds: 120
+    # LiteLLM gateway on the tailnet (docker-services VM). The models behind
+    # it run LOCALLY on the Spark, so this is NOT third-party cloud — but the
+    # transport is OpenAI-compatible, so `provider_kind != ollama` and the
+    # "external cloud model" privacy notice currently fires anyway (see the
+    # `discloses_external` discussion / TODO). Use the 100.x IP rather than the
+    # MagicDNS name so resolution works from inside the Docker container on a
+    # native Linux host without pointing it at Tailscale's DNS (100.100.100.100).
+    # Plain http is fine: the tailnet encrypts in transit (WireGuard).
+    litellm:
+      kind: openai_compatible
+      base_url: http://100.75.42.33:4000/v1
+      display_name: LiteLLM (lokal Qwen via Spark)
+      api_key_env: LITELLM_API_KEY
+      timeout_seconds: 120
+      # Runs locally on the Spark over the tailnet — not a third-party cloud,
+      # so suppress the "external cloud model" privacy notice (treat like
+      # local Ollama). Remove this if you ever point `litellm` at cloud models.
+      discloses_external: false
 
   # Per-model knobs. Content (system prompt, citation rules, refusal text,
   # jargon expansion) stays shared across models in `prompts.py` so A/B
@@ -112,6 +130,28 @@ llm:
       max_tokens: 4096
       thinking: true
       thinking_style: gemma
+    # --- LiteLLM gateway models (local Qwen on the Spark) ---
+    # model_id (after the first slash) must match the alias registered in
+    # LiteLLM. `num_ctx` is informational here: it is NOT sent on the
+    # openai_compatible path (the real window is set in Ollama/LiteLLM on the
+    # Spark). qwen3.6 supports up to 256k; verify the configured value there.
+    "litellm/qwen3.6":
+      num_ctx: 40960
+      temperature: 0.3
+      max_tokens: 2048               # bilingual eligibility answers can run long; tune per UX
+      thinking: false
+      thinking_style: none           # alias has thinking OFF — no reasoning_content to filter
+    # Reasoning variant (LiteLLM alias qwen3.6-think, think:true). LiteLLM
+    # splits CoT into `reasoning_content` in the NON-streamed response, but
+    # whether it forwards it as `delta.reasoning_content` while STREAMING is
+    # UNVERIFIED. If it doesn't, CoT may leak into delta.content and show in
+    # the answer. Run the streaming curl test before relying on this entry.
+    "litellm/qwen3.6-think":
+      num_ctx: 40960
+      temperature: 0.3
+      max_tokens: 2048
+      thinking: true
+      thinking_style: openai_reasoning_field
 
 memory:
   # Raised from 4 to 8 (#47) — the 16384-token context budget has plenty of

--- a/docs/DEPLOY.md
+++ b/docs/DEPLOY.md
@@ -1,0 +1,153 @@
+# Deployment & host operations
+
+Host-level notes for running the bot publicly: the reverse proxy that fronts
+the Docker stack, the **Tailscale ↔ nginx port-443 clash** (the one that bites
+after every reboot), and how to reach a **LiteLLM gateway** on the tailnet.
+The app itself is covered in [`README.md`](../README.md) → *Docker (Compose)*;
+this file is only the layer **in front of and around** the container.
+
+---
+
+## Reverse proxy (nginx + TLS)
+
+The container binds **`127.0.0.1:8000`** only (see `docker-compose.yml`,
+`beta-web`). Public access goes through **nginx**, which terminates TLS on
+**:443** and proxies the `/betabot/` prefix to the app:
+
+```
+https://<host>/betabot/   --nginx-->   http://127.0.0.1:8000/betabot/   (Docker)
+```
+
+- The app is mounted under that prefix via **`WEB_BASE_PATH=/betabot`** (compose
+  env). nginx passes the prefix through unchanged — do **not** strip it.
+- Server block lives at `/opt/homebrew/etc/nginx/servers/betabot.conf` (macOS
+  Homebrew layout). It also redirects `:80 → :443` and 404s the raw app paths
+  (`/api/`, `/static/`, `/docs/`) so only `/betabot/` is reachable from outside.
+- Auth is two layers (`README.md` → *Web app*): first visit with
+  `?access=<WEB_ACCESS_TOKEN>` sets the session cookie, then HTTP Basic from
+  `data/web_users` (`student-bot-mkuser <name>`). A bare `/betabot/` returning
+  **403** is the access-token gate working, not an outage.
+
+### nginx must run as root, and survive reboot
+
+Binding :80/:443 requires **root** — nginx started as your user (plain
+`brew services start nginx`) can **never** bind 443. Start it as root so
+Homebrew installs a **LaunchDaemon** (boots at startup, as root, no login
+needed):
+
+```bash
+sudo brew services start nginx     # installs /Library/LaunchDaemons/homebrew.mxcl.nginx.plist
+```
+
+Brew prints *"must be run as non-root to start at user login"* — ignore it;
+the LaunchDaemon is exactly what you want for an always-on public service.
+Validate config before (re)starting: `nginx -t`.
+
+---
+
+## ⚠️ The Tailscale ↔ port-443 clash (recurring after reboot)
+
+**Symptom:** the bot is unreachable from the public URL even though the Docker
+containers are healthy. nginx fails to start with:
+
+```
+[emerg] bind() to 0.0.0.0:443 failed (48: Address already in use)
+```
+
+**Cause:** `tailscale serve` / `funnel` binds the host's **:443** (via
+`tailscaled`, as **root**), and Tailscale re-applies that config on boot —
+grabbing 443 before nginx. Because the socket is root-owned it's **invisible to
+non-sudo `lsof`**; confirm with `netstat`:
+
+```bash
+netstat -an -p tcp | grep '\.443 '        # shows *.443 LISTEN even when lsof (no sudo) sees nothing
+curl -sk https://127.0.0.1/               # HANGS when Tailscale holds 443 (it only serves tailnet traffic)
+tailscale serve status                    # shows the conflicting :443 serve config
+```
+
+**Fix:**
+
+```bash
+tailscale serve reset            # frees 443; does NOT touch tailnet VPN / SSH / screen-sharing
+sudo brew services start nginx   # rebind 443 as root
+curl -sk -o /dev/null -w "%{http_code}\n" https://127.0.0.1/betabot/   # expect 403 (= chain works)
+```
+
+**The rule:** on any host that fronts the public site, **never configure
+`tailscale serve --https=443`**. The host's 443 belongs to nginx. If you need a
+tailnet-only HTTPS service on that machine, put it behind nginx or give it a
+different port. `tailscale serve reset` only removes the HTTPS *proxy* config —
+it does **not** disconnect Tailscale, so VPN, SSH and screen-sharing keep working.
+
+---
+
+## LiteLLM gateway on the tailnet (LLM provider)
+
+The bot reaches any OpenAI-compatible endpoint via the generic provider in
+`bot/llm.py` (`_stream_chat_openai`). A LiteLLM proxy is just another provider —
+**config only, no code**. Current setup (`config.yaml` → `llm.providers.litellm`):
+
+```yaml
+litellm:
+  kind: openai_compatible
+  base_url: http://100.75.42.33:4000/v1   # 100.x tailnet IP of the gateway host
+  display_name: LiteLLM (lokal Qwen via Spark)
+  api_key_env: LITELLM_API_KEY
+  timeout_seconds: 120
+  discloses_external: false               # models run LOCALLY on the Spark — suppress the cloud notice
+```
+
+Key points:
+
+- **Use the `100.x` IP, not the MagicDNS `.ts.net` name**, in `base_url`. A
+  Docker container on a native Linux host won't resolve MagicDNS unless you
+  point it at Tailscale's resolver (`--dns 100.100.100.100`); the IP avoids that.
+- **Plain `http://` is fine** — the tailnet encrypts in transit (WireGuard). No
+  need to put the gateway behind TLS.
+- **`LITELLM_API_KEY`** in `.env` is the gateway **virtual key** (scoped/rotatable
+  from the LiteLLM UI → Virtual Keys). The loader auto-reads any provider's
+  `api_key_env` (`config.py`), sent as `Authorization: Bearer`.
+- **`discloses_external: false`** marks this provider as local so the "external
+  cloud model, don't share sensitive info" notice does **not** fire (it's keyed
+  on this flag, not on `provider_kind`). Default (`None`) derives from kind:
+  `ollama` → local, everything else → external. **Set `false` only for gateways
+  whose models actually run locally** — keep the student-scoped key restricted to
+  local models; do not route student content to third-party clouds (OpenRouter).
+- **Model entries** are keyed `litellm/<alias>` where `<alias>` matches the name
+  registered in LiteLLM. `num_ctx` is **informational on this path** (not sent;
+  the real window is set in Ollama/LiteLLM on the gateway host).
+- **Reasoning models** (e.g. `qwen3.6-think`): LiteLLM streams chain-of-thought
+  as `delta.reasoning_content`, then the answer as `delta.content` — use
+  `thinking_style: openai_reasoning_field` so the CoT is filtered out and only
+  surfaced as a "thinking…" indicator.
+
+Quick gateway checks (run from the host, with `LITELLM_API_KEY` exported):
+
+```bash
+curl -s  http://100.75.42.33:4000/v1/models -H "Authorization: Bearer $LITELLM_API_KEY" | jq '.data[].id'
+LLM_ACTIVE=litellm/qwen3.6 uv run student-bot-cli "Vilka krav gäller för masterbehörighet?"
+```
+
+---
+
+## Moving to a new host — checklist
+
+When relocating (the new host also runs Tailscale):
+
+1. **Reverse proxy:** install nginx, copy the `betabot.conf` server block,
+   install TLS certs, and start it **as root** so it can bind 443 (LaunchDaemon
+   on macOS, a systemd unit on Linux — order it **after** `tailscaled` if both
+   run there).
+2. **Port 443:** ensure **no `tailscale serve` on 443** (see the clash section).
+3. **Container → tailnet reachability:** verify the bot container can reach the
+   LiteLLM `100.x` address. Test from inside the container:
+   ```bash
+   docker compose exec beta-web python -c "import socket; socket.create_connection(('100.75.42.33',4000),5)"
+   ```
+   On Docker Desktop/macOS this works out of the box (the VM routes via the host
+   Tailscale). On native Linux Docker it generally works too; if MagicDNS is
+   needed, add `--dns 100.100.100.100` to the container.
+4. **App env:** keep `WEB_SESSION_SECRET` stable (or sessions invalidate), set
+   `WEB_ACCESS_TOKEN`, and create `data/web_users` **before** the server stays up.
+5. **Reindex** the corpus on the new host (`scripts/reindex.py`) — the Chroma
+   index is host-specific (see `README.md` *Image notes* re: chromadb mismatch).

--- a/docs/DEPLOY.md
+++ b/docs/DEPLOY.md
@@ -121,6 +121,12 @@ Key points:
   `thinking_style: openai_reasoning_field` so the CoT is filtered out and only
   surfaced as a "thinking…" indicator.
 
+**Availability:** the committed default (`llm.active`) is `litellm/gemma4-31b`, so
+the gateway + Spark are now a **hard runtime dependency for all traffic** — if the
+Spark or the tailnet is down, the bot can't generate answers. The fast fallback is
+to switch back to the on-host model without a rebuild: set `LLM_ACTIVE=ollama/gemma-4-E4B-it-GGUF:UD-Q4_K_XL`
+in `.env` and `docker compose up -d` (or export it for a CLI run).
+
 Quick gateway checks (run from the host, with `LITELLM_API_KEY` exported):
 
 ```bash

--- a/docs/slides/index.html
+++ b/docs/slides/index.html
@@ -245,7 +245,7 @@
         <div>
           <p>The opportunity that wasn't there two years ago:</p>
           <ul>
-            <li><span class="kthhl">Gemma&nbsp;4 E4B</span> at Q4 &mdash; ~4.5 B effective parameters &mdash; runs on a Mac mini via Ollama/Metal</li>
+            <li><span class="kthhl">Gemma&nbsp;4 E4B</span> at Q4 &mdash; ~4.5 B effective parameters &mdash; runs on hardware as small as a Mac mini (Ollama/Metal)</li>
             <li><span class="kthhl">bge-m3</span> embeddings + a cross-encoder reranker, both on CPU</li>
             <li>Cross-lingual retrieval is real now: English question → Swedish policy → English answer with Swedish citations</li>
           </ul>
@@ -256,7 +256,7 @@
             <ul style="margin: 0.4em 0 0;">
               <li>One small machine (16 GB RAM)</li>
               <li>Zero cloud cost</li>
-              <li>No data leaves the host</li>
+              <li>No data leaves your own hardware</li>
             </ul>
           </div>
         </div>
@@ -301,21 +301,22 @@
              data-pattern="full" data-pattern-color="skyblue">
       <p class="eyebrow">Part 2 of 3</p>
       <h2>Design principles</h2>
-      <p class="lead">Local-first, transparent, and quietly didactic.</p>
+      <p class="lead">Self-hosted, transparent, and quietly didactic.</p>
     </section>
 
     <section>
       <p class="section-name">Part 2 · Philosophy</p>
-      <h1>Local-first, by design</h1>
+      <h1>Self-hosted, by design</h1>
       <div class="cols-2">
         <div>
-          <p>No student question, hash, or generated answer leaves the host machine.</p>
+          <p>No student question, hash, or generated answer leaves KTH-controlled infrastructure.</p>
           <ul>
-            <li class="fragment fade-in"><strong>Ollama</strong> on the host (Metal/GPU)</li>
+            <li class="fragment fade-in"><strong>LLM on a DGX&nbsp;Spark</strong> (local GPU box) via a LiteLLM gateway, over an encrypted Tailscale tailnet</li>
             <li class="fragment fade-in"><strong>Chroma</strong> vector store on local disk</li>
             <li class="fragment fade-in"><strong>SQLite</strong> log file, salted hashes only</li>
-            <li class="fragment fade-in"><strong>No API keys</strong> to any external service in the runtime path</li>
+            <li class="fragment fade-in"><strong>No third-party cloud</strong> &mdash; the only key in the runtime path is the tailnet-local gateway</li>
           </ul>
+          <p class="fragment fade-in" style="font-size: 0.8em; opacity: 0.85; margin-top: 0.6em;">The original default &mdash; Gemma&nbsp;4 E4B on a Mac mini (Ollama/Metal) &mdash; worked fine but took ~40&ndash;50&nbsp;s to first token. Moving the LLM to the Spark (a larger Gemma&nbsp;4 31B) buys speed while staying self-hosted.</p>
         </div>
         <div class="fragment fade-in">
           <div class="kthbox">
@@ -571,7 +572,7 @@
         <div class="box" data-id="chroma"
              style="left: 1200px; top: 160px;">Chroma<span class="sub">bge-m3 vectors</span></div>
         <div class="box" data-id="ollama"
-             style="left: 1200px; top: 360px;">Ollama<span class="sub">Gemma 4 E4B Q4</span></div>
+             style="left: 1200px; top: 360px;">LiteLLM<span class="sub">Gemma 4 31B · Spark</span></div>
       </div>
     </section>
 
@@ -595,7 +596,7 @@
         <div class="box" data-id="chroma"
              style="left: 1200px; top: 160px;">Chroma<span class="sub">bge-m3 vectors</span></div>
         <div class="box" data-id="ollama"
-             style="left: 1200px; top: 360px;">Ollama<span class="sub">Gemma 4 E4B Q4</span></div>
+             style="left: 1200px; top: 360px;">LiteLLM<span class="sub">Gemma 4 31B · Spark</span></div>
         <div class="box muted" data-id="topics"
              style="left: 800px; top: 460px;">topics.yaml<span class="sub">post-hoc taxonomy</span></div>
         <div class="box muted" data-id="log"
@@ -721,7 +722,7 @@
         <div>
           <h3 style="color: var(--kth-blue);">Models</h3>
           <ul>
-            <li><code>gemma-4-E4B-it-GGUF:Q4_K_XL</code> via Ollama (Metal)</li>
+            <li><code>gemma4-31b</code> via LiteLLM on a DGX&nbsp;Spark (tailnet) &mdash; was <code>gemma-4-E4B</code> on a Mac mini (Ollama/Metal)</li>
             <li><code>BAAI/bge-m3</code> embeddings (CPU)</li>
             <li><code>cross-encoder/mmarco-mMiniLMv2-L12-H384-v1</code> reranker (CPU)</li>
           </ul>
@@ -846,7 +847,7 @@
       <h1>What's deliberately <em>not</em> there</h1>
       <ul>
         <li class="fragment fade-in"><strong>No open web search.</strong> Optional dynamic fetch is hard-allowlisted to <code>kth.se/student/kurser/{kurs|program}/&lt;code&gt;</code> patterns &mdash; never arbitrary URLs.</li>
-        <li class="fragment fade-in"><strong>No agentic tools.</strong> No shell, no MCP, no API calls beyond Mattermost posting and Ollama chat. The boundary is the absence of tools.</li>
+        <li class="fragment fade-in"><strong>No agentic tools.</strong> No shell, no MCP, no API calls beyond Mattermost posting and the LiteLLM gateway (LLM chat) on the tailnet. The boundary is the absence of tools.</li>
         <li class="fragment fade-in"><strong>No multi-account isolation in the web UI.</strong> The auth gate is for trusted-colleague testing, not for production tenancy.</li>
         <li class="fragment fade-in"><strong>No real-time index updates.</strong> Reindex is a manual command after corpus edits.</li>
       </ul>

--- a/src/student_bot/bot/mattermost_client.py
+++ b/src/student_bot/bot/mattermost_client.py
@@ -106,7 +106,7 @@ _CLOUD_NOTICE_EN = (
 def gdpr_notice_sv(cfg) -> str:
     base = GDPR_NOTICE_SV
     resolved = cfg.active_model()
-    if resolved.provider_kind != "ollama":
+    if resolved.discloses_external:
         provider = resolved.display_name or resolved.provider_key or "extern leverantör"
         base += _CLOUD_NOTICE_SV.format(provider=provider)
     return base
@@ -115,7 +115,7 @@ def gdpr_notice_sv(cfg) -> str:
 def gdpr_notice_en(cfg) -> str:
     base = GDPR_NOTICE_EN
     resolved = cfg.active_model()
-    if resolved.provider_kind != "ollama":
+    if resolved.discloses_external:
         provider = resolved.display_name or resolved.provider_key or "external provider"
         base += _CLOUD_NOTICE_EN.format(provider=provider)
     return base

--- a/src/student_bot/config.py
+++ b/src/student_bot/config.py
@@ -95,6 +95,13 @@ class ProviderConfig(BaseModel):
     # cold start with long contexts; SSE keeps the connection alive but the
     # initial connect / first-byte still uses this.
     timeout_seconds: float = 120.0
+    # Whether using this provider sends student data off-box to a third party
+    # — drives the "external cloud model, don't share sensitive info" notice.
+    # None = derive from kind (`ollama` is local → no notice; everything else
+    # → notice). Set explicitly to `false` for an OpenAI-compatible endpoint
+    # that actually runs LOCALLY (e.g. a LiteLLM gateway in front of an Ollama
+    # model on the tailnet), so it's treated like local inference.
+    discloses_external: bool | None = None
 
 
 class ModelConfig(BaseModel):
@@ -162,6 +169,9 @@ class ResolvedLLM:
     thinking: bool
     thinking_style: str
     api_key: SecretStr | None
+    # Resolved (never None here): True if this provider sends data to a third
+    # party. Gates the cloud privacy notice. See ProviderConfig.discloses_external.
+    discloses_external: bool
 
 
 class MemoryConfig(BaseModel):
@@ -379,6 +389,14 @@ class Config(BaseModel):
                 f"llm.active references unknown model {active!r}; known models: {known}"
             )
         api_key = self.llm_api_keys.get(provider_key)
+        # None = derive from kind: ollama is local, everything else is external
+        # by default. An explicit bool (e.g. a local LiteLLM gateway set to
+        # false) overrides that default.
+        discloses_external = (
+            provider.discloses_external
+            if provider.discloses_external is not None
+            else provider.kind != "ollama"
+        )
         return ResolvedLLM(
             identifier=active,
             provider_key=provider_key,
@@ -393,6 +411,7 @@ class Config(BaseModel):
             thinking=model.thinking,
             thinking_style=model.thinking_style,
             api_key=api_key,
+            discloses_external=discloses_external,
         )
 
 

--- a/src/student_bot/web/app.py
+++ b/src/student_bot/web/app.py
@@ -310,7 +310,7 @@ def create_app(cfg: Config | None = None) -> FastAPI:
             resolved = cfg.active_model()
             cloud_name = (
                 resolved.display_name or resolved.provider_key
-                if resolved.provider_kind != "ollama"
+                if resolved.discloses_external
                 else ""
             )
         except RuntimeError:


### PR DESCRIPTION
## Summary
Adds support for LLMs served by a **LiteLLM gateway** on the tailnet (self-hosted Gemma 4 / Qwen 3.6 on a DGX Spark), and **switches the default model** from on-host Gemma 4 E4B (Ollama) to `litellm/gemma4-31b` for speed (E4B worked but ~40–50 s TTFT). LiteLLM is config-only — the existing OpenAI-compatible client already speaks the dialect — plus one flag so a *local* gateway model isn't mislabeled as third-party cloud.

## Changes
- **LiteLLM provider** (`config.yaml`): `kind: openai_compatible`, tailnet `100.x` IP, plain http (WireGuard encrypts), `api_key_env: LITELLM_API_KEY`, `discloses_external: false`.
- **Models**: `litellm/{qwen3.6,qwen3.6-think,gemma4-31b,gemma4-31b-think,gemma4-26b,gemma4-26b-think}`. Non-think → `thinking_style: none`; `-think` → `openai_reasoning_field` (verified: LiteLLM streams CoT as `delta.reasoning_content`, filtered out).
- **Default**: `llm.active` → `litellm/gemma4-31b`.
- **New `discloses_external` flag** (`config.py`): tri-state `bool | None`; `None` derives from kind (`ollama`→local, else→external), so existing providers are unchanged. The three privacy-notice sites (`bot/mattermost_client.py`, `web/app.py`) gate on `resolved.discloses_external` instead of `provider_kind`.
- **Docs**: new `docs/DEPLOY.md` (reverse proxy + TLS, nginx-as-root/LaunchDaemon, the recurring Tailscale↔443 clash + fix, LiteLLM provider, gateway-as-runtime-dependency + fallback, new-host checklist); linked from `README.md`.
- **Slides** (`docs/slides/index.html`): reframed "local-first" → "self-hosted", updated model/diagram/stack/security-boundary references, and added the Mac-mini → DGX Spark performance narrative.
- **`.env.example`**: documents `LITELLM_API_KEY` and the new default.

## Verification
- Gateway curls confirm `gemma4-31b`/`qwen3.6` stream `content`, and `gemma4-31b-think`/`qwen3.6-think` stream `reasoning_content`→`content` (reasoning filtered, not leaked).
- Full `student-bot-cli` run on the new default: correct retrieval, inline citations, confidence badge, sources, literacy footer, and **no** false cloud notice.
- `ruff check` clean; `discloses_external` resolves correctly for ollama/berget/litellm; 99/100 unit tests pass (the 1 failure, `test_eligibility_fallback`'s `HT2023`/`HT23` assertion, is pre-existing and unrelated — reproduces with these changes stashed).

## Ops / follow-ups
- `docker compose build && up` to ship the `discloses_external` code + updated slides to the container.
- Default now hard-depends on the Spark/tailnet; fallback is `LLM_ACTIVE=ollama/gemma-4-E4B-it-GGUF:UD-Q4_K_XL`.
- Pre-existing `HT2023`/`HT23` eligibility-fallback test failure still open.
