### PR TITLE
ci: pin ruff to uv.lock instead of latest

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,14 +17,17 @@ jobs:
         with:
           enable-cache: true
 
-      - name: Install ruff
-        run: uv tool install "ruff>=0.6"
+      - name: Sync dependencies (with dev extra)
+        run: uv sync --extra dev
 
+      # Use the ruff pinned in uv.lock (not the latest release) so CI and local
+      # `uv run ruff` agree. `uv tool run ruff` pulled whatever was newest and
+      # drifted ahead of the repo's pin, failing on rules the project doesn't use.
       - name: Ruff lint
-        run: uv tool run ruff check .
+        run: uv run ruff check .
 
       - name: Ruff format (check)
-        run: uv tool run ruff format --check .
+        run: uv run ruff format --check .
 
   build:
     name: Build + import smoke test (Python ${{ matrix.python-version }})


### PR DESCRIPTION
## Problem

CI's lint job installs the **latest** ruff (`uv tool install "ruff>=0.6"` + `uv tool run ruff`), which drifts ahead of the `ruff==0.15.12` pinned in `uv.lock`. Newer ruff enforces ~130 style/lint rules the project doesn't currently follow, so the **Ruff lint** job has been red on `main` (since the newer ruff started resolving) and on unrelated PRs — e.g. the `setup-uv` dependabot bump (#83) shows a red X for an import-sort rule that has nothing to do with its one-line change.

The underlying code is fine: the repo's pinned `ruff==0.15.12` passes both `ruff check .` and `ruff format --check .` cleanly.

## Fix

Sync the dev extra and run `uv run ruff`, so CI uses exactly the ruff resolved in `uv.lock` and matches what contributors run locally (`uv run ruff`). No more drift.

## Verification

Local, with the pinned ruff (`0.15.12`):

- `uv run ruff check .` → *All checks passed!*
- `uv run ruff format --check .` → *59 files already formatted*

🤖 Generated with [Claude Code](https://claude.com/claude-code)