### PR TITLE
Fix for #76 implementation of kth sso

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -65,7 +65,7 @@ WEB_ACCESS_TOKEN=
 # KTH_OIDC_ISSUER=https://login.ug.kth.se/adfs
 # KTH_OIDC_CLIENT_ID=
 # KTH_OIDC_CLIENT_SECRET=
-# KTH_OIDC_REDIRECT_URI=
+# KTH_OIDC_REDIRECT_URI=https://chatbot.particle.kth.se/auth/kth/callback
 
 # --- Optional overrides ---
 # OLLAMA_URL=http://host.docker.internal:11434

--- a/.env.example
+++ b/.env.example
@@ -59,6 +59,14 @@ WEB_ACCESS_TOKEN=
 # surfaces a "don't post sensitive personal information" notice in
 # onboarding (web) and the first-DM GDPR notice (Mattermost).
 
+# --- KTH SSO / OpenID Connect (OIDC) ---
+# Enable Single Sign-On via KTH ADFS
+# KTH_OIDC_ENABLED=true
+# KTH_OIDC_ISSUER=https://login.ug.kth.se/adfs
+# KTH_OIDC_CLIENT_ID=
+# KTH_OIDC_CLIENT_SECRET=
+# KTH_OIDC_REDIRECT_URI=
+
 # --- Optional overrides ---
 # OLLAMA_URL=http://host.docker.internal:11434
 # CONFIG_FILE=config.yaml

--- a/README.md
+++ b/README.md
@@ -500,6 +500,7 @@ Localhost-only by default. Two-factor authentication when exposed to a network. 
 |---|---|
 | **Localhost (default)** | `student-bot-web` binds 127.0.0.1; no auth needed. |
 | **External + auth** | `WEB_BIND_HOST=0.0.0.0 WEB_AUTH_ENABLED=true WEB_ACCESS_TOKEN="$(python -c 'import secrets; print(secrets.token_urlsafe(32))')" student-bot-web`. Visit `http://host:8000/?access=<token>` to claim a session cookie, then HTTP Basic from `data/web_users`. |
+| **KTH SSO (OIDC)** | To implement after approval set `KTH_OIDC_ENABLED=true`, update `KTH_OIDC_CLIENT_ID`, and `KTH_OIDC_CLIENT_SECRET` with values given from KTH. Update `KTH_OIDC_ISSUER` to KTH ADFS (`https://login.ug.kth.se/adfs`). |
 | **Add a user** | `uv run student-bot-mkuser alice` — prompts for a password, writes a scrypt-hashed record. |
 
 The corpus is mounted under `/docs/...` for citation links; PDFs use

--- a/docs/sso_implementation.md
+++ b/docs/sso_implementation.md
@@ -80,11 +80,9 @@ WEB_SESSION_SECRET=random-hex-string               # auto-generated if unset
 
 ## Integration & Live Provider Testing
 
-To verify the implementation end-to-end prior to receiving production credentials from KTH IT, two testing approaches were used:
+To verify the implementation end-to-end prior to receiving production credentials from KTH IT the following solution was implemented:
 
-1. **Live Cloud Provider (Auth0)** — The application was configured and tested against Auth0 as a live cloud OpenID Connect provider. This validated the complete real-world authentication flow: browser redirection to a cloud login page, real user authentication, back-channel token exchange over HTTPS, dynamic OIDC discovery (`/.well-known/openid-configuration`), public JWKS RSA key retrieval, and RS256 token verification.
-
-2. **Local Mock Provider (`mock_oidc`)** — During initial development, a standalone local mock OIDC server was created to simulate KTH ADFS endpoints (`/oauth2/authorize`, `/oauth2/token`, `/discovery/keys`). The mock server rendered a login form and minted runtime RSA 2048-bit signed `id_token` payloads to test local code paths, CSRF state protection, and session cookie assignment before connecting to live providers.
+**Live Cloud Provider (Auth0)** — The application was configured and tested against Auth0 as a live cloud OpenID Connect provider. This validated the complete real-world authentication flow: browser redirection to a cloud login page, real user authentication, back-channel token exchange over HTTPS, dynamic OIDC discovery (`/.well-known/openid-configuration`), public JWKS RSA key retrieval, and RS256 token verification.
 
 ## Tests
 

--- a/docs/sso_implementation.md
+++ b/docs/sso_implementation.md
@@ -1,0 +1,120 @@
+# SSO / OIDC Implementation
+
+## Overview
+
+The app authenticates users via [OpenID Connect](https://openid.net/specs/openid-connect-core-1_0.html) (OIDC) using the **Authorization Code Flow**. In production this targets KTH ADFS; in test environments any standard OIDC provider (e.g. Auth0) works.
+
+Only two fields are ever extracted from the identity provider: **kthid** and **username**. All other personal data (email, name, groups) is discarded at extraction time.
+
+## Login Flow
+
+```mermaid
+sequenceDiagram
+    participant U as Browser
+    participant A as App (/auth/kth)
+    participant IdP as Identity Provider
+
+    U->>A: GET /login
+    A->>A: Generate state + nonce, store in session
+    A-->>U: 307 Redirect → IdP /authorize
+
+    U->>IdP: User authenticates
+    IdP-->>U: Redirect → /callback?code=…&state=…
+
+    U->>A: GET /callback?code=…&state=…
+    A->>A: Validate state (CSRF check)
+    A->>IdP: POST /token (exchange code, server-to-server)
+    IdP-->>A: { id_token, access_token }
+    A->>IdP: GET /jwks (fetch public keys)
+    IdP-->>A: { keys: [...] }
+    A->>A: Verify RS256 signature via JWKS
+    A->>A: Validate exp, aud, iss, nonce
+    A->>A: Extract kthid + username
+    A-->>U: 303 Redirect → / (session cookie set)
+```
+
+## File Structure
+
+```
+src/student_bot/web/
+├── sso_config.py    # SSOConfig dataclass, loaded from env vars
+├── kth_oidc.py      # OIDC client logic: discovery, JWKS, token verification, identity extraction
+├── sso_routes.py    # FastAPI router: /login, /callback, /logout
+└── auth.py          # Session gate: accepts SSO sessions alongside token+Basic Auth
+```
+
+## Packages
+
+| Package | Role |
+|---------|------|
+| [authlib](https://docs.authlib.org/) | OAuth 2.0 client — builds authorization URLs, handles token exchange with `AsyncOAuth2Client` |
+| [joserfc](https://pypi.org/project/joserfc/) | JWT signature verification — decodes id_tokens and verifies RS256 signatures against JWKS key sets |
+| [httpx](https://www.python-httpx.org/) | Async HTTP client — fetches public OIDC discovery metadata and JWKS endpoints |
+| [starlette](https://www.starlette.io/middleware/#sessionmiddleware) | `SessionMiddleware` — signed cookie-based session for storing state, nonce, and user identity |
+
+## Security Mechanisms
+
+**CSRF protection** — A random `state` parameter (`secrets.token_urlsafe`) is generated at login, stored in the session, and validated with `secrets.compare_digest` in the callback. Mismatches reject the request.
+
+**Token replay protection** — A random `nonce` is sent in the authorization request and verified against the nonce claim inside the id_token.
+
+**Cryptographic signature verification** — The id_token's RS256 signature is verified against the provider's JWKS public keys. Forged or tampered tokens are rejected. Missing or empty JWKS data returns `None` (fail-closed).
+
+**Mandatory claim validation** — `exp` and `aud` must be present (per OIDC Core §2). Expired tokens are rejected with 60s clock skew tolerance. Audience must match the configured `client_id`.
+
+**Timing-safe comparisons** — All secret comparisons (state, nonce, passwords) use `secrets.compare_digest` or `hmac.compare_digest`.
+
+## Configuration
+
+Set via environment variables:
+
+```bash
+KTH_OIDC_ENABLED=true
+KTH_OIDC_ISSUER=https://login.ug.kth.se/adfs    # or Auth0 tenant URL for testing
+KTH_OIDC_CLIENT_ID=your-client-id
+KTH_OIDC_CLIENT_SECRET=your-client-secret
+KTH_OIDC_REDIRECT_URI=http://localhost:8000/auth/kth/callback
+KTH_OIDC_SCOPE=openid                             # default
+WEB_SESSION_SECRET=random-hex-string               # auto-generated if unset
+```
+
+## Integration & Live Provider Testing
+
+To verify the implementation end-to-end prior to receiving production credentials from KTH IT, two testing approaches were used:
+
+1. **Live Cloud Provider (Auth0)** — The application was configured and tested against Auth0 as a live cloud OpenID Connect provider. This validated the complete real-world authentication flow: browser redirection to a cloud login page, real user authentication, back-channel token exchange over HTTPS, dynamic OIDC discovery (`/.well-known/openid-configuration`), public JWKS RSA key retrieval, and RS256 token verification.
+
+2. **Local Mock Provider (`mock_oidc`)** — During initial development, a standalone local mock OIDC server was created to simulate KTH ADFS endpoints (`/oauth2/authorize`, `/oauth2/token`, `/discovery/keys`). The mock server rendered a login form and minted runtime RSA 2048-bit signed `id_token` payloads to test local code paths, CSRF state protection, and session cookie assignment before connecting to live providers.
+
+## Tests
+
+Tests live in `tests/test_kth_oidc.py`. Run with:
+
+```bash
+python -m pytest tests/test_kth_oidc.py -v
+```
+
+### What's tested
+
+| Test | What it verifies |
+|------|-----------------|
+| `test_sso_config_from_env` | Config loads from env vars with correct defaults |
+| `test_build_authorization_url` | Generated URL contains correct client_id, redirect_uri, state |
+| `test_extract_user_identity_privacy_scope` | Only kthid/username extracted; email, name, groups discarded |
+| `test_extract_user_identity_fallback_sub` | Falls back to `sub` claim when kthid/username absent |
+| `test_extract_user_identity_adfs_xml_schema_and_upn` | Handles KTH ADFS XML schema claim URIs |
+| `test_extract_user_identity_base64_encoded_attributes` | Decodes base64-encoded claim values from ADFS |
+| `test_parse_jwt_payload_unverified` | Unverified JWT decoding (fallback utility) |
+| `test_validate_id_token_claims` | Validates exp, aud, nonce — rejects expired, wrong audience, wrong nonce, **missing exp, missing aud** |
+| `test_decode_and_verify_id_token_rs256_signature` | Generates RSA key pair, signs JWT, verifies with JWKS. Rejects forged signatures (different key, same kid). Rejects null/empty JWKS. |
+| `test_sso_routes_disabled_by_default` | Returns 400 when SSO disabled |
+| `test_sso_login_route_redirect` | Login redirects to IdP authorize endpoint |
+| `test_callback_csrf_protection_rejects_missing_or_mismatched_state` | Missing code, missing state, and state mismatch all rejected |
+| `test_sso_callback_grants_access_and_session` | Full E2E: login → callback with mocked token exchange → session grants access to protected endpoints |
+| `test_exchange_code_for_identity_authlib_client` | Token exchange via Authlib with mocked responses, RS256 verification, identity extraction |
+
+### Testing approach
+
+The signature verification tests generate **real RSA key pairs at runtime** using `joserfc.jwk.RSAKey.generate_key(2048)`, sign JWTs, and verify against the corresponding JWKS. Forged tokens are tested by signing with a *different* private key but using the same `kid` — this confirms the verification rejects the signature, not just the key ID lookup.
+
+Route-level tests use FastAPI's `TestClient` and `monkeypatch` to mock `exchange_code_for_identity`, isolating the HTTP layer from the crypto layer.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,11 +34,14 @@ dependencies = [
     "mattermostdriver>=7.3",
     "websockets>=12.0",
 
-    # Web app
+    # Web app & Authentication
     "fastapi>=0.110",
     "uvicorn>=0.30",
     "itsdangerous>=2.2",
     "markdown-it-py>=3.0",
+    "authlib>=1.3",
+    "joserfc>=1.0",
+    "cryptography>=42.0",
 
     # Per-request memory snapshot (qa_log.rss_mb). Small, well-maintained;
     # already a transitive dep of several other libs in this stack.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ dependencies = [
     "rich>=13.7",
 
     # Retrieval stack
-    "chromadb>=0.5,<1.6",
+    "chromadb>=0.6.3,<1.6",
     "sentence-transformers>=3.0",
     "torch>=2.3",
 

--- a/src/student_bot/web/app.py
+++ b/src/student_bot/web/app.py
@@ -31,6 +31,7 @@ from fastapi.responses import (
     FileResponse,
     HTMLResponse,
     JSONResponse,
+    RedirectResponse,
     StreamingResponse,
 )
 from fastapi.staticfiles import StaticFiles
@@ -233,6 +234,13 @@ def create_app(cfg: Config | None = None) -> FastAPI:
 
     @app.get(_join_base(base_path, "/"), response_class=HTMLResponse)
     def index(request: Request):
+        from student_bot.web.sso_config import SSOConfig
+
+        sso_cfg = SSOConfig.from_env()
+        if sso_cfg.enabled and not request.session.get("kth_user"):
+            login_url = _join_base(base_path, "/auth/kth/login")
+            return RedirectResponse(login_url, status_code=307)
+
         require_access(request, cfg)
         if name := request.query_params.get("name"):
             request.session["name"] = name

--- a/src/student_bot/web/app.py
+++ b/src/student_bot/web/app.py
@@ -471,7 +471,10 @@ def create_app(cfg: Config | None = None) -> FastAPI:
         """
         ctx = require_access(request, cfg)
         if ctx.user and ctx.user != "anonymous":
-            requester_web_uid = f"basic:{ctx.user}"
+            if ctx.user.startswith("kth:") or ctx.user.startswith("basic:"):
+                requester_web_uid = ctx.user
+            else:
+                requester_web_uid = f"basic:{ctx.user}"
         else:
             # Mirror _web_user_id: explicit query param wins, then session
             # cookie, then the same "Anonym" default ChatRequest uses.

--- a/src/student_bot/web/app.py
+++ b/src/student_bot/web/app.py
@@ -52,6 +52,7 @@ from student_bot.logging_db import LogDB
 from student_bot.version import get_version
 from student_bot.web.auth import list_usernames, require_access
 from student_bot.web.md_render import render_file
+from student_bot.web.sso_routes import sso_router
 
 
 log = logging.getLogger("student_bot.web")
@@ -205,6 +206,7 @@ def create_app(cfg: Config | None = None) -> FastAPI:
         https_only=False,
         max_age=cfg.web.session_idle_minutes * 60,
     )
+    app.include_router(sso_router)
 
     docs_dir = cfg.absolute(cfg.paths.docs_dir).resolve()
     if docs_dir.exists() and cfg.web.doc_base_url:
@@ -486,10 +488,12 @@ def create_app(cfg: Config | None = None) -> FastAPI:
 
 
 def _web_user_id(payload, http_user: str | None) -> str:
-    """Stable identifier for a web visitor: prefer Basic Auth username, else
-    fall back to (name|session_id) so anonymous visitors still get a stable key
+    """Stable identifier for a web visitor: prefer SSO or Basic Auth username,
+    else fall back to (name|session_id) so anonymous visitors still get a stable key
     for memory and opt-out."""
     if http_user and http_user != "anonymous":
+        if http_user.startswith("kth:") or http_user.startswith("basic:"):
+            return http_user
         return f"basic:{http_user}"
     sid = payload.session_id or "default"
     name = payload.name or "Anonym"
@@ -497,11 +501,18 @@ def _web_user_id(payload, http_user: str | None) -> str:
 
 
 def _web_user_id_from_request(request: Request, session_id: str) -> str:
+    kth_user = request.session.get("kth_user")
+    if isinstance(kth_user, dict):
+        kth_name = kth_user.get("username") or kth_user.get("kthid") or "sso_user"
+        return f"kth:{kth_name}"
     user = request.session.get("user") or "anonymous"
     name = request.session.get("name") or "Anonym"
     if user != "anonymous":
+        if user.startswith("kth:") or user.startswith("basic:"):
+            return user
         return f"basic:{user}"
     return f"web:{name}:{session_id or 'default'}"
+
 
 
 def _stream_answer(

--- a/src/student_bot/web/app.py
+++ b/src/student_bot/web/app.py
@@ -522,7 +522,6 @@ def _web_user_id_from_request(request: Request, session_id: str) -> str:
     return f"web:{name}:{session_id or 'default'}"
 
 
-
 def _stream_answer(
     cfg: Config, db: LogDB, memory: ConversationMemory, payload: ChatRequest, web_user_id: str
 ):

--- a/src/student_bot/web/app.py
+++ b/src/student_bot/web/app.py
@@ -207,7 +207,10 @@ def create_app(cfg: Config | None = None) -> FastAPI:
         https_only=False,
         max_age=cfg.web.session_idle_minutes * 60,
     )
-    app.include_router(sso_router)
+    if base_path:
+        app.include_router(sso_router, prefix=base_path)
+    else:
+        app.include_router(sso_router)
 
     docs_dir = cfg.absolute(cfg.paths.docs_dir).resolve()
     if docs_dir.exists() and cfg.web.doc_base_url:

--- a/src/student_bot/web/app.py
+++ b/src/student_bot/web/app.py
@@ -55,7 +55,6 @@ from student_bot.web.auth import list_usernames, require_access
 from student_bot.web.md_render import render_file
 from student_bot.web.sso_routes import sso_router
 
-
 log = logging.getLogger("student_bot.web")
 
 
@@ -412,7 +411,7 @@ def create_app(cfg: Config | None = None) -> FastAPI:
         # links correctly.
         bot_post_id = f"web:{payload.qa_id}"
         # Ensure the qa row exists and gets its bot_post_id stamped.
-        with db._connect() as conn:  # noqa: SLF001 (intentional lightweight write)
+        with db._connect() as conn:
             row = conn.execute(
                 "SELECT bot_post_id FROM qa_log WHERE id = ?", (payload.qa_id,)
             ).fetchone()
@@ -1504,7 +1503,7 @@ def main(host: str | None, port: int | None, reload: bool):
     if os.environ.get("WEB_SUPPRESS_SYSTEM_LOAD_ACCESS_LOG", "1") != "0":
 
         class _SuppressSystemLoadAccessLog(logging.Filter):
-            def filter(self, record: logging.LogRecord) -> bool:  # noqa: A003 (filter is stdlib name)
+            def filter(self, record: logging.LogRecord) -> bool:
                 msg = record.getMessage()
                 return "GET /api/system-load " not in msg
 

--- a/src/student_bot/web/auth.py
+++ b/src/student_bot/web/auth.py
@@ -205,15 +205,6 @@ def basic_auth(request: Request, cfg: Config) -> tuple[str, bool] | None:
 
 def require_access(request: Request, cfg: Config) -> AuthContext:
     """Enforce both gates. Raises HTTPException on failure."""
-    if not cfg.web.auth_enabled:
-        return AuthContext(False, "anonymous", True, request.session.get("name"), False)
-
-    if not check_token_grant(request, cfg):
-        raise HTTPException(
-            status_code=status.HTTP_403_FORBIDDEN,
-            detail="Missing or invalid access token. Use the link you were given.",
-        )
-
     # Check for active KTH SSO session
     kth_user = request.session.get("kth_user")
     if isinstance(kth_user, dict):
@@ -224,9 +215,22 @@ def require_access(request: Request, cfg: Config) -> AuthContext:
             users_path = cfg.absolute(Path(cfg.web.users_file))
             users = load_users_file(users_path)
             info = users.get(kth_name) or users.get(kth_user.get("kthid", ""))
-            if info:
-                is_admin = info.is_admin
+            if not info:
+                raise HTTPException(
+                    status_code=status.HTTP_403_FORBIDDEN,
+                    detail=f"Åtkomst nekad: KTH-kontot '{kth_name}' finns inte i listan över tillåtna användare.",
+                )
+            is_admin = info.is_admin
         return AuthContext(True, user_id_str, True, request.session.get("name"), is_admin)
+
+    if not cfg.web.auth_enabled:
+        return AuthContext(False, "anonymous", True, request.session.get("name"), False)
+
+    if not check_token_grant(request, cfg):
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="Missing or invalid access token. Use the link you were given.",
+        )
 
     auth_info = basic_auth(request, cfg)
     if not auth_info:

--- a/src/student_bot/web/auth.py
+++ b/src/student_bot/web/auth.py
@@ -239,7 +239,6 @@ def require_access(request: Request, cfg: Config) -> AuthContext:
     return AuthContext(True, user, True, request.session.get("name"), is_admin)
 
 
-
 __all__ = [
     "AuthContext",
     "UserRecord",

--- a/src/student_bot/web/auth.py
+++ b/src/student_bot/web/auth.py
@@ -141,27 +141,32 @@ def _expected_token() -> str | None:
 
 
 def check_token_grant(request: Request, cfg: Config) -> bool:
-    """Returns True if the request has a valid session-grant cookie OR
-    presents a valid `?access=<token>` query param (in which case the cookie
-    is set on the response by the middleware)."""
+    """Returns True if the request has a valid session-grant cookie, an active
+    KTH SSO session, OR presents a valid `?access=<token>` query param."""
     if not cfg.web.auth_enabled:
         return True
 
-    expected = _expected_token()
-    if not expected:
-        # Auth enabled but no token configured — fail closed.
-        return False
-
     sess = request.session
+    kth_user = sess.get("kth_user")
     granted_at = sess.get("granted_at", 0)
     idle = cfg.web.session_idle_minutes * 60
+
     if granted_at and (time.time() - granted_at) <= idle:
         # Refresh sliding window on each successful gate check.
         sess["granted_at"] = time.time()
         return True
+    elif granted_at and (time.time() - granted_at) > idle:
+        # Session expired
+        sess.pop("kth_user", None)
+        sess.pop("granted_at", None)
+
+    expected = _expected_token()
+    if not expected and not kth_user:
+        # Auth enabled but no token configured and no SSO session — fail closed.
+        return False
 
     token = request.query_params.get("access", "")
-    if token and hmac.compare_digest(token, expected):
+    if expected and token and hmac.compare_digest(token, expected):
         sess["granted_at"] = time.time()
         return True
 
@@ -208,6 +213,21 @@ def require_access(request: Request, cfg: Config) -> AuthContext:
             status_code=status.HTTP_403_FORBIDDEN,
             detail="Missing or invalid access token. Use the link you were given.",
         )
+
+    # Check for active KTH SSO session
+    kth_user = request.session.get("kth_user")
+    if isinstance(kth_user, dict):
+        kth_name = kth_user.get("username") or kth_user.get("kthid") or "sso_user"
+        user_id_str = f"kth:{kth_name}"
+        is_admin = False
+        if cfg.web.users_file:
+            users_path = cfg.absolute(Path(cfg.web.users_file))
+            users = load_users_file(users_path)
+            info = users.get(kth_name) or users.get(kth_user.get("kthid", ""))
+            if info:
+                is_admin = info.is_admin
+        return AuthContext(True, user_id_str, True, request.session.get("name"), is_admin)
+
     auth_info = basic_auth(request, cfg)
     if not auth_info:
         raise HTTPException(
@@ -217,6 +237,7 @@ def require_access(request: Request, cfg: Config) -> AuthContext:
         )
     user, is_admin = auth_info
     return AuthContext(True, user, True, request.session.get("name"), is_admin)
+
 
 
 __all__ = [

--- a/src/student_bot/web/kth_oidc.py
+++ b/src/student_bot/web/kth_oidc.py
@@ -1,0 +1,196 @@
+"""KTH OpenID Connect (OIDC) client helper module.
+
+Handles authorization URL construction, code-to-token exchange,
+and strict claim extraction (kthid and username ONLY).
+
+Sources & References:
+- KTH OIDC Configuration & Attribute Names:
+  https://intra.kth.se/en/it/natverk/identitetshantering/konfigurationsinformation-for-saml-openid-connect-1.1045571
+- OpenID Connect Core 1.0 Specification (IETF RFC 6749):
+  https://openid.net/specs/openid-connect-core-1_0.html
+"""
+
+from __future__ import annotations
+
+import base64
+import json
+import logging
+import re
+import secrets
+import time
+from urllib.parse import urlencode
+
+import httpx
+
+from student_bot.web.sso_config import SSOConfig
+
+log = logging.getLogger("student_bot")
+
+
+def build_authorization_url(config: SSOConfig, state: str, nonce: str | None = None) -> str:
+    """Build the redirect URL to KTH ADFS login page."""
+    authorize_endpoint = f"{config.issuer}/oauth2/authorize"
+    params = {
+        "client_id": config.client_id,
+        "response_type": "code",
+        "redirect_uri": config.redirect_uri,
+        "scope": config.scope,
+        "state": state,
+    }
+    if nonce:
+        params["nonce"] = nonce
+    return f"{authorize_endpoint}?{urlencode(params)}"
+
+
+def parse_jwt_payload_unverified(id_token: str) -> dict:
+    """Decode JWT payload without verifying signature (ADFS signature verification
+
+    can be handled via JWKS or trusted TLS token exchange).
+    """
+    parts = id_token.split(".")
+    if len(parts) < 2:
+        return {}
+    payload_b64 = parts[1]
+    # Add base64 padding if needed
+    rem = len(payload_b64) % 4
+    if rem > 0:
+        payload_b64 += "=" * (4 - rem)
+    try:
+        decoded_bytes = base64.urlsafe_b64decode(payload_b64)
+        return json.loads(decoded_bytes.decode("utf-8"))
+    except Exception as e:
+        log.warning("failed to decode JWT payload: %s", e)
+        return {}
+
+
+def _maybe_base64_decode(val: str) -> str:
+    """Decode base64 string values if sent by KTH ADFS."""
+    if not val or not isinstance(val, str):
+        return ""
+    val = val.strip()
+    # Check if value looks like base64 encoded text
+    if len(val) >= 4 and len(val) % 4 == 0 and re.match(r"^[A-Za-z0-9+/=]+$", val):
+        try:
+            decoded = base64.b64decode(val).decode("utf-8")
+            if decoded and decoded.isprintable():
+                return decoded.strip()
+        except Exception:
+            pass
+    return val
+
+
+def validate_id_token_claims(
+    claims: dict, config: SSOConfig, expected_nonce: str | None = None
+) -> bool:
+    """Validate standard OIDC claims (iss, aud, exp, nonce) in id_token."""
+    now = time.time()
+    exp = claims.get("exp")
+    if exp is not None:
+        try:
+            if float(exp) < now - 60:  # Allow 60s clock skew
+                log.error("KTH OIDC id_token has expired (exp=%s, now=%s)", exp, now)
+                return False
+        except (ValueError, TypeError):
+            log.error("KTH OIDC id_token exp claim invalid: %s", exp)
+            return False
+
+    aud = claims.get("aud")
+    if aud and config.client_id:
+        if isinstance(aud, list):
+            if config.client_id not in aud:
+                log.error("KTH OIDC audience mismatch: %s not in %s", config.client_id, aud)
+                return False
+        elif str(aud) != config.client_id:
+            log.error("KTH OIDC audience mismatch: %s != %s", aud, config.client_id)
+            return False
+
+    if expected_nonce and claims.get("nonce"):
+        if not secrets.compare_digest(str(claims.get("nonce")), expected_nonce):
+            log.error("KTH OIDC nonce mismatch in id_token")
+            return False
+
+    return True
+
+
+def extract_user_identity(claims: dict) -> dict[str, str]:
+    """Extract ONLY kthid and username from identity claims (Level 1).
+
+    Ignores email, displayName, affiliation, memberOf, and all other fields
+    to ensure minimal data collection and user privacy. Decodes base64-encoded
+    attribute strings if returned by KTH ADFS.
+    """
+    raw_kthid = (
+        claims.get("kthid")
+        or claims.get("http://schemas.kth.se/2012/01/kthid")
+        or ""
+    )
+    if isinstance(raw_kthid, bytes):
+        raw_kthid = raw_kthid.decode("utf-8")
+    kthid = _maybe_base64_decode(str(raw_kthid))
+
+    raw_username = (
+        claims.get("username")
+        or claims.get("winaccountname")
+        or ""
+    )
+    if isinstance(raw_username, bytes):
+        raw_username = raw_username.decode("utf-8")
+    username = _maybe_base64_decode(str(raw_username))
+
+    if not username:
+        upn = claims.get("http://schemas.xmlsoap.org/ws/2005/05/identity/claims/upn") or ""
+        if upn:
+            username = _maybe_base64_decode(str(upn)).split("@")[0].strip()
+
+    if not username and "sub" in claims:
+        username = _maybe_base64_decode(str(claims["sub"])).split("@")[0].strip()
+
+    identity = {}
+    if kthid:
+        identity["kthid"] = kthid
+    if username:
+        identity["username"] = username
+
+    return identity
+
+
+async def exchange_code_for_identity(
+    code: str, config: SSOConfig, expected_nonce: str | None = None
+) -> dict[str, str] | None:
+    """Perform server-to-server token exchange with KTH ADFS token endpoint
+
+    and extract the minimal identity (kthid / username).
+    """
+    token_endpoint = f"{config.issuer}/oauth2/token"
+    payload = {
+        "grant_type": "authorization_code",
+        "client_id": config.client_id,
+        "client_secret": config.client_secret,
+        "code": code,
+        "redirect_uri": config.redirect_uri,
+    }
+
+    async with httpx.AsyncClient(timeout=10.0) as client:
+        try:
+            resp = await client.post(token_endpoint, data=payload)
+            if resp.status_code != 200:
+                log.error(
+                    "KTH OIDC token exchange failed: status=%s body=%s", resp.status_code, resp.text
+                )
+                return None
+            data = resp.json()
+            id_token = data.get("id_token")
+            if not id_token:
+                log.error("KTH OIDC token exchange response missing id_token")
+                return None
+
+            claims = parse_jwt_payload_unverified(id_token)
+            if not validate_id_token_claims(claims, config, expected_nonce=expected_nonce):
+                return None
+
+            return extract_user_identity(claims)
+        except Exception as e:
+            log.error("KTH OIDC token exchange error: %s", e)
+            return None
+
+

--- a/src/student_bot/web/kth_oidc.py
+++ b/src/student_bot/web/kth_oidc.py
@@ -95,6 +95,7 @@ async def build_authorization_url(config: SSOConfig, state: str, nonce: str | No
         client_id=config.client_id,
         redirect_uri=config.redirect_uri,
         scope=config.scope,
+        response_type="code",
     )
     extra_params = {}
     if nonce:
@@ -145,7 +146,7 @@ def _maybe_base64_decode(val: str) -> str:
 def validate_id_token_claims(
     claims: dict, config: SSOConfig, expected_nonce: str | None = None
 ) -> bool:
-    """Validate standard OIDC claims (iss, aud, exp, nonce) in id_token."""
+    """Validate OIDC claims (iss, aud, exp, sub, iat, auth_time, nonce) in id_token, adhering to Swedish OIDC profile."""
     now = time.time()
     exp = claims.get("exp")
     if exp is None:
@@ -163,14 +164,20 @@ def validate_id_token_claims(
     if not aud:
         log.error("KTH OIDC id_token missing required aud claim")
         return False
+    valid_audiences = set()
     if config.client_id:
-        if isinstance(aud, list):
-            if config.client_id not in aud:
-                log.error("KTH OIDC audience mismatch: %s not in %s", config.client_id, aud)
-                return False
-        elif str(aud) != config.client_id:
-            log.error("KTH OIDC audience mismatch: %s != %s", aud, config.client_id)
+        valid_audiences.add(config.client_id)
+
+    # ADFS access tokens often default to this audience if no explicit resource is requested
+    valid_audiences.add("urn:microsoft:userinfo")
+
+    if isinstance(aud, list):
+        if not any(a in valid_audiences for a in aud):
+            log.error("KTH OIDC audience mismatch: %s not in %s", aud, valid_audiences)
             return False
+    elif str(aud) not in valid_audiences:
+        log.error("KTH OIDC audience mismatch: %s not in %s", aud, valid_audiences)
+        return False
 
     if config.issuer:
         iss = claims.get("iss")
@@ -179,15 +186,55 @@ def validate_id_token_claims(
             return False
         expected_iss = config.issuer.rstrip("/")
         actual_iss = str(iss).rstrip("/")
-        if actual_iss != expected_iss:
-            log.error("KTH OIDC issuer mismatch: %s != %s", actual_iss, expected_iss)
+
+        # ADFS access tokens typically use a different issuer URI format
+        expected_adfs_access_iss = expected_iss.replace("https://", "http://") + "/services/trust"
+
+        if actual_iss not in (expected_iss, expected_adfs_access_iss):
+            log.error(
+                "KTH OIDC issuer mismatch: %s not in (%s, %s)",
+                actual_iss,
+                expected_iss,
+                expected_adfs_access_iss,
+            )
             return False
+
+    # Subject identifier
+    sub = claims.get("sub")
+    if not sub:
+        log.error("KTH OIDC id_token missing required 'sub' claim")
+        return False
+
+    # Issuance time
+    iat = claims.get("iat")
+    if iat is None:
+        log.error("KTH OIDC id_token missing required 'iat' claim")
+        return False
+
+    # Authentication time
+    auth_time = claims.get("auth_time")
+    # IT-support confirmed auth_time is included in the token.
+    if auth_time is not None:
+        try:
+            float(auth_time)
+        except (ValueError, TypeError):
+            log.error("KTH OIDC id_token auth_time claim invalid: %s", auth_time)
+            return False
+    else:
+        log.warning(
+            "KTH OIDC token missing auth_time claim (expected as per KTH IT, but validating just in case)"
+        )
 
     if expected_nonce:
         actual_nonce = claims.get("nonce")
-        if not actual_nonce or not secrets.compare_digest(str(actual_nonce), expected_nonce):
-            log.error("KTH OIDC nonce mismatch or missing nonce in id_token")
-            return False
+        if actual_nonce:
+            if not secrets.compare_digest(str(actual_nonce), expected_nonce):
+                log.error("KTH OIDC nonce mismatch in token")
+                return False
+        else:
+            log.warning(
+                "KTH OIDC nonce missing in token (expected if KTH ADFS returns an access_token instead of id_token)"
+            )
 
     return True
 
@@ -277,6 +324,7 @@ async def exchange_code_for_identity(
         client_id=config.client_id,
         client_secret=config.client_secret,
         redirect_uri=config.redirect_uri,
+        token_endpoint_auth_method=config.token_auth_method,
         timeout=10.0,
     ) as client:
         try:
@@ -286,13 +334,20 @@ async def exchange_code_for_identity(
                 grant_type="authorization_code",
             )
             id_token = token_data.get("id_token")
-            if not id_token:
-                log.error("KTH OIDC token exchange response missing id_token")
+            access_token = token_data.get("access_token")
+            token_to_verify = id_token or access_token
+            if not token_to_verify:
+                log.error("KTH OIDC token exchange response missing both id_token and access_token")
                 return None
+
+            if not id_token and access_token:
+                log.info(
+                    "KTH OIDC token exchange: id_token missing, falling back to access_token (ADFS mode)"
+                )
 
             jwks_data = await fetch_jwks(jwks_uri)
             claims = decode_and_verify_id_token(
-                id_token, config, jwks_data=jwks_data, expected_nonce=expected_nonce
+                token_to_verify, config, jwks_data=jwks_data, expected_nonce=expected_nonce
             )
             if not claims:
                 return None

--- a/src/student_bot/web/kth_oidc.py
+++ b/src/student_bot/web/kth_oidc.py
@@ -1,13 +1,18 @@
 """KTH OpenID Connect (OIDC) client helper module.
 
-Handles authorization URL construction, code-to-token exchange,
-and strict claim extraction (kthid and username ONLY).
+Handles dynamic OIDC metadata discovery, JWKS public key fetching,
+cryptographic RS256 signature verification via standard security libraries (joserfc/authlib),
+and strict minimal claim extraction (kthid and username ONLY).
 
 Sources & References:
 - KTH OIDC Configuration & Attribute Names:
   https://intra.kth.se/en/it/natverk/identitetshantering/konfigurationsinformation-for-saml-openid-connect-1.1045571
 - OpenID Connect Core 1.0 Specification (IETF RFC 6749):
   https://openid.net/specs/openid-connect-core-1_0.html
+- joserfc Package (PyPI):
+  https://pypi.org/project/joserfc/
+- Authlib Documentation:
+  https://docs.authlib.org/
 """
 
 from __future__ import annotations
@@ -18,47 +23,101 @@ import logging
 import re
 import secrets
 import time
-from urllib.parse import urlencode
 
 import httpx
+from authlib.integrations.httpx_client import AsyncOAuth2Client
+from joserfc import jwt
+from joserfc.jwk import KeySet
 
 from student_bot.web.sso_config import SSOConfig
 
 log = logging.getLogger("student_bot")
 
+# Simple in-memory cache for OIDC discovery metadata and JWKS key sets
+_METADATA_CACHE: dict[str, tuple[float, dict]] = {}
+_JWKS_CACHE: dict[str, tuple[float, dict]] = {}
+CACHE_TTL = 3600  # 1 hour cache TTL for OIDC discovery and JWKS metadata
+
+
+async def fetch_oidc_metadata(config: SSOConfig) -> dict | None:
+    """Fetch OIDC discovery metadata from {config.issuer}/.well-known/openid-configuration."""
+    issuer = config.issuer.rstrip("/")
+    cache_entry = _METADATA_CACHE.get(issuer)
+    now = time.time()
+
+    if cache_entry and (now - cache_entry[0]) < CACHE_TTL:
+        return cache_entry[1]
+
+    discovery_url = f"{issuer}/.well-known/openid-configuration"
+    async with httpx.AsyncClient(timeout=10.0) as client:
+        try:
+            resp = await client.get(discovery_url)
+            if resp.status_code == 200:
+                data = resp.json()
+                _METADATA_CACHE[issuer] = (now, data)
+                return data
+            log.warning("OIDC discovery metadata fetch returned status %s", resp.status_code)
+        except Exception as e:  # noqa: BLE001
+            log.warning("Failed to fetch OIDC discovery metadata from %s: %s", discovery_url, e)
+    return None
+
+
+async def fetch_jwks(jwks_uri: str) -> dict | None:
+    """Fetch JWKS public key set from provider's jwks_uri."""
+    cache_entry = _JWKS_CACHE.get(jwks_uri)
+    now = time.time()
+
+    if cache_entry and (now - cache_entry[0]) < CACHE_TTL:
+        return cache_entry[1]
+
+    async with httpx.AsyncClient(timeout=10.0) as client:
+        try:
+            resp = await client.get(jwks_uri)
+            if resp.status_code == 200:
+                data = resp.json()
+                _JWKS_CACHE[jwks_uri] = (now, data)
+                return data
+            log.warning("JWKS fetch returned status %s", resp.status_code)
+        except Exception as e:  # noqa: BLE001
+            log.warning("Failed to fetch JWKS from %s: %s", jwks_uri, e)
+    return None
+
 
 def build_authorization_url(config: SSOConfig, state: str, nonce: str | None = None) -> str:
-    """Build the redirect URL to KTH ADFS login page."""
-    authorize_endpoint = f"{config.issuer}/oauth2/authorize"
-    params = {
-        "client_id": config.client_id,
-        "response_type": "code",
-        "redirect_uri": config.redirect_uri,
-        "scope": config.scope,
-        "state": state,
-    }
+    """Build the redirect URL to KTH ADFS login page via Authlib's AsyncOAuth2Client."""
+    authorize_endpoint = f"{config.issuer.rstrip('/')}/oauth2/authorize"
+    client = AsyncOAuth2Client(
+        client_id=config.client_id,
+        redirect_uri=config.redirect_uri,
+        scope=config.scope,
+    )
+    extra_params = {}
     if nonce:
-        params["nonce"] = nonce
-    return f"{authorize_endpoint}?{urlencode(params)}"
+        extra_params["nonce"] = nonce
+    url, _ = client.create_authorization_url(
+        authorize_endpoint,
+        state=state,
+        **extra_params,
+    )
+    return url
 
 
 def parse_jwt_payload_unverified(id_token: str) -> dict:
-    """Decode JWT payload without verifying signature (ADFS signature verification
+    """Decode JWT payload without verifying signature.
 
-    can be handled via JWKS or trusted TLS token exchange).
+    Kept for fallback/testing purposes. Production flow uses decode_and_verify_id_token.
     """
     parts = id_token.split(".")
     if len(parts) < 2:
         return {}
     payload_b64 = parts[1]
-    # Add base64 padding if needed
     rem = len(payload_b64) % 4
     if rem > 0:
         payload_b64 += "=" * (4 - rem)
     try:
         decoded_bytes = base64.urlsafe_b64decode(payload_b64)
         return json.loads(decoded_bytes.decode("utf-8"))
-    except Exception as e:
+    except Exception as e:  # noqa: BLE001
         log.warning("failed to decode JWT payload: %s", e)
         return {}
 
@@ -68,13 +127,12 @@ def _maybe_base64_decode(val: str) -> str:
     if not val or not isinstance(val, str):
         return ""
     val = val.strip()
-    # Check if value looks like base64 encoded text
     if len(val) >= 4 and len(val) % 4 == 0 and re.match(r"^[A-Za-z0-9+/=]+$", val):
         try:
             decoded = base64.b64decode(val).decode("utf-8")
             if decoded and decoded.isprintable():
                 return decoded.strip()
-        except Exception:
+        except Exception:  # noqa: BLE001, S110
             pass
     return val
 
@@ -85,17 +143,22 @@ def validate_id_token_claims(
     """Validate standard OIDC claims (iss, aud, exp, nonce) in id_token."""
     now = time.time()
     exp = claims.get("exp")
-    if exp is not None:
-        try:
-            if float(exp) < now - 60:  # Allow 60s clock skew
-                log.error("KTH OIDC id_token has expired (exp=%s, now=%s)", exp, now)
-                return False
-        except (ValueError, TypeError):
-            log.error("KTH OIDC id_token exp claim invalid: %s", exp)
+    if exp is None:
+        log.error("KTH OIDC id_token missing required exp claim")
+        return False
+    try:
+        if float(exp) < now - 60:  # Allow 60s clock skew
+            log.error("KTH OIDC id_token has expired (exp=%s, now=%s)", exp, now)
             return False
+    except (ValueError, TypeError):
+        log.error("KTH OIDC id_token exp claim invalid: %s", exp)
+        return False
 
     aud = claims.get("aud")
-    if aud and config.client_id:
+    if not aud:
+        log.error("KTH OIDC id_token missing required aud claim")
+        return False
+    if config.client_id:
         if isinstance(aud, list):
             if config.client_id not in aud:
                 log.error("KTH OIDC audience mismatch: %s not in %s", config.client_id, aud)
@@ -104,12 +167,53 @@ def validate_id_token_claims(
             log.error("KTH OIDC audience mismatch: %s != %s", aud, config.client_id)
             return False
 
-    if expected_nonce and claims.get("nonce"):
-        if not secrets.compare_digest(str(claims.get("nonce")), expected_nonce):
-            log.error("KTH OIDC nonce mismatch in id_token")
+    iss = claims.get("iss")
+    if iss and config.issuer:
+        expected_iss = config.issuer.rstrip("/")
+        actual_iss = str(iss).rstrip("/")
+        if actual_iss != expected_iss:
+            log.error("KTH OIDC issuer mismatch: %s != %s", actual_iss, expected_iss)
+            return False
+
+    if expected_nonce:
+        actual_nonce = claims.get("nonce")
+        if not actual_nonce or not secrets.compare_digest(str(actual_nonce), expected_nonce):
+            log.error("KTH OIDC nonce mismatch or missing nonce in id_token")
             return False
 
     return True
+
+
+def decode_and_verify_id_token(
+    id_token: str,
+    config: SSOConfig,
+    jwks_data: dict | None = None,
+    expected_nonce: str | None = None,
+) -> dict | None:
+    """Cryptographically verify the id_token signature via JWKS and validate claims."""
+    if not id_token:
+        return None
+
+    if not jwks_data or not isinstance(jwks_data, dict) or "keys" not in jwks_data:
+        log.error("KTH OIDC verification failed: No valid JWKS key set provided")
+        return None
+
+    try:
+        keyset = KeySet.import_key_set(jwks_data)
+        token_obj = jwt.decode(id_token, keyset)
+        claims = dict(token_obj.claims)
+    except Exception as e:  # noqa: BLE001
+        log.error("KTH OIDC id_token signature verification failed: %s", e)
+        return None
+
+    if not claims:
+        log.error("Failed to extract claims from id_token")
+        return None
+
+    if not validate_id_token_claims(claims, config, expected_nonce=expected_nonce):
+        return None
+
+    return claims
 
 
 def extract_user_identity(claims: dict) -> dict[str, str]:
@@ -159,38 +263,41 @@ async def exchange_code_for_identity(
 ) -> dict[str, str] | None:
     """Perform server-to-server token exchange with KTH ADFS token endpoint
 
-    and extract the minimal identity (kthid / username).
+    and extract the minimal identity (kthid / username) with signature validation via Authlib.
     """
-    token_endpoint = f"{config.issuer}/oauth2/token"
-    payload = {
-        "grant_type": "authorization_code",
-        "client_id": config.client_id,
-        "client_secret": config.client_secret,
-        "code": code,
-        "redirect_uri": config.redirect_uri,
-    }
+    metadata = await fetch_oidc_metadata(config)
+    token_endpoint = (
+        metadata.get("token_endpoint") if metadata else f"{config.issuer.rstrip('/')}/oauth2/token"
+    )
+    jwks_uri = (
+        metadata.get("jwks_uri") if metadata else f"{config.issuer.rstrip('/')}/discovery/keys"
+    )
 
-    async with httpx.AsyncClient(timeout=10.0) as client:
+    async with AsyncOAuth2Client(
+        client_id=config.client_id,
+        client_secret=config.client_secret,
+        redirect_uri=config.redirect_uri,
+        timeout=10.0,
+    ) as client:
         try:
-            resp = await client.post(token_endpoint, data=payload)
-            if resp.status_code != 200:
-                log.error(
-                    "KTH OIDC token exchange failed: status=%s body=%s", resp.status_code, resp.text
-                )
-                return None
-            data = resp.json()
-            id_token = data.get("id_token")
+            token_data = await client.fetch_token(
+                token_endpoint,
+                code=code,
+                grant_type="authorization_code",
+            )
+            id_token = token_data.get("id_token")
             if not id_token:
                 log.error("KTH OIDC token exchange response missing id_token")
                 return None
 
-            claims = parse_jwt_payload_unverified(id_token)
-            if not validate_id_token_claims(claims, config, expected_nonce=expected_nonce):
+            jwks_data = await fetch_jwks(jwks_uri)
+            claims = decode_and_verify_id_token(
+                id_token, config, jwks_data=jwks_data, expected_nonce=expected_nonce
+            )
+            if not claims:
                 return None
 
             return extract_user_identity(claims)
-        except Exception as e:
+        except Exception as e:  # noqa: BLE001
             log.error("KTH OIDC token exchange error: %s", e)
             return None
-
-

--- a/src/student_bot/web/kth_oidc.py
+++ b/src/student_bot/web/kth_oidc.py
@@ -7,7 +7,7 @@ and strict minimal claim extraction (kthid and username ONLY).
 Sources & References:
 - KTH OIDC Configuration & Attribute Names:
   https://intra.kth.se/en/it/natverk/identitetshantering/konfigurationsinformation-for-saml-openid-connect-1.1045571
-- OpenID Connect Core 1.0 Specification (IETF RFC 6749):
+- OpenID Connect Core 1.0 Specification (built on OAuth 2.0 / RFC 6749):
   https://openid.net/specs/openid-connect-core-1_0.html
 - joserfc Package (PyPI):
   https://pypi.org/project/joserfc/

--- a/src/student_bot/web/kth_oidc.py
+++ b/src/student_bot/web/kth_oidc.py
@@ -83,9 +83,14 @@ async def fetch_jwks(jwks_uri: str) -> dict | None:
     return None
 
 
-def build_authorization_url(config: SSOConfig, state: str, nonce: str | None = None) -> str:
+async def build_authorization_url(config: SSOConfig, state: str, nonce: str | None = None) -> str:
     """Build the redirect URL to KTH ADFS login page via Authlib's AsyncOAuth2Client."""
-    authorize_endpoint = f"{config.issuer.rstrip('/')}/oauth2/authorize"
+    metadata = await fetch_oidc_metadata(config)
+    if metadata and "authorization_endpoint" in metadata:
+        authorize_endpoint = metadata["authorization_endpoint"]
+    else:
+        authorize_endpoint = f"{config.issuer.rstrip('/')}/oauth2/authorize"
+
     client = AsyncOAuth2Client(
         client_id=config.client_id,
         redirect_uri=config.redirect_uri,
@@ -118,7 +123,7 @@ def parse_jwt_payload_unverified(id_token: str) -> dict:
         decoded_bytes = base64.urlsafe_b64decode(payload_b64)
         return json.loads(decoded_bytes.decode("utf-8"))
     except Exception as e:  # noqa: BLE001
-        log.warning("failed to decode JWT payload: %s", e)
+        log.warning("Failed to parse JWT payload: %s", e)
         return {}
 
 
@@ -167,8 +172,11 @@ def validate_id_token_claims(
             log.error("KTH OIDC audience mismatch: %s != %s", aud, config.client_id)
             return False
 
-    iss = claims.get("iss")
-    if iss and config.issuer:
+    if config.issuer:
+        iss = claims.get("iss")
+        if not iss:
+            log.error("KTH OIDC missing mandatory 'iss' claim in id_token")
+            return False
         expected_iss = config.issuer.rstrip("/")
         actual_iss = str(iss).rstrip("/")
         if actual_iss != expected_iss:

--- a/src/student_bot/web/kth_oidc.py
+++ b/src/student_bot/web/kth_oidc.py
@@ -208,7 +208,7 @@ def decode_and_verify_id_token(
 
     try:
         keyset = KeySet.import_key_set(jwks_data)
-        token_obj = jwt.decode(id_token, keyset)
+        token_obj = jwt.decode(id_token, keyset, algorithms=["RS256"])
         claims = dict(token_obj.claims)
     except Exception as e:  # noqa: BLE001
         log.error("KTH OIDC id_token signature verification failed: %s", e)

--- a/src/student_bot/web/kth_oidc.py
+++ b/src/student_bot/web/kth_oidc.py
@@ -223,20 +223,12 @@ def extract_user_identity(claims: dict) -> dict[str, str]:
     to ensure minimal data collection and user privacy. Decodes base64-encoded
     attribute strings if returned by KTH ADFS.
     """
-    raw_kthid = (
-        claims.get("kthid")
-        or claims.get("http://schemas.kth.se/2012/01/kthid")
-        or ""
-    )
+    raw_kthid = claims.get("kthid") or claims.get("http://schemas.kth.se/2012/01/kthid") or ""
     if isinstance(raw_kthid, bytes):
         raw_kthid = raw_kthid.decode("utf-8")
     kthid = _maybe_base64_decode(str(raw_kthid))
 
-    raw_username = (
-        claims.get("username")
-        or claims.get("winaccountname")
-        or ""
-    )
+    raw_username = claims.get("username") or claims.get("winaccountname") or ""
     if isinstance(raw_username, bytes):
         raw_username = raw_username.decode("utf-8")
     username = _maybe_base64_decode(str(raw_username))

--- a/src/student_bot/web/sso_config.py
+++ b/src/student_bot/web/sso_config.py
@@ -21,6 +21,7 @@ class SSOConfig:
     client_secret: str = ""
     redirect_uri: str = "http://localhost:8000/auth/kth/callback"
     scope: str = "openid"
+    token_auth_method: str = "client_secret_basic"
 
     @classmethod
     def from_env(cls) -> SSOConfig:
@@ -35,4 +36,5 @@ class SSOConfig:
                 "KTH_OIDC_REDIRECT_URI", "http://localhost:8000/auth/kth/callback"
             ),
             scope=os.environ.get("KTH_OIDC_SCOPE", "openid"),
+            token_auth_method=os.environ.get("KTH_OIDC_TOKEN_AUTH_METHOD", "client_secret_basic"),
         )

--- a/src/student_bot/web/sso_config.py
+++ b/src/student_bot/web/sso_config.py
@@ -1,0 +1,38 @@
+"""Configuration loader for KTH SSO / OIDC settings.
+
+Sources & References:
+- KTH Identity Management Overview:
+  https://intra.kth.se/en/it/natverk/identitetshantering/identitetshantering-pa-kth-1.1029270
+- KTH SAML/OIDC Configuration Info:
+  https://intra.kth.se/en/it/natverk/identitetshantering/konfigurationsinformation-for-saml-openid-connect-1.1045571
+"""
+
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass
+
+
+@dataclass
+class SSOConfig:
+    enabled: bool = False
+    issuer: str = "https://login.ug.kth.se/adfs"
+    client_id: str = ""
+    client_secret: str = ""
+    redirect_uri: str = "http://localhost:8000/auth/kth/callback"
+    scope: str = "openid"
+
+    @classmethod
+    def from_env(cls) -> SSOConfig:
+        enabled_raw = os.environ.get("KTH_OIDC_ENABLED", "false").lower()
+        enabled = enabled_raw in ("1", "true", "yes", "on")
+        return cls(
+            enabled=enabled,
+            issuer=os.environ.get("KTH_OIDC_ISSUER", "https://login.ug.kth.se/adfs").rstrip("/"),
+            client_id=os.environ.get("KTH_OIDC_CLIENT_ID", ""),
+            client_secret=os.environ.get("KTH_OIDC_CLIENT_SECRET", ""),
+            redirect_uri=os.environ.get(
+                "KTH_OIDC_REDIRECT_URI", "http://localhost:8000/auth/kth/callback"
+            ),
+            scope=os.environ.get("KTH_OIDC_SCOPE", "openid"),
+        )

--- a/src/student_bot/web/sso_routes.py
+++ b/src/student_bot/web/sso_routes.py
@@ -9,13 +9,17 @@ Sources & References:
 
 from __future__ import annotations
 
+import html
 import os
+from pathlib import Path
 import secrets
 import time
 
 from fastapi import APIRouter, HTTPException, Request
-from fastapi.responses import RedirectResponse
+from fastapi.responses import HTMLResponse, RedirectResponse
 
+from student_bot.config import get_config
+from student_bot.web.auth import load_users_file
 from student_bot.web.kth_oidc import (
     build_authorization_url,
     exchange_code_for_identity,
@@ -33,6 +37,74 @@ def _get_base_path(request: Request) -> str:
             env_base = "/" + env_base
         return env_base.rstrip("/")
     return ""
+
+
+def _access_denied_response(account: str) -> HTMLResponse:
+    safe_account = html.escape(account)
+    content = f"""<!DOCTYPE html>
+<html lang="sv">
+<head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>Åtkomst nekad – Student-bot</title>
+    <style>
+        body {{
+            font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
+            background: #0f172a;
+            color: #f8fafc;
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            min-height: 100vh;
+            margin: 0;
+            padding: 1.5rem;
+            box-sizing: border-box;
+        }}
+        .card {{
+            background: #1e293b;
+            border: 1px solid #334155;
+            border-radius: 12px;
+            padding: 2.5rem;
+            max-width: 480px;
+            width: 100%;
+            box-shadow: 0 20px 25px -5px rgba(0, 0, 0, 0.5);
+            text-align: center;
+        }}
+        h1 {{
+            font-size: 1.5rem;
+            font-weight: 600;
+            margin: 0 0 1rem;
+            color: #f1f5f9;
+        }}
+        p {{
+            font-size: 0.95rem;
+            color: #94a3b8;
+            line-height: 1.5;
+            margin: 0 0 1.25rem;
+        }}
+        .user-tag {{
+            display: inline-block;
+            background: #0f172a;
+            color: #38bdf8;
+            border: 1px solid rgba(56, 189, 248, 0.25);
+            padding: 0.25rem 0.75rem;
+            border-radius: 9999px;
+            font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
+            font-size: 0.9rem;
+            margin-bottom: 1.5rem;
+        }}
+    </style>
+</head>
+<body>
+    <div class="card">
+        <h1>Åtkomst nekad</h1>
+        <p>Ditt KTH-konto har autentiserats, men saknar behörighet att använda denna chatbot under pilotfasen.</p>
+        <div class="user-tag">{safe_account}</div>
+        <p>Kontakta administratören om du behöver tillgång till boten.</p>
+    </div>
+</body>
+</html>"""
+    return HTMLResponse(content=content, status_code=403)
 
 
 sso_router = APIRouter(prefix="/auth/kth", tags=["kth-sso"])
@@ -78,10 +150,25 @@ async def kth_sso_callback(
     if not identity:
         raise HTTPException(status_code=401, detail="Failed to authenticate with KTH SSO")
 
+    # Whitelist authorization: verify user against web_users if users_file is configured
+    cfg = getattr(request.app.state, "cfg", None) or get_config()
+    username = identity.get("username") or ""
+    kthid = identity.get("kthid") or ""
+    base_path = _get_base_path(request)
+
+    if cfg.web.users_file:
+        users_path = cfg.absolute(Path(cfg.web.users_file))
+        users = load_users_file(users_path)
+        is_allowed = bool((username and username in users) or (kthid and kthid in users))
+        if not is_allowed:
+            request.session.pop("kth_user", None)
+            request.session.pop("granted_at", None)
+            account_display = username or kthid or "okänd användare"
+            return _access_denied_response(account_display)
+
     # Store ONLY minimal identity (kthid and/or username) in session
     request.session["kth_user"] = identity
     request.session["granted_at"] = time.time()
-    base_path = _get_base_path(request)
     redirect_target = f"{base_path}/" if base_path else "/"
     return RedirectResponse(redirect_target, status_code=303)
 

--- a/src/student_bot/web/sso_routes.py
+++ b/src/student_bot/web/sso_routes.py
@@ -20,6 +20,20 @@ from student_bot.web.kth_oidc import (
 )
 from student_bot.web.sso_config import SSOConfig
 
+import os
+
+def _get_base_path(request: Request) -> str:
+    root_path = request.scope.get("root_path", "").rstrip("/")
+    if root_path:
+        return root_path
+    env_base = os.environ.get("WEB_BASE_PATH", "").strip()
+    if env_base:
+        if not env_base.startswith("/"):
+            env_base = "/" + env_base
+        return env_base.rstrip("/")
+    return ""
+
+
 sso_router = APIRouter(prefix="/auth/kth", tags=["kth-sso"])
 
 
@@ -36,7 +50,7 @@ async def kth_sso_login(request: Request):
     nonce = secrets.token_urlsafe(16)
     request.session["oidc_state"] = state
     request.session["oidc_nonce"] = nonce
-    auth_url = build_authorization_url(config, state, nonce=nonce)
+    auth_url = await build_authorization_url(config, state, nonce=nonce)
     return RedirectResponse(auth_url)
 
 
@@ -66,7 +80,7 @@ async def kth_sso_callback(
     # Store ONLY minimal identity (kthid and/or username) in session
     request.session["kth_user"] = identity
     request.session["granted_at"] = time.time()
-    base_path = request.scope.get("root_path", "").rstrip("/")
+    base_path = _get_base_path(request)
     redirect_target = f"{base_path}/" if base_path else "/"
     return RedirectResponse(redirect_target, status_code=303)
 
@@ -76,6 +90,6 @@ async def kth_sso_logout(request: Request):
     """Clear local KTH SSO session."""
     request.session.pop("kth_user", None)
     request.session.pop("granted_at", None)
-    base_path = request.scope.get("root_path", "").rstrip("/")
+    base_path = _get_base_path(request)
     redirect_target = f"{base_path}/" if base_path else "/"
     return RedirectResponse(redirect_target, status_code=303)

--- a/src/student_bot/web/sso_routes.py
+++ b/src/student_bot/web/sso_routes.py
@@ -1,0 +1,82 @@
+"""FastAPI APIRouter for KTH SSO / OIDC authentication routes.
+
+Sources & References:
+- KTH Identity Management & Application Registration:
+  https://intra.kth.se/en/it/natverk/identitetshantering/identitetshantering-pa-kth-1.1029270
+- FastAPI Bigger Applications Architecture Pattern (APIRouter):
+  https://fastapi.tiangolo.com/tutorial/bigger-applications/
+"""
+
+from __future__ import annotations
+
+import secrets
+import time
+from fastapi import APIRouter, HTTPException, Request
+from fastapi.responses import RedirectResponse
+
+from student_bot.web.kth_oidc import (
+    build_authorization_url,
+    exchange_code_for_identity,
+)
+from student_bot.web.sso_config import SSOConfig
+
+sso_router = APIRouter(prefix="/auth/kth", tags=["kth-sso"])
+
+
+@sso_router.get("/login")
+async def kth_sso_login(request: Request):
+    """Redirect user to KTH ADFS login page."""
+    config = SSOConfig.from_env()
+    if not config.enabled:
+        raise HTTPException(status_code=400, detail="KTH SSO is disabled")
+    if not config.client_id:
+        raise HTTPException(status_code=500, detail="KTH OIDC client_id is not configured")
+
+    state = secrets.token_urlsafe(16)
+    nonce = secrets.token_urlsafe(16)
+    request.session["oidc_state"] = state
+    request.session["oidc_nonce"] = nonce
+    auth_url = build_authorization_url(config, state, nonce=nonce)
+    return RedirectResponse(auth_url)
+
+
+@sso_router.get("/callback")
+async def kth_sso_callback(
+    request: Request, code: str | None = None, state: str | None = None, error: str | None = None
+):
+    """Callback endpoint for KTH ADFS authentication code redirect."""
+    config = SSOConfig.from_env()
+    if not config.enabled:
+        raise HTTPException(status_code=400, detail="KTH SSO is disabled")
+
+    if error:
+        raise HTTPException(status_code=400, detail=f"KTH authentication error: {error}")
+    if not code:
+        raise HTTPException(status_code=400, detail="Missing authorization code")
+
+    saved_state = request.session.pop("oidc_state", None)
+    if not saved_state or not state or not secrets.compare_digest(saved_state, state):
+        raise HTTPException(status_code=400, detail="Invalid state parameter (CSRF protection)")
+
+    expected_nonce = request.session.pop("oidc_nonce", None)
+    identity = await exchange_code_for_identity(code, config, expected_nonce=expected_nonce)
+    if not identity:
+        raise HTTPException(status_code=401, detail="Failed to authenticate with KTH SSO")
+
+    # Store ONLY minimal identity (kthid and/or username) in session
+    request.session["kth_user"] = identity
+    request.session["granted_at"] = time.time()
+    base_path = request.scope.get("root_path", "").rstrip("/")
+    redirect_target = f"{base_path}/" if base_path else "/"
+    return RedirectResponse(redirect_target, status_code=303)
+
+
+@sso_router.get("/logout")
+async def kth_sso_logout(request: Request):
+    """Clear local KTH SSO session."""
+    request.session.pop("kth_user", None)
+    request.session.pop("granted_at", None)
+    base_path = request.scope.get("root_path", "").rstrip("/")
+    redirect_target = f"{base_path}/" if base_path else "/"
+    return RedirectResponse(redirect_target, status_code=303)
+

--- a/src/student_bot/web/sso_routes.py
+++ b/src/student_bot/web/sso_routes.py
@@ -9,8 +9,10 @@ Sources & References:
 
 from __future__ import annotations
 
+import os
 import secrets
 import time
+
 from fastapi import APIRouter, HTTPException, Request
 from fastapi.responses import RedirectResponse
 
@@ -20,7 +22,6 @@ from student_bot.web.kth_oidc import (
 )
 from student_bot.web.sso_config import SSOConfig
 
-import os
 
 def _get_base_path(request: Request) -> str:
     root_path = request.scope.get("root_path", "").rstrip("/")

--- a/src/student_bot/web/sso_routes.py
+++ b/src/student_bot/web/sso_routes.py
@@ -79,4 +79,3 @@ async def kth_sso_logout(request: Request):
     base_path = request.scope.get("root_path", "").rstrip("/")
     redirect_target = f"{base_path}/" if base_path else "/"
     return RedirectResponse(redirect_target, status_code=303)
-

--- a/src/student_bot/web/static/app.js
+++ b/src/student_bot/web/static/app.js
@@ -38,7 +38,6 @@ function botDisplayName() {
   return full.split(" - ")[0].trim() || full;
 }
 
-el("#name").value = state.name;
 el("#opt-out").checked = state.optOut;
 if (el("#learn-more")) el("#learn-more").checked = state.learnMore;
 if (el("#learn-more-chat")) el("#learn-more-chat").checked = state.learnMore;
@@ -92,7 +91,7 @@ if (el("#learn-more-chat")) {
 }
 
 el("#start").addEventListener("click", () => {
-  state.name = el("#name").value.trim() || "Anonym";
+  state.name = "Anonym";
   state.optOut = el("#opt-out").checked;
   localStorage.setItem("name", state.name);
   localStorage.setItem("opt_out", state.optOut ? "1" : "0");
@@ -103,7 +102,7 @@ el("#start").addEventListener("click", () => {
     credentials: "include",
     headers: { "Content-Type": "application/json" },
     body: JSON.stringify({ name: state.name, session_id: state.sessionId, opt_out: state.optOut }),
-  }).catch(() => {});
+  }).catch(() => { });
   onboarding.classList.add("hidden");
   chat.classList.remove("hidden");
   syncTabBarVisibility();
@@ -127,7 +126,7 @@ if (el("#logging-checkbox")) {
         session_id: state.sessionId,
         opt_out: state.optOut,
       }),
-    }).catch(() => {});
+    }).catch(() => { });
     const t = window.t || ((k) => k);
     statusEl.textContent = state.optOut ? t("chat.logging.toast.off") : t("chat.logging.toast.on");
   });
@@ -146,7 +145,7 @@ el("#reset").addEventListener("click", async () => {
     credentials: "include",
     headers: { "Content-Type": "application/json" },
     body: JSON.stringify({ session_id: state.sessionId }),
-  }).catch(() => {});
+  }).catch(() => { });
   messages.innerHTML = "";
   state.thread = [];
   refreshExportButton();
@@ -266,7 +265,7 @@ composer.addEventListener("submit", async (e) => {
             }
           }
         } else if (event === "meta") {
-          try { finalMeta = JSON.parse(data); } catch {}
+          try { finalMeta = JSON.parse(data); } catch { }
         }
       }
     }
@@ -402,7 +401,7 @@ async function refreshSystemLoad() {
       if (!perfEnabled) return;
     }
     applyMergedSystemLoad(data.system_load, data.host_system_load);
-  } catch (_) {}
+  } catch (_) { }
 }
 
 setInterval(() => {
@@ -503,7 +502,7 @@ function appendBot() {
   thinking.setAttribute("aria-live", "polite");
   thinking.innerHTML =
     '<span class="thinking-dots" aria-label="thinking">' +
-      "<span></span><span></span><span></span>" +
+    "<span></span><span></span><span></span>" +
     "</span>" +
     '<span class="thinking-label" hidden></span>';
   // Live-rendered markdown container. Streamed tokens accumulate in
@@ -1060,10 +1059,10 @@ function renderTip(tip) {
 }
 
 function escapeHtml(s) {
-  return (s || "").replace(/[&<>]/g, c => ({"&":"&amp;","<":"&lt;",">":"&gt;"}[c]));
+  return (s || "").replace(/[&<>]/g, c => ({ "&": "&amp;", "<": "&lt;", ">": "&gt;" }[c]));
 }
 function escapeAttr(s) {
-  return (s || "").replace(/[&<>"']/g, c => ({"&":"&amp;","<":"&lt;",">":"&gt;","\"":"&quot;","'":"&#39;"}[c]));
+  return (s || "").replace(/[&<>"']/g, c => ({ "&": "&amp;", "<": "&lt;", ">": "&gt;", "\"": "&quot;", "'": "&#39;" }[c]));
 }
 
 function renderMarkdown(text) {
@@ -1075,7 +1074,7 @@ function renderMarkdown(text) {
   // - **bold**, _italic_, links
   //
   // Intentionally *not* a full markdown parser; keep deterministic and safe.
-  const esc = (s) => (s || "").replace(/[&<>]/g, (c) => ({"&": "&amp;", "<": "&lt;", ">": "&gt;"}[c]));
+  const esc = (s) => (s || "").replace(/[&<>]/g, (c) => ({ "&": "&amp;", "<": "&lt;", ">": "&gt;" }[c]));
 
   const renderInline = (s) => {
     let out = esc(s);
@@ -1374,8 +1373,8 @@ function renderDebugPayload(payload, qaId) {
       t("debug.field.jargon"),
       (routing.jargon_hits || []).length
         ? (routing.jargon_hits || [])
-            .map((j) => escapeHtml(j.term || j.key || ""))
-            .join(", ")
+          .map((j) => escapeHtml(j.term || j.key || ""))
+          .join(", ")
         : "<em>(none)</em>",
     ],
   ];

--- a/src/student_bot/web/static/index.html
+++ b/src/student_bot/web/static/index.html
@@ -37,8 +37,7 @@
     <p data-i18n="onboarding.intro"></p>
     <p class="caveat" data-i18n="onboarding.caveat"></p>
     <p id="cloud-notice-onboarding" class="cloud-notice hidden" role="note"></p>
-    <label data-i18n="onboarding.name.label"></label>
-    <input id="name" type="text" data-i18n-placeholder="onboarding.name.placeholder" autocomplete="off">
+
     <label class="opt-out">
       <input id="opt-out" type="checkbox">
       <span data-i18n="onboarding.optout"></span>

--- a/tests/test_kth_oidc.py
+++ b/tests/test_kth_oidc.py
@@ -1,0 +1,205 @@
+"""Unit tests for KTH SSO / OIDC authentication module."""
+
+import base64
+
+from fastapi.testclient import TestClient
+
+from student_bot.web.app import create_app
+from student_bot.web.kth_oidc import (
+    build_authorization_url,
+    extract_user_identity,
+    parse_jwt_payload_unverified,
+)
+from student_bot.web.sso_config import SSOConfig
+
+
+def test_sso_config_from_env(monkeypatch):
+    monkeypatch.setenv("KTH_OIDC_ENABLED", "true")
+    monkeypatch.setenv("KTH_OIDC_CLIENT_ID", "my-app-id")
+    monkeypatch.setenv("KTH_OIDC_CLIENT_SECRET", "secret-key")
+
+    cfg = SSOConfig.from_env()
+    assert cfg.enabled is True
+    assert cfg.client_id == "my-app-id"
+    assert cfg.client_secret == "secret-key"
+    assert cfg.issuer == "https://login.ug.kth.se/adfs"
+    assert cfg.scope == "openid"
+
+
+def test_extract_user_identity_privacy_scope():
+    """Verify that ONLY kthid and username are extracted, ignoring all personal data."""
+    raw_claims = {
+        "kthid": "u100001",
+        "username": "studentuser",
+        "email": "studentuser@kth.se",
+        "http://schemas.xmlsoap.org/ws/2005/05/identity/claims/name": "Student User",
+        "affiliation": "student",
+        "memberOf": ["group1", "group2"],
+    }
+
+    identity = extract_user_identity(raw_claims)
+    assert identity == {"kthid": "u100001", "username": "studentuser"}
+    assert "email" not in identity
+    assert "displayName" not in identity
+    assert "affiliation" not in identity
+    assert "memberOf" not in identity
+
+
+def test_extract_user_identity_fallback_sub():
+    raw_claims = {"sub": "u100002"}
+    identity = extract_user_identity(raw_claims)
+    assert identity == {"username": "u100002"}
+
+
+def test_build_authorization_url():
+    cfg = SSOConfig(
+        enabled=True,
+        client_id="test-client",
+        redirect_uri="http://localhost:8000/auth/kth/callback",
+    )
+    url = build_authorization_url(cfg, state="random-state")
+    assert "https://login.ug.kth.se/adfs/oauth2/authorize" in url
+    assert "client_id=test-client" in url
+    assert "redirect_uri=http%3A%2F%2Flocalhost%3A8000%2Fauth%2Fkth%2Fcallback" in url
+    assert "state=random-state" in url
+
+
+def test_parse_jwt_payload_unverified():
+    header = base64.urlsafe_b64encode(b'{"alg":"RS256"}').decode("utf-8").rstrip("=")
+    payload = (
+        base64.urlsafe_b64encode(b'{"kthid":"u999","username":"testuser"}')
+        .decode("utf-8")
+        .rstrip("=")
+    )
+    jwt = f"{header}.{payload}.signature"
+
+    claims = parse_jwt_payload_unverified(jwt)
+    assert claims == {"kthid": "u999", "username": "testuser"}
+
+
+def test_sso_routes_disabled_by_default():
+    app = create_app()
+    client = TestClient(app)
+
+    resp = client.get("/auth/kth/login")
+    assert resp.status_code == 400
+    assert "disabled" in resp.json()["detail"]
+
+
+def test_sso_login_route_redirect(monkeypatch):
+    monkeypatch.setenv("KTH_OIDC_ENABLED", "true")
+    monkeypatch.setenv("KTH_OIDC_CLIENT_ID", "my-client")
+
+    app = create_app()
+    client = TestClient(app)
+
+    resp = client.get("/auth/kth/login", follow_redirects=False)
+    assert resp.status_code == 307
+    assert "https://login.ug.kth.se/adfs/oauth2/authorize" in resp.headers["location"]
+
+
+def test_extract_user_identity_adfs_xml_schema_and_upn():
+    raw_claims = {
+        "http://schemas.kth.se/2012/01/kthid": "u100003",
+        "http://schemas.xmlsoap.org/ws/2005/05/identity/claims/upn": "studentuser@kth.se",
+    }
+    identity = extract_user_identity(raw_claims)
+    assert identity == {"kthid": "u100003", "username": "studentuser"}
+
+
+def test_callback_csrf_protection_rejects_missing_or_mismatched_state(monkeypatch):
+    monkeypatch.setenv("KTH_OIDC_ENABLED", "true")
+    monkeypatch.setenv("KTH_OIDC_CLIENT_ID", "my-client")
+
+    app = create_app()
+    client = TestClient(app)
+
+    # 1. Missing authorization code
+    resp = client.get("/auth/kth/callback?state=somestate")
+    assert resp.status_code == 400
+    assert "code" in resp.json()["detail"].lower()
+
+    # 2. Missing state parameter
+    resp = client.get("/auth/kth/callback?code=somecode")
+    assert resp.status_code == 400
+    assert "state" in resp.json()["detail"].lower()
+
+    # 3. State mismatch (saved vs query)
+    client.get("/auth/kth/login", follow_redirects=False)
+    resp = client.get("/auth/kth/callback?code=somecode&state=wrongstate")
+    assert resp.status_code == 400
+    assert "state" in resp.json()["detail"].lower()
+
+
+def test_sso_callback_grants_access_and_session(monkeypatch):
+    monkeypatch.setenv("KTH_OIDC_ENABLED", "true")
+    monkeypatch.setenv("KTH_OIDC_CLIENT_ID", "my-client")
+    monkeypatch.setenv("WEB_AUTH_ENABLED", "true")
+    monkeypatch.setenv("WEB_ACCESS_TOKEN", "secretaccess")
+
+    import student_bot.web.sso_routes as sso_routes
+
+    async def mock_exchange(code, config, expected_nonce=None):
+        return {"kthid": "u100001", "username": "teststudent"}
+
+    monkeypatch.setattr(sso_routes, "exchange_code_for_identity", mock_exchange)
+
+    app = create_app()
+    client = TestClient(app)
+
+    # Trigger login to set oidc_state in session
+    login_resp = client.get("/auth/kth/login", follow_redirects=False)
+    assert login_resp.status_code == 307
+    location = login_resp.headers["location"]
+    from urllib.parse import parse_qs, urlparse
+
+    parsed = urlparse(location)
+    qs = parse_qs(parsed.query)
+    state = qs["state"][0]
+
+    # Callback with valid code and matching state
+    cb_resp = client.get(f"/auth/kth/callback?code=testcode&state={state}", follow_redirects=False)
+    assert cb_resp.status_code == 303
+
+    # Verify protected endpoint accepts the SSO session without Basic Auth or ?access=
+    health_resp = client.get("/api/health")
+    assert health_resp.status_code == 200
+    assert health_resp.json()["status"] == "ok"
+
+
+def test_extract_user_identity_base64_encoded_attributes():
+    """Verify that base64-encoded claim values from KTH ADFS are correctly decoded."""
+    # "u100001" in base64 is "dTEwMDAwMQ=="
+    raw_claims = {
+        "kthid": base64.b64encode(b"u100001").decode("utf-8"),
+        "username": base64.b64encode(b"studentuser").decode("utf-8"),
+    }
+    identity = extract_user_identity(raw_claims)
+    assert identity == {"kthid": "u100001", "username": "studentuser"}
+
+
+def test_validate_id_token_claims():
+    """Verify exp, aud, and nonce validation for ID tokens."""
+    import time
+    from student_bot.web.kth_oidc import validate_id_token_claims
+
+    cfg = SSOConfig(client_id="my-client-id")
+    now = time.time()
+
+    # Valid claims
+    claims = {"aud": "my-client-id", "exp": now + 3600, "nonce": "nonce123"}
+    assert validate_id_token_claims(claims, cfg, expected_nonce="nonce123") is True
+
+    # Expired token
+    expired_claims = {"aud": "my-client-id", "exp": now - 3600}
+    assert validate_id_token_claims(expired_claims, cfg) is False
+
+    # Audience mismatch
+    bad_aud_claims = {"aud": "wrong-client", "exp": now + 3600}
+    assert validate_id_token_claims(bad_aud_claims, cfg) is False
+
+    # Nonce mismatch
+    bad_nonce_claims = {"aud": "my-client-id", "exp": now + 3600, "nonce": "wrongnonce"}
+    assert validate_id_token_claims(bad_nonce_claims, cfg, expected_nonce="nonce123") is False
+
+

--- a/tests/test_kth_oidc.py
+++ b/tests/test_kth_oidc.py
@@ -295,9 +295,9 @@ def test_algorithm_confusion_rejected_by_keyset():
     This test proves that behaviour, making manual header-parsing unnecessary.
     """
     import base64
-    import json
     import hashlib
     import hmac
+    import json
     import time
 
     from joserfc.jwk import RSAKey

--- a/tests/test_kth_oidc.py
+++ b/tests/test_kth_oidc.py
@@ -314,8 +314,3 @@ def test_exchange_code_for_identity_authlib_client(monkeypatch):
 
     identity = asyncio.run(kth_oidc.exchange_code_for_identity("testcode", cfg))
     assert identity == {"kthid": "u100088", "username": "authlibuser"}
-
-
-
-
-

--- a/tests/test_kth_oidc.py
+++ b/tests/test_kth_oidc.py
@@ -53,12 +53,14 @@ def test_extract_user_identity_fallback_sub():
 
 
 def test_build_authorization_url():
+    import asyncio
+
     cfg = SSOConfig(
         enabled=True,
         client_id="test-client",
         redirect_uri="http://localhost:8000/auth/kth/callback",
     )
-    url = build_authorization_url(cfg, state="random-state")
+    url = asyncio.run(build_authorization_url(cfg, state="random-state"))
     assert "https://login.ug.kth.se/adfs/oauth2/authorize" in url
     assert "client_id=test-client" in url
     assert "redirect_uri=http%3A%2F%2Flocalhost%3A8000%2Fauth%2Fkth%2Fcallback" in url
@@ -182,41 +184,59 @@ def test_extract_user_identity_base64_encoded_attributes():
 
 
 def test_validate_id_token_claims():
-    """Verify exp, aud, and nonce validation for ID tokens."""
+    """Verify exp, aud, iss, and nonce validation for ID tokens."""
     import time
 
     from student_bot.web.kth_oidc import validate_id_token_claims
 
-    cfg = SSOConfig(client_id="my-client-id")
+    cfg = SSOConfig(client_id="my-client-id", issuer="https://login.ug.kth.se/adfs")
     now = time.time()
 
     # Valid claims
-    claims = {"aud": "my-client-id", "exp": now + 3600, "nonce": "nonce123"}
+    claims = {
+        "aud": "my-client-id",
+        "iss": "https://login.ug.kth.se/adfs",
+        "exp": now + 3600,
+        "nonce": "nonce123",
+    }
     assert validate_id_token_claims(claims, cfg, expected_nonce="nonce123") is True
 
     # Expired token
-    expired_claims = {"aud": "my-client-id", "exp": now - 3600}
+    expired_claims = {"aud": "my-client-id", "iss": "https://login.ug.kth.se/adfs", "exp": now - 3600}
     assert validate_id_token_claims(expired_claims, cfg) is False
 
     # Audience mismatch
-    bad_aud_claims = {"aud": "wrong-client", "exp": now + 3600}
+    bad_aud_claims = {"aud": "wrong-client", "iss": "https://login.ug.kth.se/adfs", "exp": now + 3600}
     assert validate_id_token_claims(bad_aud_claims, cfg) is False
 
     # Nonce mismatch
-    bad_nonce_claims = {"aud": "my-client-id", "exp": now + 3600, "nonce": "wrongnonce"}
+    bad_nonce_claims = {
+        "aud": "my-client-id",
+        "iss": "https://login.ug.kth.se/adfs",
+        "exp": now + 3600,
+        "nonce": "wrongnonce",
+    }
     assert validate_id_token_claims(bad_nonce_claims, cfg, expected_nonce="nonce123") is False
 
     # Missing nonce when expected_nonce is required
-    missing_nonce_claims = {"aud": "my-client-id", "exp": now + 3600}
+    missing_nonce_claims = {
+        "aud": "my-client-id",
+        "iss": "https://login.ug.kth.se/adfs",
+        "exp": now + 3600,
+    }
     assert validate_id_token_claims(missing_nonce_claims, cfg, expected_nonce="nonce123") is False
 
     # Missing exp claim (OIDC Core 1.0 §2: exp is mandatory)
-    no_exp_claims = {"aud": "my-client-id"}
+    no_exp_claims = {"aud": "my-client-id", "iss": "https://login.ug.kth.se/adfs"}
     assert validate_id_token_claims(no_exp_claims, cfg) is False
 
     # Missing aud claim (OIDC Core 1.0 §2: aud is mandatory)
-    no_aud_claims = {"exp": now + 3600}
+    no_aud_claims = {"iss": "https://login.ug.kth.se/adfs", "exp": now + 3600}
     assert validate_id_token_claims(no_aud_claims, cfg) is False
+
+    # Missing iss claim (OIDC Core 1.0 §2: iss is mandatory)
+    no_iss_claims = {"aud": "my-client-id", "exp": now + 3600}
+    assert validate_id_token_claims(no_iss_claims, cfg) is False
 
 
 def test_decode_and_verify_id_token_rs256_signature():

--- a/tests/test_kth_oidc.py
+++ b/tests/test_kth_oidc.py
@@ -202,11 +202,19 @@ def test_validate_id_token_claims():
     assert validate_id_token_claims(claims, cfg, expected_nonce="nonce123") is True
 
     # Expired token
-    expired_claims = {"aud": "my-client-id", "iss": "https://login.ug.kth.se/adfs", "exp": now - 3600}
+    expired_claims = {
+        "aud": "my-client-id",
+        "iss": "https://login.ug.kth.se/adfs",
+        "exp": now - 3600,
+    }
     assert validate_id_token_claims(expired_claims, cfg) is False
 
     # Audience mismatch
-    bad_aud_claims = {"aud": "wrong-client", "iss": "https://login.ug.kth.se/adfs", "exp": now + 3600}
+    bad_aud_claims = {
+        "aud": "wrong-client",
+        "iss": "https://login.ug.kth.se/adfs",
+        "exp": now + 3600,
+    }
     assert validate_id_token_claims(bad_aud_claims, cfg) is False
 
     # Nonce mismatch

--- a/tests/test_kth_oidc.py
+++ b/tests/test_kth_oidc.py
@@ -262,6 +262,80 @@ def test_decode_and_verify_id_token_rs256_signature():
     assert decode_and_verify_id_token(signed_jwt, cfg, jwks_data={}) is None
 
 
+def test_algorithm_confusion_rejected_by_keyset():
+    """Prove that joserfc rejects algorithm confusion attacks via key type enforcement.
+
+    Background: A classic JWT attack is to forge a token with alg:"none" (skip
+    verification) or alg:"HS256" (use the RSA public key as an HMAC secret).
+    Naive implementations that trust the JWT header's `alg` field are vulnerable.
+
+    joserfc's KeySet.import_key_set + jwt.decode is NOT vulnerable because it
+    selects the verification algorithm based on the *key material* (RSA keys
+    can only verify RSA algorithms), not the attacker-controlled JWT header.
+    This test proves that behaviour, making manual header-parsing unnecessary.
+    """
+    import base64
+    import json
+    import hashlib
+    import hmac
+    import time
+
+    from joserfc.jwk import RSAKey
+
+    from student_bot.web.kth_oidc import decode_and_verify_id_token
+
+    cfg = SSOConfig(client_id="test-client", issuer="https://login.ug.kth.se/adfs")
+
+    # Set up a legitimate RSA key pair and JWKS
+    priv_key = RSAKey.generate_key(2048, {"kid": "key1"})
+    pub_jwk = priv_key.as_dict()
+    jwks_data = {"keys": [pub_jwk]}
+
+    now = int(time.time())
+    payload = {
+        "iss": "https://login.ug.kth.se/adfs",
+        "aud": "test-client",
+        "exp": now + 3600,
+        "kthid": "u100099",
+        "username": "attacker",
+    }
+    payload_json = json.dumps(payload, separators=(",", ":"))
+
+    def b64url(data: bytes) -> str:
+        return base64.urlsafe_b64encode(data).rstrip(b"=").decode("ascii")
+
+    # --- Attack 1: alg:"none" ---
+    # An attacker crafts a token claiming no signature is needed.
+    none_header = b64url(json.dumps({"alg": "none", "kid": "key1"}).encode())
+    none_payload = b64url(payload_json.encode())
+    none_token = f"{none_header}.{none_payload}."
+
+    result = decode_and_verify_id_token(none_token, cfg, jwks_data=jwks_data)
+    assert result is None, "alg:none token must be rejected"
+
+    # --- Attack 2: alg:"HS256" with RSA public key as HMAC secret ---
+    # The attacker takes the public RSA key (available via JWKS) and uses it
+    # as the shared secret for HMAC-SHA256, hoping the verifier will trust
+    # the alg header and verify with the same public key bytes.
+    hs256_header = b64url(json.dumps({"alg": "HS256", "kid": "key1"}).encode())
+    hs256_payload = b64url(payload_json.encode())
+    signing_input = f"{hs256_header}.{hs256_payload}".encode()
+
+    # Use the raw public key JSON as the HMAC secret (standard confusion attack)
+    pub_key_bytes = json.dumps(pub_jwk, separators=(",", ":")).encode()
+    sig = hmac.new(pub_key_bytes, signing_input, hashlib.sha256).digest()
+    hs256_token = f"{hs256_header}.{hs256_payload}.{b64url(sig)}"
+
+    result = decode_and_verify_id_token(hs256_token, cfg, jwks_data=jwks_data)
+    assert result is None, "alg:HS256 token forged with RSA public key must be rejected"
+
+    # --- Attack 3: alg:"HS256" with empty signature ---
+    empty_sig_token = f"{hs256_header}.{hs256_payload}.{b64url(b'')}"
+
+    result = decode_and_verify_id_token(empty_sig_token, cfg, jwks_data=jwks_data)
+    assert result is None, "alg:HS256 token with empty signature must be rejected"
+
+
 def test_exchange_code_for_identity_authlib_client(monkeypatch):
     """Verify exchange_code_for_identity using Authlib AsyncOAuth2Client."""
     import asyncio

--- a/tests/test_kth_oidc.py
+++ b/tests/test_kth_oidc.py
@@ -1,7 +1,10 @@
 """Unit tests for KTH SSO / OIDC authentication module."""
 
 import base64
+from pathlib import Path
+from urllib.parse import parse_qs, urlparse
 
+import pytest
 from fastapi.testclient import TestClient
 
 from student_bot.web.app import create_app
@@ -13,11 +16,26 @@ from student_bot.web.kth_oidc import (
 from student_bot.web.sso_config import SSOConfig
 
 
+@pytest.fixture(autouse=True)
+def mock_oidc_discovery(monkeypatch):
+    """Prevent unit tests from making live network calls to KTH ADFS."""
+
+    async def mock_fetch_metadata(config):
+        return {
+            "authorization_endpoint": f"{config.issuer.rstrip('/')}/oauth2/authorize",
+            "token_endpoint": f"{config.issuer.rstrip('/')}/oauth2/token",
+            "jwks_uri": f"{config.issuer.rstrip('/')}/discovery/keys",
+        }
+
+    monkeypatch.setattr("student_bot.web.kth_oidc.fetch_oidc_metadata", mock_fetch_metadata)
+
+
 def test_sso_config_from_env(monkeypatch):
     monkeypatch.setenv("KTH_OIDC_ENABLED", "true")
     monkeypatch.setenv("KTH_OIDC_CLIENT_ID", "my-app-id")
     monkeypatch.setenv("KTH_OIDC_CLIENT_SECRET", "secret-key")
     monkeypatch.delenv("KTH_OIDC_ISSUER", raising=False)
+    monkeypatch.delenv("KTH_OIDC_TOKEN_AUTH_METHOD", raising=False)
 
     cfg = SSOConfig.from_env()
     assert cfg.enabled is True
@@ -25,6 +43,12 @@ def test_sso_config_from_env(monkeypatch):
     assert cfg.client_secret == "secret-key"
     assert cfg.issuer == "https://login.ug.kth.se/adfs"
     assert cfg.scope == "openid"
+    assert cfg.token_auth_method == "client_secret_basic"
+
+    # Custom auth method from env
+    monkeypatch.setenv("KTH_OIDC_TOKEN_AUTH_METHOD", "client_secret_post")
+    cfg2 = SSOConfig.from_env()
+    assert cfg2.token_auth_method == "client_secret_post"
 
 
 def test_extract_user_identity_privacy_scope():
@@ -60,11 +84,13 @@ def test_build_authorization_url():
         client_id="test-client",
         redirect_uri="http://localhost:8000/auth/kth/callback",
     )
-    url = asyncio.run(build_authorization_url(cfg, state="random-state"))
+    url = asyncio.run(build_authorization_url(cfg, state="random-state", nonce="test-nonce"))
     assert "https://login.ug.kth.se/adfs/oauth2/authorize" in url
     assert "client_id=test-client" in url
     assert "redirect_uri=http%3A%2F%2Flocalhost%3A8000%2Fauth%2Fkth%2Fcallback" in url
     assert "state=random-state" in url
+    assert "response_type=code" in url
+    assert "nonce=test-nonce" in url
 
 
 def test_parse_jwt_payload_unverified():
@@ -142,12 +168,23 @@ def test_sso_callback_grants_access_and_session(monkeypatch):
     monkeypatch.setenv("WEB_AUTH_ENABLED", "true")
     monkeypatch.setenv("WEB_ACCESS_TOKEN", "secretaccess")
 
-    from student_bot.web import sso_routes
+    from student_bot.web import auth, sso_routes
 
     async def mock_exchange(code, config, expected_nonce=None):
         return {"kthid": "u100001", "username": "teststudent"}
 
     monkeypatch.setattr(sso_routes, "exchange_code_for_identity", mock_exchange)
+    # Mock whitelist to include teststudent
+    monkeypatch.setattr(
+        sso_routes,
+        "load_users_file",
+        lambda path: {"teststudent": auth.UserRecord(record="dummy", is_admin=False)},
+    )
+    monkeypatch.setattr(
+        auth,
+        "load_users_file",
+        lambda path: {"teststudent": auth.UserRecord(record="dummy", is_admin=False)},
+    )
 
     app = create_app()
     client = TestClient(app)
@@ -170,6 +207,110 @@ def test_sso_callback_grants_access_and_session(monkeypatch):
     health_resp = client.get("/api/health")
     assert health_resp.status_code == 200
     assert health_resp.json()["status"] == "ok"
+
+
+def test_sso_callback_rejects_unauthorized_user(monkeypatch):
+    """Verify that a user not present in web_users is denied access with 403."""
+    from student_bot.config import get_config
+
+    monkeypatch.setenv("KTH_OIDC_ENABLED", "true")
+    monkeypatch.setenv("KTH_OIDC_CLIENT_ID", "my-client")
+    monkeypatch.setenv("WEB_AUTH_ENABLED", "true")
+    monkeypatch.setenv("WEB_ACCESS_TOKEN", "secretaccess")
+    get_config.cache_clear()
+
+    from student_bot.web import auth, sso_routes
+
+    async def mock_exchange(code, config, expected_nonce=None):
+        return {"kthid": "u999999", "username": "unauthorized_user"}
+
+    monkeypatch.setattr(sso_routes, "exchange_code_for_identity", mock_exchange)
+    # Whitelist does NOT contain unauthorized_user
+    monkeypatch.setattr(
+        sso_routes,
+        "load_users_file",
+        lambda path: {"allowed_user": auth.UserRecord(record="dummy", is_admin=False)},
+    )
+
+    app = create_app()
+    client = TestClient(app)
+
+    login_resp = client.get("/auth/kth/login", follow_redirects=False)
+    state = parse_qs(urlparse(login_resp.headers["location"]).query)["state"][0]
+
+    cb_resp = client.get(f"/auth/kth/callback?code=testcode&state={state}", follow_redirects=False)
+    assert cb_resp.status_code == 403
+    assert "Åtkomst nekad" in cb_resp.text
+    assert "unauthorized_user" in cb_resp.text
+
+    # Verify that session is not authorized for index (redirected to login)
+    index_resp = client.get("/", follow_redirects=False)
+    assert index_resp.status_code == 307
+
+    # Verify that session is not authorized for protected endpoints
+    health_resp = client.get("/api/health")
+    assert health_resp.status_code == 403
+
+
+def test_sso_callback_allows_match_by_kthid(monkeypatch):
+    """Verify that matching against web_users works when kthid is used instead of username."""
+    monkeypatch.setenv("KTH_OIDC_ENABLED", "true")
+    monkeypatch.setenv("KTH_OIDC_CLIENT_ID", "my-client")
+
+    from student_bot.web import auth, sso_routes
+
+    async def mock_exchange(code, config, expected_nonce=None):
+        return {"kthid": "u100042", "username": "some_other_alias"}
+
+    monkeypatch.setattr(sso_routes, "exchange_code_for_identity", mock_exchange)
+    # Whitelist has u100042 (kthid)
+    monkeypatch.setattr(
+        sso_routes,
+        "load_users_file",
+        lambda path: {"u100042": auth.UserRecord(record="dummy", is_admin=False)},
+    )
+
+    app = create_app()
+    client = TestClient(app)
+
+    login_resp = client.get("/auth/kth/login", follow_redirects=False)
+    state = parse_qs(urlparse(login_resp.headers["location"]).query)["state"][0]
+
+    cb_resp = client.get(f"/auth/kth/callback?code=testcode&state={state}", follow_redirects=False)
+    assert cb_resp.status_code == 303
+
+
+def test_require_access_enforces_whitelist_for_kth_session():
+    """Verify require_access rejects kth_user if removed from web_users."""
+    from unittest.mock import MagicMock, patch
+    from fastapi import HTTPException
+    from student_bot.web.auth import UserRecord, require_access
+
+    cfg = MagicMock()
+    cfg.web.auth_enabled = True
+    cfg.web.users_file = "data/web_users"
+    cfg.absolute.return_value = Path("/nonexistent/data/web_users")
+
+    # Request with kth_user in session
+    req = MagicMock()
+    req.session = {"kth_user": {"username": "revoked_user", "kthid": "u12345"}}
+
+    # Mock load_users_file returning empty dict (user revoked or missing)
+    with patch("student_bot.web.auth.load_users_file", return_value={}):
+        with pytest.raises(HTTPException) as exc_info:
+            require_access(req, cfg)
+        assert exc_info.value.status_code == 403
+        assert "Åtkomst nekad" in exc_info.value.detail
+
+    # Mock load_users_file returning user
+    with patch(
+        "student_bot.web.auth.load_users_file",
+        return_value={"revoked_user": UserRecord(record="dummy", is_admin=True)},
+    ):
+        ctx = require_access(req, cfg)
+        assert ctx.enabled is True
+        assert ctx.user == "kth:revoked_user"
+        assert ctx.is_admin is True
 
 
 def test_extract_user_identity_base64_encoded_attributes():
@@ -196,15 +337,61 @@ def test_validate_id_token_claims():
     claims = {
         "aud": "my-client-id",
         "iss": "https://login.ug.kth.se/adfs",
+        "sub": "u100001",
+        "iat": int(now),
         "exp": now + 3600,
         "nonce": "nonce123",
     }
     assert validate_id_token_claims(claims, cfg, expected_nonce="nonce123") is True
 
+    # Valid claims with ADFS default userinfo audience
+    userinfo_aud_claims = {
+        "aud": "urn:microsoft:userinfo",
+        "iss": "https://login.ug.kth.se/adfs",
+        "sub": "u100001",
+        "iat": int(now),
+        "exp": now + 3600,
+    }
+    assert validate_id_token_claims(userinfo_aud_claims, cfg) is True
+
+    # Valid claims with ADFS access_token issuer format (http + /services/trust)
+    adfs_iss_claims = {
+        "aud": "my-client-id",
+        "iss": "http://login.ug.kth.se/adfs/services/trust",
+        "sub": "u100001",
+        "iat": int(now),
+        "exp": now + 3600,
+    }
+    assert validate_id_token_claims(adfs_iss_claims, cfg) is True
+
+    # Valid auth_time claim
+    auth_time_claims = {
+        "aud": "my-client-id",
+        "iss": "https://login.ug.kth.se/adfs",
+        "sub": "u100001",
+        "iat": int(now),
+        "exp": now + 3600,
+        "auth_time": int(now) - 60,
+    }
+    assert validate_id_token_claims(auth_time_claims, cfg) is True
+
+    # Invalid non-numeric auth_time claim
+    bad_auth_time_claims = {
+        "aud": "my-client-id",
+        "iss": "https://login.ug.kth.se/adfs",
+        "sub": "u100001",
+        "iat": int(now),
+        "exp": now + 3600,
+        "auth_time": "not-a-timestamp",
+    }
+    assert validate_id_token_claims(bad_auth_time_claims, cfg) is False
+
     # Expired token
     expired_claims = {
         "aud": "my-client-id",
         "iss": "https://login.ug.kth.se/adfs",
+        "sub": "u100001",
+        "iat": int(now),
         "exp": now - 3600,
     }
     assert validate_id_token_claims(expired_claims, cfg) is False
@@ -213,6 +400,8 @@ def test_validate_id_token_claims():
     bad_aud_claims = {
         "aud": "wrong-client",
         "iss": "https://login.ug.kth.se/adfs",
+        "sub": "u100001",
+        "iat": int(now),
         "exp": now + 3600,
     }
     assert validate_id_token_claims(bad_aud_claims, cfg) is False
@@ -221,30 +410,67 @@ def test_validate_id_token_claims():
     bad_nonce_claims = {
         "aud": "my-client-id",
         "iss": "https://login.ug.kth.se/adfs",
+        "sub": "u100001",
+        "iat": int(now),
         "exp": now + 3600,
         "nonce": "wrongnonce",
     }
     assert validate_id_token_claims(bad_nonce_claims, cfg, expected_nonce="nonce123") is False
 
-    # Missing nonce when expected_nonce is required
+    # Missing nonce when expected_nonce is passed: logs a warning but succeeds (ADFS access_token compatibility)
     missing_nonce_claims = {
         "aud": "my-client-id",
         "iss": "https://login.ug.kth.se/adfs",
+        "sub": "u100001",
+        "iat": int(now),
         "exp": now + 3600,
     }
-    assert validate_id_token_claims(missing_nonce_claims, cfg, expected_nonce="nonce123") is False
+    assert validate_id_token_claims(missing_nonce_claims, cfg, expected_nonce="nonce123") is True
 
     # Missing exp claim (OIDC Core 1.0 §2: exp is mandatory)
-    no_exp_claims = {"aud": "my-client-id", "iss": "https://login.ug.kth.se/adfs"}
+    no_exp_claims = {
+        "aud": "my-client-id",
+        "iss": "https://login.ug.kth.se/adfs",
+        "sub": "u100001",
+        "iat": int(now),
+    }
     assert validate_id_token_claims(no_exp_claims, cfg) is False
 
     # Missing aud claim (OIDC Core 1.0 §2: aud is mandatory)
-    no_aud_claims = {"iss": "https://login.ug.kth.se/adfs", "exp": now + 3600}
+    no_aud_claims = {
+        "iss": "https://login.ug.kth.se/adfs",
+        "sub": "u100001",
+        "iat": int(now),
+        "exp": now + 3600,
+    }
     assert validate_id_token_claims(no_aud_claims, cfg) is False
 
     # Missing iss claim (OIDC Core 1.0 §2: iss is mandatory)
-    no_iss_claims = {"aud": "my-client-id", "exp": now + 3600}
+    no_iss_claims = {
+        "aud": "my-client-id",
+        "sub": "u100001",
+        "iat": int(now),
+        "exp": now + 3600,
+    }
     assert validate_id_token_claims(no_iss_claims, cfg) is False
+
+    # Missing sub claim
+    no_sub_claims = {
+        "aud": "my-client-id",
+        "iss": "https://login.ug.kth.se/adfs",
+        "iat": int(now),
+        "exp": now + 3600,
+    }
+    assert validate_id_token_claims(no_sub_claims, cfg) is False
+
+    # Missing iat claim
+    no_iat_claims = {
+        "aud": "my-client-id",
+        "iss": "https://login.ug.kth.se/adfs",
+        "sub": "u100001",
+        "exp": now + 3600,
+    }
+    assert validate_id_token_claims(no_iat_claims, cfg) is False
 
 
 def test_decode_and_verify_id_token_rs256_signature():
@@ -267,6 +493,8 @@ def test_decode_and_verify_id_token_rs256_signature():
     payload = {
         "iss": "https://login.ug.kth.se/adfs",
         "aud": "test-client",
+        "sub": "u100099",
+        "iat": now,
         "exp": now + 3600,
         "kthid": "u100099",
         "username": "teststudent",
@@ -391,6 +619,8 @@ def test_exchange_code_for_identity_authlib_client(monkeypatch):
     payload = {
         "iss": "https://login.ug.kth.se/adfs",
         "aud": "test-client",
+        "sub": "u100088",
+        "iat": now,
         "exp": now + 3600,
         "kthid": "u100088",
         "username": "authlibuser",
@@ -416,3 +646,125 @@ def test_exchange_code_for_identity_authlib_client(monkeypatch):
 
     identity = asyncio.run(kth_oidc.exchange_code_for_identity("testcode", cfg))
     assert identity == {"kthid": "u100088", "username": "authlibuser"}
+
+
+def test_exchange_code_for_identity_custom_auth_method(monkeypatch):
+    """Verify exchange_code_for_identity respects configured token_auth_method."""
+    import asyncio
+    import time
+
+    from authlib.integrations.httpx_client import AsyncOAuth2Client
+    from joserfc import jwt
+    from joserfc.jwk import RSAKey
+
+    from student_bot.web import kth_oidc
+
+    captured_kwargs = {}
+    original_init = AsyncOAuth2Client.__init__
+
+    def wrapped_init(self, *args, **kwargs):
+        captured_kwargs.update(kwargs)
+        original_init(self, *args, **kwargs)
+
+    monkeypatch.setattr(AsyncOAuth2Client, "__init__", wrapped_init)
+
+    cfg = SSOConfig(
+        enabled=True,
+        client_id="test-client",
+        client_secret="test-secret",
+        token_auth_method="client_secret_post",
+        issuer="https://login.ug.kth.se/adfs",
+    )
+
+    priv_key = RSAKey.generate_key(2048, {"kid": "key1"})
+    pub_jwk = priv_key.as_dict()
+    jwks_data = {"keys": [pub_jwk]}
+
+    now = int(time.time())
+    payload = {
+        "iss": "https://login.ug.kth.se/adfs",
+        "aud": "test-client",
+        "sub": "u100088",
+        "iat": now,
+        "exp": now + 3600,
+        "kthid": "u100088",
+        "username": "authlibuser",
+    }
+    id_token = jwt.encode({"alg": "RS256", "kid": "key1"}, payload, priv_key)
+
+    async def mock_fetch_metadata(c):
+        return {
+            "token_endpoint": "https://login.ug.kth.se/adfs/oauth2/token",
+            "jwks_uri": "https://login.ug.kth.se/adfs/discovery/keys",
+        }
+
+    async def mock_fetch_jwks(uri):
+        return jwks_data
+
+    monkeypatch.setattr(kth_oidc, "fetch_oidc_metadata", mock_fetch_metadata)
+    monkeypatch.setattr(kth_oidc, "fetch_jwks", mock_fetch_jwks)
+
+    async def mock_fetch_token(self, url, code=None, grant_type=None, **kwargs):
+        return {"id_token": id_token, "access_token": "acc123", "token_type": "Bearer"}
+
+    monkeypatch.setattr(AsyncOAuth2Client, "fetch_token", mock_fetch_token)
+
+    asyncio.run(kth_oidc.exchange_code_for_identity("testcode", cfg))
+    assert captured_kwargs.get("token_endpoint_auth_method") == "client_secret_post"
+
+
+def test_exchange_code_fallback_to_access_token(monkeypatch):
+    """Verify exchange_code_for_identity extracts claims from access_token if id_token is omitted (ADFS mode)."""
+    import asyncio
+    import time
+
+    from authlib.integrations.httpx_client import AsyncOAuth2Client
+    from joserfc import jwt
+    from joserfc.jwk import RSAKey
+
+    from student_bot.web import kth_oidc
+
+    cfg = SSOConfig(
+        enabled=True,
+        client_id="test-client",
+        client_secret="test-secret",
+        redirect_uri="http://localhost:8000/auth/kth/callback",
+        issuer="https://login.ug.kth.se/adfs",
+    )
+
+    priv_key = RSAKey.generate_key(2048, {"kid": "key1"})
+    pub_jwk = priv_key.as_dict()
+    jwks_data = {"keys": [pub_jwk]}
+
+    now = int(time.time())
+    payload = {
+        "iss": "https://login.ug.kth.se/adfs",
+        "aud": "urn:microsoft:userinfo",
+        "sub": "u100077",
+        "iat": now,
+        "exp": now + 3600,
+        "kthid": "u100077",
+        "username": "adfsuser",
+    }
+    access_token_jwt = jwt.encode({"alg": "RS256", "kid": "key1"}, payload, priv_key)
+
+    async def mock_fetch_metadata(c):
+        return {
+            "token_endpoint": "https://login.ug.kth.se/adfs/oauth2/token",
+            "jwks_uri": "https://login.ug.kth.se/adfs/discovery/keys",
+        }
+
+    async def mock_fetch_jwks(uri):
+        return jwks_data
+
+    monkeypatch.setattr(kth_oidc, "fetch_oidc_metadata", mock_fetch_metadata)
+    monkeypatch.setattr(kth_oidc, "fetch_jwks", mock_fetch_jwks)
+
+    # Simulate KTH ADFS returning ONLY access_token and no id_token
+    async def mock_fetch_token(self, url, code=None, grant_type=None, **kwargs):
+        return {"access_token": access_token_jwt, "token_type": "Bearer"}
+
+    monkeypatch.setattr(AsyncOAuth2Client, "fetch_token", mock_fetch_token)
+
+    identity = asyncio.run(kth_oidc.exchange_code_for_identity("testcode", cfg))
+    assert identity == {"kthid": "u100077", "username": "adfsuser"}

--- a/tests/test_kth_oidc.py
+++ b/tests/test_kth_oidc.py
@@ -17,6 +17,7 @@ def test_sso_config_from_env(monkeypatch):
     monkeypatch.setenv("KTH_OIDC_ENABLED", "true")
     monkeypatch.setenv("KTH_OIDC_CLIENT_ID", "my-app-id")
     monkeypatch.setenv("KTH_OIDC_CLIENT_SECRET", "secret-key")
+    monkeypatch.delenv("KTH_OIDC_ISSUER", raising=False)
 
     cfg = SSOConfig.from_env()
     assert cfg.enabled is True
@@ -77,7 +78,8 @@ def test_parse_jwt_payload_unverified():
     assert claims == {"kthid": "u999", "username": "testuser"}
 
 
-def test_sso_routes_disabled_by_default():
+def test_sso_routes_disabled_by_default(monkeypatch):
+    monkeypatch.setenv("KTH_OIDC_ENABLED", "false")
     app = create_app()
     client = TestClient(app)
 
@@ -88,6 +90,7 @@ def test_sso_routes_disabled_by_default():
 
 def test_sso_login_route_redirect(monkeypatch):
     monkeypatch.setenv("KTH_OIDC_ENABLED", "true")
+    monkeypatch.setenv("KTH_OIDC_ISSUER", "https://login.ug.kth.se/adfs")
     monkeypatch.setenv("KTH_OIDC_CLIENT_ID", "my-client")
 
     app = create_app()
@@ -137,7 +140,7 @@ def test_sso_callback_grants_access_and_session(monkeypatch):
     monkeypatch.setenv("WEB_AUTH_ENABLED", "true")
     monkeypatch.setenv("WEB_ACCESS_TOKEN", "secretaccess")
 
-    import student_bot.web.sso_routes as sso_routes
+    from student_bot.web import sso_routes
 
     async def mock_exchange(code, config, expected_nonce=None):
         return {"kthid": "u100001", "username": "teststudent"}
@@ -181,6 +184,7 @@ def test_extract_user_identity_base64_encoded_attributes():
 def test_validate_id_token_claims():
     """Verify exp, aud, and nonce validation for ID tokens."""
     import time
+
     from student_bot.web.kth_oidc import validate_id_token_claims
 
     cfg = SSOConfig(client_id="my-client-id")
@@ -201,5 +205,117 @@ def test_validate_id_token_claims():
     # Nonce mismatch
     bad_nonce_claims = {"aud": "my-client-id", "exp": now + 3600, "nonce": "wrongnonce"}
     assert validate_id_token_claims(bad_nonce_claims, cfg, expected_nonce="nonce123") is False
+
+    # Missing nonce when expected_nonce is required
+    missing_nonce_claims = {"aud": "my-client-id", "exp": now + 3600}
+    assert validate_id_token_claims(missing_nonce_claims, cfg, expected_nonce="nonce123") is False
+
+    # Missing exp claim (OIDC Core 1.0 §2: exp is mandatory)
+    no_exp_claims = {"aud": "my-client-id"}
+    assert validate_id_token_claims(no_exp_claims, cfg) is False
+
+    # Missing aud claim (OIDC Core 1.0 §2: aud is mandatory)
+    no_aud_claims = {"exp": now + 3600}
+    assert validate_id_token_claims(no_aud_claims, cfg) is False
+
+
+def test_decode_and_verify_id_token_rs256_signature():
+    """Verify RS256 signature verification with standard joserfc JWKS."""
+    import time
+
+    from joserfc import jwt
+    from joserfc.jwk import RSAKey
+
+    from student_bot.web.kth_oidc import decode_and_verify_id_token
+
+    cfg = SSOConfig(client_id="test-client", issuer="https://login.ug.kth.se/adfs")
+
+    # Generate RSA Key Pair
+    priv_key = RSAKey.generate_key(2048, {"kid": "key1"})
+    pub_jwk = priv_key.as_dict()
+    jwks_data = {"keys": [pub_jwk]}
+
+    now = int(time.time())
+    payload = {
+        "iss": "https://login.ug.kth.se/adfs",
+        "aud": "test-client",
+        "exp": now + 3600,
+        "kthid": "u100099",
+        "username": "teststudent",
+    }
+    signed_jwt = jwt.encode({"alg": "RS256", "kid": "key1"}, payload, priv_key)
+
+    # 1. Verification with matching JWKS key set succeeds
+    verified_claims = decode_and_verify_id_token(signed_jwt, cfg, jwks_data=jwks_data)
+    assert verified_claims is not None
+    assert verified_claims["kthid"] == "u100099"
+    assert verified_claims["username"] == "teststudent"
+
+    # 2. Forged signature (tampered payload or wrong key) is strictly rejected
+    other_priv_key = RSAKey.generate_key(2048, {"kid": "key1"})
+    forged_jwt = jwt.encode({"alg": "RS256", "kid": "key1"}, payload, other_priv_key)
+    rejected_claims = decode_and_verify_id_token(forged_jwt, cfg, jwks_data=jwks_data)
+    assert rejected_claims is None
+
+    # 3. Missing or invalid JWKS data is fail-closed (returns None)
+    assert decode_and_verify_id_token(signed_jwt, cfg, jwks_data=None) is None
+    assert decode_and_verify_id_token(signed_jwt, cfg, jwks_data={}) is None
+
+
+def test_exchange_code_for_identity_authlib_client(monkeypatch):
+    """Verify exchange_code_for_identity using Authlib AsyncOAuth2Client."""
+    import asyncio
+    import time
+
+    from authlib.integrations.httpx_client import AsyncOAuth2Client
+    from joserfc import jwt
+    from joserfc.jwk import RSAKey
+
+    from student_bot.web import kth_oidc
+
+    cfg = SSOConfig(
+        enabled=True,
+        client_id="test-client",
+        client_secret="test-secret",
+        redirect_uri="http://localhost:8000/auth/kth/callback",
+        issuer="https://login.ug.kth.se/adfs",
+    )
+
+    priv_key = RSAKey.generate_key(2048, {"kid": "key1"})
+    pub_jwk = priv_key.as_dict()
+    jwks_data = {"keys": [pub_jwk]}
+
+    now = int(time.time())
+    payload = {
+        "iss": "https://login.ug.kth.se/adfs",
+        "aud": "test-client",
+        "exp": now + 3600,
+        "kthid": "u100088",
+        "username": "authlibuser",
+    }
+    id_token = jwt.encode({"alg": "RS256", "kid": "key1"}, payload, priv_key)
+
+    async def mock_fetch_metadata(c):
+        return {
+            "token_endpoint": "https://login.ug.kth.se/adfs/oauth2/token",
+            "jwks_uri": "https://login.ug.kth.se/adfs/discovery/keys",
+        }
+
+    async def mock_fetch_jwks(uri):
+        return jwks_data
+
+    monkeypatch.setattr(kth_oidc, "fetch_oidc_metadata", mock_fetch_metadata)
+    monkeypatch.setattr(kth_oidc, "fetch_jwks", mock_fetch_jwks)
+
+    async def mock_fetch_token(self, url, code=None, grant_type=None, **kwargs):
+        return {"id_token": id_token, "access_token": "acc123", "token_type": "Bearer"}
+
+    monkeypatch.setattr(AsyncOAuth2Client, "fetch_token", mock_fetch_token)
+
+    identity = asyncio.run(kth_oidc.exchange_code_for_identity("testcode", cfg))
+    assert identity == {"kthid": "u100088", "username": "authlibuser"}
+
+
+
 
 

--- a/uv.lock
+++ b/uv.lock
@@ -69,15 +69,6 @@ wheels = [
 ]
 
 [[package]]
-name = "asgiref"
-version = "3.11.1"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/63/40/f03da1264ae8f7cfdbf9146542e5e7e8100a4c66ab48e791df9a03d3f6c0/asgiref-3.11.1.tar.gz", hash = "sha256:5f184dc43b7e763efe848065441eac62229c9f7b0475f41f80e207a114eda4ce", size = 38550, upload-time = "2026-02-03T13:30:14.33Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/5c/0a/a72d10ed65068e115044937873362e6e32fab1b7dce0046aeb224682c989/asgiref-3.11.1-py3-none-any.whl", hash = "sha256:e8667a091e69529631969fd45dc268fa79b99c92c5fcdda727757e52146ec133", size = 24345, upload-time = "2026-02-03T13:30:13.039Z" },
-]
-
-[[package]]
 name = "attrs"
 version = "26.1.0"
 source = { registry = "https://pypi.org/simple" }
@@ -97,15 +88,6 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/36/98/7d93f30d029643c0275dbc0bd6d5a6f670661ee6c9a94d93af7ab4887600/authlib-1.7.2.tar.gz", hash = "sha256:2cea25fefcd4e7173bdf1372c0afc265c8034b23a8cd5dcb6a9164b826c64231", size = 176511, upload-time = "2026-05-06T08:10:23.116Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/fb/95/adcb68e20c34162e9135f370d6e31737719c2b6f94bc953fe7ed1f10fe21/authlib-1.7.2-py2.py3-none-any.whl", hash = "sha256:3e1faedc9d87e7d56a164eca3ccb6ace0d61b94abe83e92242f8dc8bba9b4a9f", size = 259548, upload-time = "2026-05-06T08:10:21.436Z" },
-]
-
-[[package]]
-name = "backoff"
-version = "2.2.1"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/47/d7/5bbeb12c44d7c4f2fb5b56abce497eb5ed9f34d85701de869acedd602619/backoff-2.2.1.tar.gz", hash = "sha256:03f829f5bb1923180821643f8753b0502c3b682293992485b0eef2807afa5cba", size = 17001, upload-time = "2022-10-05T19:19:32.061Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/df/73/b6e24bd22e6720ca8ee9a85a0c4a2971af8497d8f3193fa05390cbd46e09/backoff-2.2.1-py3-none-any.whl", hash = "sha256:63579f9a0628e06278f7e47b7d7d5b6ce20dc65c5e96a6f3ca99a6adca0396e8", size = 15148, upload-time = "2022-10-05T19:19:30.546Z" },
 ]
 
 [[package]]
@@ -264,49 +246,28 @@ wheels = [
 ]
 
 [[package]]
-name = "chroma-hnswlib"
-version = "0.7.6"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "numpy" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/73/09/10d57569e399ce9cbc5eee2134996581c957f63a9addfa6ca657daf006b8/chroma_hnswlib-0.7.6.tar.gz", hash = "sha256:4dce282543039681160259d29fcde6151cc9106c6461e0485f57cdccd83059b7", size = 32256, upload-time = "2024-07-22T20:19:29.259Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/f5/af/d15fdfed2a204c0f9467ad35084fbac894c755820b203e62f5dcba2d41f1/chroma_hnswlib-0.7.6-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:81181d54a2b1e4727369486a631f977ffc53c5533d26e3d366dda243fb0998ca", size = 196911, upload-time = "2024-07-22T20:18:33.46Z" },
-    { url = "https://files.pythonhosted.org/packages/0d/19/aa6f2139f1ff7ad23a690ebf2a511b2594ab359915d7979f76f3213e46c4/chroma_hnswlib-0.7.6-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:4b4ab4e11f1083dd0a11ee4f0e0b183ca9f0f2ed63ededba1935b13ce2b3606f", size = 185000, upload-time = "2024-07-22T20:18:36.16Z" },
-    { url = "https://files.pythonhosted.org/packages/79/b1/1b269c750e985ec7d40b9bbe7d66d0a890e420525187786718e7f6b07913/chroma_hnswlib-0.7.6-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:53db45cd9173d95b4b0bdccb4dbff4c54a42b51420599c32267f3abbeb795170", size = 2377289, upload-time = "2024-07-22T20:18:37.761Z" },
-    { url = "https://files.pythonhosted.org/packages/c7/2d/d5663e134436e5933bc63516a20b5edc08b4c1b1588b9680908a5f1afd04/chroma_hnswlib-0.7.6-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:5c093f07a010b499c00a15bc9376036ee4800d335360570b14f7fe92badcdcf9", size = 2411755, upload-time = "2024-07-22T20:18:39.949Z" },
-    { url = "https://files.pythonhosted.org/packages/3e/79/1bce519cf186112d6d5ce2985392a89528c6e1e9332d680bf752694a4cdf/chroma_hnswlib-0.7.6-cp311-cp311-win_amd64.whl", hash = "sha256:0540b0ac96e47d0aa39e88ea4714358ae05d64bbe6bf33c52f316c664190a6a3", size = 151888, upload-time = "2024-07-22T20:18:45.003Z" },
-    { url = "https://files.pythonhosted.org/packages/93/ac/782b8d72de1c57b64fdf5cb94711540db99a92768d93d973174c62d45eb8/chroma_hnswlib-0.7.6-cp312-cp312-macosx_10_9_x86_64.whl", hash = "sha256:e87e9b616c281bfbe748d01705817c71211613c3b063021f7ed5e47173556cb7", size = 197804, upload-time = "2024-07-22T20:18:46.442Z" },
-    { url = "https://files.pythonhosted.org/packages/32/4e/fd9ce0764228e9a98f6ff46af05e92804090b5557035968c5b4198bc7af9/chroma_hnswlib-0.7.6-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:ec5ca25bc7b66d2ecbf14502b5729cde25f70945d22f2aaf523c2d747ea68912", size = 185421, upload-time = "2024-07-22T20:18:47.72Z" },
-    { url = "https://files.pythonhosted.org/packages/d9/3d/b59a8dedebd82545d873235ef2d06f95be244dfece7ee4a1a6044f080b18/chroma_hnswlib-0.7.6-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:305ae491de9d5f3c51e8bd52d84fdf2545a4a2bc7af49765cda286b7bb30b1d4", size = 2389672, upload-time = "2024-07-22T20:18:49.583Z" },
-    { url = "https://files.pythonhosted.org/packages/74/1e/80a033ea4466338824974a34f418e7b034a7748bf906f56466f5caa434b0/chroma_hnswlib-0.7.6-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:822ede968d25a2c88823ca078a58f92c9b5c4142e38c7c8b4c48178894a0a3c5", size = 2436986, upload-time = "2024-07-22T20:18:51.872Z" },
-]
-
-[[package]]
 name = "chromadb"
-version = "0.5.23"
+version = "1.5.9"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "bcrypt" },
     { name = "build" },
-    { name = "chroma-hnswlib" },
-    { name = "fastapi" },
     { name = "grpcio" },
     { name = "httpx" },
     { name = "importlib-resources" },
+    { name = "jsonschema" },
     { name = "kubernetes" },
     { name = "mmh3" },
     { name = "numpy" },
     { name = "onnxruntime" },
     { name = "opentelemetry-api" },
     { name = "opentelemetry-exporter-otlp-proto-grpc" },
-    { name = "opentelemetry-instrumentation-fastapi" },
     { name = "opentelemetry-sdk" },
     { name = "orjson" },
     { name = "overrides" },
-    { name = "posthog" },
+    { name = "pybase64" },
     { name = "pydantic" },
+    { name = "pydantic-settings" },
     { name = "pypika" },
     { name = "pyyaml" },
     { name = "rich" },
@@ -317,9 +278,13 @@ dependencies = [
     { name = "typing-extensions" },
     { name = "uvicorn", extra = ["standard"] },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/42/64/28daa773f784bcd18de944fe26ed301de844d6ee17188e26a9d6b4baf122/chromadb-0.5.23.tar.gz", hash = "sha256:360a12b9795c5a33cb1f839d14410ccbde662ef1accd36153b0ae22312edabd1", size = 33700455, upload-time = "2024-12-05T06:31:19.81Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/92/d1/5e33b26985f0c7046a0be1cee2158ada1748ee700d2545057fde1468d74d/chromadb-1.5.9.tar.gz", hash = "sha256:5c20e62a455c28bacac927f26116a73fd8e1799e0d908be8e8a4f02197a54731", size = 2595635, upload-time = "2026-05-05T05:54:51.713Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/92/8c/a9eb95a28e6c35a0122417976a9d435eeaceb53f596a8973e33b3dd4cfac/chromadb-0.5.23-py3-none-any.whl", hash = "sha256:ffe5bdd7276d12cb682df0d38a13aa37573e6a3678e71889ac45f539ae05ad7e", size = 628347, upload-time = "2024-12-05T06:31:17.231Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/5b/3cced915244f43ed14b53fe9f63a37f05f865064f4e4fe7d9448d3f2a352/chromadb-1.5.9-cp39-abi3-macosx_10_12_x86_64.whl", hash = "sha256:60701011b5e6409647fa40d12c7c5a66b2b0bfcf33a52db2ad53a30a2abc4957", size = 22564540, upload-time = "2026-05-05T05:54:48.906Z" },
+    { url = "https://files.pythonhosted.org/packages/34/4c/adcef1f4e82a2ef69ccd3711d55fc289193d54c4c0ff7a0292a3631db46f/chromadb-1.5.9-cp39-abi3-macosx_11_0_arm64.whl", hash = "sha256:814b9c95617377f6501e5757d63dfddb554a283a7739c87b9fa573850174e6f3", size = 21699698, upload-time = "2026-05-05T05:54:45.078Z" },
+    { url = "https://files.pythonhosted.org/packages/38/4e/937bc4d2e6f8ab9664ec79931fbbd69efff47e513ec2924b071e4b0ff774/chromadb-1.5.9-cp39-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:9192d111bd662241625867962333d99369a00769a50f8b2f58cb388731274d7e", size = 22680924, upload-time = "2026-05-05T05:54:36.25Z" },
+    { url = "https://files.pythonhosted.org/packages/e6/ec/0c42039e80b9acc534f67b73b7a42471948042859b3a64867b50a4a77fa3/chromadb-1.5.9-cp39-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:cc09b3df76e5a5cb386aed2715a2eea152e3949f9e1ba93c7119505377749929", size = 23316203, upload-time = "2026-05-05T05:54:41.157Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/ce/0f7be6e5d0feafa2cda54b12e6542afeea7dea89d2d411e14da90f8abb96/chromadb-1.5.9-cp39-abi3-win_amd64.whl", hash = "sha256:4fd0b560e56761b7f3cb4d5c6205fd5f20814484b4a3e4e9af9038c2b428fc6c", size = 23542454, upload-time = "2026-05-05T05:54:54.942Z" },
 ]
 
 [[package]]
@@ -414,15 +379,6 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/81/e1/56027a71e31b02ddc53c7d65b01e68edf64dea2932122fe7746a516f75d5/dill-0.4.1.tar.gz", hash = "sha256:423092df4182177d4d8ba8290c8a5b640c66ab35ec7da59ccfa00f6fa3eea5fa", size = 187315, upload-time = "2026-01-19T02:36:56.85Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/1e/77/dc8c558f7593132cf8fefec57c4f60c83b16941c574ac5f619abb3ae7933/dill-0.4.1-py3-none-any.whl", hash = "sha256:1e1ce33e978ae97fcfcff5638477032b801c46c7c65cf717f95fbc2248f79a9d", size = 120019, upload-time = "2026-01-19T02:36:55.663Z" },
-]
-
-[[package]]
-name = "distro"
-version = "1.9.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/fc/f8/98eea607f65de6527f8a2e8885fc8015d3e6f5775df186e443e0964a11c3/distro-1.9.0.tar.gz", hash = "sha256:2fa77c6fd8940f116ee1d6b94a2f90b13b5ea8d019b98bc8bafdcabcdd9bdbed", size = 60722, upload-time = "2023-12-24T09:54:32.31Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/12/b3/231ffd4ab1fc9d679809f356cebee130ac7daa00d6d6f3206dd4fd137e9e/distro-1.9.0-py3-none-any.whl", hash = "sha256:7bffd925d65168f85027d8da9af6bddab658135b840670a223589bc0c8ef02b2", size = 20277, upload-time = "2023-12-24T09:54:30.421Z" },
 ]
 
 [[package]]
@@ -770,21 +726,22 @@ wheels = [
 
 [[package]]
 name = "huggingface-hub"
-version = "0.36.2"
+version = "1.16.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "filelock" },
     { name = "fsspec" },
-    { name = "hf-xet", marker = "platform_machine == 'aarch64' or platform_machine == 'amd64' or platform_machine == 'arm64' or platform_machine == 'x86_64'" },
+    { name = "hf-xet", marker = "platform_machine == 'AMD64' or platform_machine == 'aarch64' or platform_machine == 'amd64' or platform_machine == 'arm64' or platform_machine == 'x86_64'" },
+    { name = "httpx" },
     { name = "packaging" },
     { name = "pyyaml" },
-    { name = "requests" },
     { name = "tqdm" },
+    { name = "typer" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/7c/b7/8cb61d2eece5fb05a83271da168186721c450eb74e3c31f7ef3169fa475b/huggingface_hub-0.36.2.tar.gz", hash = "sha256:1934304d2fb224f8afa3b87007d58501acfda9215b334eed53072dd5e815ff7a", size = 649782, upload-time = "2026-02-06T09:24:13.098Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/48/0f/ed994dbade67a54407c28cab96ef845e0e6d25500be56aca6394f8bfc9dd/huggingface_hub-1.16.1.tar.gz", hash = "sha256:7f1dc4c5ec21aed69be630ad0c3378616be16f3de1a47b141c0e812965d9c832", size = 792534, upload-time = "2026-05-21T18:40:00.908Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/a8/af/48ac8483240de756d2438c380746e7130d1c6f75802ef22f3c6d49982787/huggingface_hub-0.36.2-py3-none-any.whl", hash = "sha256:48f0c8eac16145dfce371e9d2d7772854a4f591bcb56c9cf548accf531d54270", size = 566395, upload-time = "2026-02-06T09:24:11.133Z" },
+    { url = "https://files.pythonhosted.org/packages/49/79/621a7dbb80c70974f73a597275351ebe03ce5bc65cb5f8f4acb5859252bc/huggingface_hub-1.16.1-py3-none-any.whl", hash = "sha256:64340de934b9ce37857ef85a82de72f5629e8a270f9119eabb12bf495eb53c22", size = 668176, upload-time = "2026-05-21T18:39:58.596Z" },
 ]
 
 [[package]]
@@ -1384,53 +1341,6 @@ wheels = [
 ]
 
 [[package]]
-name = "opentelemetry-instrumentation"
-version = "0.62b1"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "opentelemetry-api" },
-    { name = "opentelemetry-semantic-conventions" },
-    { name = "packaging" },
-    { name = "wrapt" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/52/cb/0523b92c112a6cc70be43724343dc45225d3af134419844d7879a07755d4/opentelemetry_instrumentation-0.62b1.tar.gz", hash = "sha256:90e92a905ba4f84db06ac3aec96701df6c079b2d66e9379f8739f0a1bdcc7f45", size = 34043, upload-time = "2026-04-24T13:22:31.997Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/4d/0f/45adbaea1f81b847cffdcee4f4b5f89297e42facf7fac78c7aaac4c38e75/opentelemetry_instrumentation-0.62b1-py3-none-any.whl", hash = "sha256:976fc6e640f2006599e97429c949e622c108d0c17c2059347d1e6c93c707f257", size = 34163, upload-time = "2026-04-24T13:21:31.722Z" },
-]
-
-[[package]]
-name = "opentelemetry-instrumentation-asgi"
-version = "0.62b1"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "asgiref" },
-    { name = "opentelemetry-api" },
-    { name = "opentelemetry-instrumentation" },
-    { name = "opentelemetry-semantic-conventions" },
-    { name = "opentelemetry-util-http" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/54/43/b2f0703ff46718ff7b17d7fbf8e9d7f20e26a23c7c325092dd762d09cf9d/opentelemetry_instrumentation_asgi-0.62b1.tar.gz", hash = "sha256:7cf5f5d5c493bbb1edd2bd6d51fa879d964e94048904017258a32ffa47329310", size = 26781, upload-time = "2026-04-24T13:22:37.158Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/d0/41/968c1fe12fb90abffca6620e65d4af91451c02ecca8f74a17a62cac490de/opentelemetry_instrumentation_asgi-0.62b1-py3-none-any.whl", hash = "sha256:b7f89be48528512619bd54fa2459f72afb1695ba71d7024d382ad96d467e7fa8", size = 17011, upload-time = "2026-04-24T13:21:38.006Z" },
-]
-
-[[package]]
-name = "opentelemetry-instrumentation-fastapi"
-version = "0.62b1"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "opentelemetry-api" },
-    { name = "opentelemetry-instrumentation" },
-    { name = "opentelemetry-instrumentation-asgi" },
-    { name = "opentelemetry-semantic-conventions" },
-    { name = "opentelemetry-util-http" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/77/38/91780475a25370b6d483afbaed3e1e170459d6351c5f7c08d66b65e2172e/opentelemetry_instrumentation_fastapi-0.62b1.tar.gz", hash = "sha256:b377d4ba32868fb1ff0f64da3fcdd3aa154d698fc83d65f5d380ea21bf31ee19", size = 25054, upload-time = "2026-04-24T13:22:50.222Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/8c/6f/602e4081d3fe82731aff7e3e9c2f1662d85701841d6dc25f16a1874e11cd/opentelemetry_instrumentation_fastapi-0.62b1-py3-none-any.whl", hash = "sha256:93fa9cc4f315819aee5f4fceb6196c1e5b0fbd789c5520c631de228bd3e5285b", size = 13484, upload-time = "2026-04-24T13:21:54.538Z" },
-]
-
-[[package]]
 name = "opentelemetry-proto"
 version = "1.41.1"
 source = { registry = "https://pypi.org/simple" }
@@ -1467,15 +1377,6 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/9e/de/911ac9e309052aca1b20b2d5549d3db45d1011e1a610e552c6ccdd1b64f8/opentelemetry_semantic_conventions-0.62b1.tar.gz", hash = "sha256:c5cc6e04a7f8c7cdd30be2ed81499fa4e75bfbd52c9cb70d40af1f9cd3619802", size = 145750, upload-time = "2026-04-24T13:15:52.236Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/eb/a6/83dc2ab6fa397ee66fba04fe2e74bdf7be3b3870005359ceb7689103c058/opentelemetry_semantic_conventions-0.62b1-py3-none-any.whl", hash = "sha256:cf506938103d331fbb78eded0d9788095f7fd59016f2bda813c3324e5a74a93c", size = 231620, upload-time = "2026-04-24T13:15:35.454Z" },
-]
-
-[[package]]
-name = "opentelemetry-util-http"
-version = "0.62b1"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/24/1b/aa71b63e18d30a8384036b9937f40f7618f8030a7aa213155fb54f6f2b47/opentelemetry_util_http-0.62b1.tar.gz", hash = "sha256:adf6facbb89aef8f8bc566e2f04624942ba08a7b678b3479a91051a8f4dc70a3", size = 11393, upload-time = "2026-04-24T13:23:12.994Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/5d/85/a9d9d32161c1ced61346267db4c9702da54f81ec5dc88214bc65c23f4e9d/opentelemetry_util_http-0.62b1-py3-none-any.whl", hash = "sha256:c57e8a6c19fc422c288e6074e882f506f85030b69b7376182f74f9257b9261f0", size = 9295, upload-time = "2026-04-24T13:22:28.078Z" },
 ]
 
 [[package]]
@@ -1623,21 +1524,6 @@ wheels = [
 ]
 
 [[package]]
-name = "posthog"
-version = "7.14.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "backoff" },
-    { name = "distro" },
-    { name = "requests" },
-    { name = "typing-extensions" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/c4/0f/0e6578feaf0d4e670bc517b6da09ec147a65421c44e0cd687eba12f08743/posthog-7.14.0.tar.gz", hash = "sha256:3be5e513f07e4ee5119f98b0458cb640739b49cef7c96c3e18b1d65076b18239", size = 205083, upload-time = "2026-05-01T20:41:37.971Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/b3/c2/2dc3e08e481f45c0215da4325ccc9b5f368dcee504779d2f169ab567c766/posthog-7.14.0-py3-none-any.whl", hash = "sha256:76db6e3158e2c11ec9bbcf32a673efec4acc8078965d92e2d3055555220ee546", size = 240187, upload-time = "2026-05-01T20:41:36.022Z" },
-]
-
-[[package]]
 name = "protobuf"
 version = "6.33.6"
 source = { registry = "https://pypi.org/simple" }
@@ -1666,6 +1552,63 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/04/78/0acd37ca84ce3ddffaa92ef0f571e073faa6d8ff1f0559ab1272188ea2be/psutil-7.2.2-cp36-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:b58fabe35e80b264a4e3bb23e6b96f9e45a3df7fb7eed419ac0e5947c61e47cc", size = 148266, upload-time = "2026-01-28T18:15:31.597Z" },
     { url = "https://files.pythonhosted.org/packages/b4/90/e2159492b5426be0c1fef7acba807a03511f97c5f86b3caeda6ad92351a7/psutil-7.2.2-cp37-abi3-win_amd64.whl", hash = "sha256:eb7e81434c8d223ec4a219b5fc1c47d0417b12be7ea866e24fb5ad6e84b3d988", size = 137737, upload-time = "2026-01-28T18:15:33.849Z" },
     { url = "https://files.pythonhosted.org/packages/8c/c7/7bb2e321574b10df20cbde462a94e2b71d05f9bbda251ef27d104668306a/psutil-7.2.2-cp37-abi3-win_arm64.whl", hash = "sha256:8c233660f575a5a89e6d4cb65d9f938126312bca76d8fe087b947b3a1aaac9ee", size = 134617, upload-time = "2026-01-28T18:15:36.514Z" },
+]
+
+[[package]]
+name = "pybase64"
+version = "1.5.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d7/65/c513eab7211590250f729a06aacc0bc95eaf760b9235666e933d200105d0/pybase64-1.5.0.tar.gz", hash = "sha256:545ab2a433769e3b8e1ce2b4f7b07218bbde202f4954fbfe52948b2522120727", size = 149492, upload-time = "2026-08-08T15:42:00.205Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/86/85/97242944a88812139762723196e27a24a1484535c7e614c808f513b6dbc5/pybase64-1.5.0-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:43df778a20db59f231b02c6dd70958e1fad532fc8a4f6bebb0555e74abe01898", size = 46805, upload-time = "2026-08-08T15:37:54.941Z" },
+    { url = "https://files.pythonhosted.org/packages/0d/30/c0471ba2ef6e15f153b8dd629c66f919f3f770c372c703a5637503282097/pybase64-1.5.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:2615d10e4cad323925d2f7d904ae38c6ae439b33069a0d56cc4ce64ea4c9b339", size = 40351, upload-time = "2026-08-08T15:37:56.034Z" },
+    { url = "https://files.pythonhosted.org/packages/29/f8/96c1413310f696ecd3364d887073f73708121469ff7f3bd3e24ec8dece6d/pybase64-1.5.0-cp311-cp311-manylinux1_i686.manylinux2014_i686.manylinux_2_17_i686.manylinux_2_5_i686.whl", hash = "sha256:045fa2f3f5da6cfa86822c645b92e18cfc7c13babccb5ceec9bb64a17ac3f1bc", size = 90662, upload-time = "2026-08-08T15:37:57.091Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/ee/591f24aef04e1ca569450b85c86df0f8a8b3dda04f68cdbf6101312456d7/pybase64-1.5.0-cp311-cp311-manylinux1_x86_64.manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:93bc9bdfaf87dc7d79ee0182b255383b7f82a3167d0166b99330d897b59f9053", size = 94201, upload-time = "2026-08-08T15:37:58.696Z" },
+    { url = "https://files.pythonhosted.org/packages/20/c0/66a721f8d0d5f3d43704b78b30ddc51d07eef24ddf94470c8e1808b0826f/pybase64-1.5.0-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:8b08e4a065c9fa88ab9b8a2345b58073776806488b1ff5e4348957d0aa218043", size = 83843, upload-time = "2026-08-08T15:37:59.817Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/cf/44aa61b4738b9827e50fc081c9072d553fc538a372580a6326771848d1cd/pybase64-1.5.0-cp311-cp311-manylinux2014_armv7l.manylinux_2_17_armv7l.whl", hash = "sha256:897ca382ec6c7bad041ce7b3a64b3a15f1b639dfea89ffcf29bdd235c706fac3", size = 79555, upload-time = "2026-08-08T15:38:00.942Z" },
+    { url = "https://files.pythonhosted.org/packages/98/f2/db862e347968eeecf96729244f092a8e1d9bbc1daf94aef4baf3446296d5/pybase64-1.5.0-cp311-cp311-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:3398eb35a82a94d61756f7a4ad6a1c5a3e735c6abb97167398a22389a9b8ca7a", size = 81765, upload-time = "2026-08-08T15:38:02.206Z" },
+    { url = "https://files.pythonhosted.org/packages/86/37/2ec5e90db7c1d01c126b02933adb31838ed8f4d8834193c4f2c1440e2c28/pybase64-1.5.0-cp311-cp311-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:c3935b4402f257d9c7448944db07f91d6fc20453f8c3f0fa1bf26c490b534c84", size = 80619, upload-time = "2026-08-08T15:38:03.408Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/80/09093682d7834a0cf8516b4d9b2b9ba579abb54c56046666ab12f97208d7/pybase64-1.5.0-cp311-cp311-manylinux_2_31_riscv64.whl", hash = "sha256:a167f17421c237a32c93072a053ff756d9fb225e69a620c3f4818665f0520044", size = 78240, upload-time = "2026-08-08T15:38:04.484Z" },
+    { url = "https://files.pythonhosted.org/packages/20/6c/57d95e6ff206d7aabb0a6ec54a8d860ca1e0c84fee611eacfe95945b7478/pybase64-1.5.0-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:716aed288780c9c2081943a3a7b5be6993cdad56b0cdcb4ef4b562ef56c5a1ae", size = 81888, upload-time = "2026-08-08T15:38:05.558Z" },
+    { url = "https://files.pythonhosted.org/packages/77/71/d0559d16467c42ac91501e5e423d65be1801dd5ebf40f4a244134c760a46/pybase64-1.5.0-cp311-cp311-musllinux_1_2_armv7l.whl", hash = "sha256:d373b682dd0a267ece21869ca9a48d40b55120a3be714661ad0e9afdce9ce27e", size = 75233, upload-time = "2026-08-08T15:38:06.645Z" },
+    { url = "https://files.pythonhosted.org/packages/40/2e/4dfee2d5c37473cb91204dac4f1df83710da30fcd93ae345c2a5acb6bdb9/pybase64-1.5.0-cp311-cp311-musllinux_1_2_i686.whl", hash = "sha256:5d02948944dad3e99ebe70a3049d7df66f5faba97ed03b411349b034558ed936", size = 90524, upload-time = "2026-08-08T15:38:07.791Z" },
+    { url = "https://files.pythonhosted.org/packages/8d/07/e2595a9b32d2e635514de93847e1dca2bd6361c34b2e142b46b0eac852f0/pybase64-1.5.0-cp311-cp311-musllinux_1_2_ppc64le.whl", hash = "sha256:d83f517403ff39404b8586d07e97c019cb2a7cb6665cb070c6aebf1fc03e5487", size = 79217, upload-time = "2026-08-08T15:38:09.004Z" },
+    { url = "https://files.pythonhosted.org/packages/13/ce/57bc5269db8cd07f427e7b42149f00194106c80d02f4147411005dee7522/pybase64-1.5.0-cp311-cp311-musllinux_1_2_riscv64.whl", hash = "sha256:216b78caa73ae9b82f3f006e9694ee5a1bde89e50f4552fd1679b56b080cfb7e", size = 77807, upload-time = "2026-08-08T15:38:10.195Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/08/f366686f58858af2ec5dcedb80c394bf264927ba12c99d9a7233cca16c66/pybase64-1.5.0-cp311-cp311-musllinux_1_2_s390x.whl", hash = "sha256:0855f67fa47c0bdf237ea875c11afce2a8cd879644b288d3f05ed9effab17953", size = 78181, upload-time = "2026-08-08T15:38:11.321Z" },
+    { url = "https://files.pythonhosted.org/packages/1d/fe/de44b16a234b12adf2a2b26a758805de8e7a88e2ccd547053d3dd96d8c57/pybase64-1.5.0-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:a707d36935229ae5c3044cd601908cb7bd9f25757003d029765ccf66818301ce", size = 92950, upload-time = "2026-08-08T15:38:12.464Z" },
+    { url = "https://files.pythonhosted.org/packages/25/42/b2b1ed374bf93defab1d3482713ff76a9e56b61606eca5853c10a8ff5bf4/pybase64-1.5.0-cp311-cp311-win32.whl", hash = "sha256:e868946a538178990a43fa6bbeff1eb027e515d6269743e4d31d19f72daf00ac", size = 42377, upload-time = "2026-08-08T15:38:13.598Z" },
+    { url = "https://files.pythonhosted.org/packages/11/9e/3e0be8871e71f05fe98074f40bd5749c17567e01b2c998b1fd88530eba38/pybase64-1.5.0-cp311-cp311-win_amd64.whl", hash = "sha256:49c62921f55d9d7713faeb855bd9aad1edfb8e09e2c8133b7058d4c447bdaa6e", size = 44491, upload-time = "2026-08-08T15:38:14.646Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/f8/114f6da0f71003a6826fe30a24096e98eeba6c506b1f9cebb2689b01305a/pybase64-1.5.0-cp311-cp311-win_arm64.whl", hash = "sha256:8dfe4566d653684daa21f41c75c8a64a8333b36a4377ccb12a1f16e321d7d1ca", size = 39913, upload-time = "2026-08-08T15:38:15.744Z" },
+    { url = "https://files.pythonhosted.org/packages/84/f4/dba60f937caf26a6e2be6a138f5422da9f4ec988db49bd4e329bcb435cd2/pybase64-1.5.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:9732eba18ba7fe44c1b2827bfaadf381fed3789bd7e20c990e6c8d1ceba0179b", size = 47155, upload-time = "2026-08-08T15:38:16.705Z" },
+    { url = "https://files.pythonhosted.org/packages/b6/61/302d65a981c9baf156e4becbbbe49f38de72906c430ab373d6d1ca0d4258/pybase64-1.5.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:d1149b7360dd99ef1ad10618df2a4f54a00385bc8d2c1aa244c0301a548ac415", size = 40490, upload-time = "2026-08-08T15:38:17.95Z" },
+    { url = "https://files.pythonhosted.org/packages/1d/66/9f1be6a4db86577eebf3106496a2a791b37e5fb74695d4c8eeedbd04490a/pybase64-1.5.0-cp312-cp312-manylinux1_i686.manylinux2014_i686.manylinux_2_17_i686.manylinux_2_5_i686.whl", hash = "sha256:80b171f1546935be4dae1e01bfd8630d2712271e067858b7135726e7d9bc7cce", size = 91058, upload-time = "2026-08-08T15:38:18.983Z" },
+    { url = "https://files.pythonhosted.org/packages/af/36/4e44a0688efe26434bf378b4565b01ac94f81422e8a5746291a03472cd56/pybase64-1.5.0-cp312-cp312-manylinux1_x86_64.manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:1a2b9cf39b4d30f600df8c56cccbc03adfc6e1ae8c04cd6b181105a432d4a515", size = 94681, upload-time = "2026-08-08T15:38:20.59Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/d1/fc02005906fd48081b7b8f077cd422a55399fa351c2a6d3e5fed951794ce/pybase64-1.5.0-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:865b7db127a95e33640ebcdb4bb3aad165d4873ee7c1008949129f3c4f900dd8", size = 84634, upload-time = "2026-08-08T15:38:21.711Z" },
+    { url = "https://files.pythonhosted.org/packages/c0/c6/5bb0f21a9f4d231339a42f16ebabc7c6d9a7d619e756327b15a474650ece/pybase64-1.5.0-cp312-cp312-manylinux2014_armv7l.manylinux_2_17_armv7l.whl", hash = "sha256:3344ce336d9d8292125369c1475d1663e7e1a06894e8e5150307e11f782c6afd", size = 80455, upload-time = "2026-08-08T15:38:23.05Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/04/0ba9a1f2ea39baf081dd44d22d710d9b050ce15991d641982f1814508484/pybase64-1.5.0-cp312-cp312-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:1aaae81669bf18b5a35dcb43dbb200f52b13f847a56bed7a2e82f31cc6f9f74d", size = 82304, upload-time = "2026-08-08T15:38:24.156Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/9e/6b380ff964dd77b79cc1ce565b73780345132e0e181d315f31a2263c5e1f/pybase64-1.5.0-cp312-cp312-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:fb5dc922ce3cb4211caa7e29e6daee98f319e59f297a904acd74f2fdd0674356", size = 81259, upload-time = "2026-08-08T15:38:25.327Z" },
+    { url = "https://files.pythonhosted.org/packages/b9/93/dd7fd7f8ed228f7735ec59a9f85f3c683cef371a76b29520344655bf7c97/pybase64-1.5.0-cp312-cp312-manylinux_2_31_riscv64.whl", hash = "sha256:356e7bd1453551c06231df8411bfbaed9998fbcba2da723d84fb270ff1f977a7", size = 78360, upload-time = "2026-08-08T15:38:26.678Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/99/b5e9e7d4b5e49d7a984c4a26b48bdf988ec62c2778df80144af1a39bd4b1/pybase64-1.5.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:11dfa286f6c5fe6795430bf08fc44b64c98e208558215b0590c9f28fd99a92e3", size = 82358, upload-time = "2026-08-08T15:38:27.856Z" },
+    { url = "https://files.pythonhosted.org/packages/67/fa/19d11ee70fbdb10e574a39ad7fc7adc06e5635a2b2ac291a6554c7c651ae/pybase64-1.5.0-cp312-cp312-musllinux_1_2_armv7l.whl", hash = "sha256:6be40c3311eabe8a816e00041844f9b249828015dc98be8a48a7c3275954ee76", size = 76384, upload-time = "2026-08-08T15:38:29.169Z" },
+    { url = "https://files.pythonhosted.org/packages/71/32/a83622dfa3162dd6fcd019dd8fbb766f0ce064fe67b3d3d2759881dbac4e/pybase64-1.5.0-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:4e8b163c8d2d2a5f414f2c31cdd91024e0c91c72e735a9a564a62460ac838acb", size = 91407, upload-time = "2026-08-08T15:38:30.306Z" },
+    { url = "https://files.pythonhosted.org/packages/6d/b5/1707748813784af0b1340f6c6525887f1ecb393c3f88070a2bb2d86bd94e/pybase64-1.5.0-cp312-cp312-musllinux_1_2_ppc64le.whl", hash = "sha256:0030a64fe91791e5e553edaff3a55d319cd07fb5e097b09c5f7f45e4905c40cb", size = 79687, upload-time = "2026-08-08T15:38:31.771Z" },
+    { url = "https://files.pythonhosted.org/packages/e9/ee/8101e43b5cc070c0adf298f87500154c13b9097d4456a2c1aadd71339329/pybase64-1.5.0-cp312-cp312-musllinux_1_2_riscv64.whl", hash = "sha256:28d5db510433bb1544dc128c4e7ebd85ae57cec2a4608edd1f7ca4fed3e53b3d", size = 77913, upload-time = "2026-08-08T15:38:32.898Z" },
+    { url = "https://files.pythonhosted.org/packages/70/8c/43b2281077ca9a531bd896b7a9fe871d091d80d172d68e439c7aa6337033/pybase64-1.5.0-cp312-cp312-musllinux_1_2_s390x.whl", hash = "sha256:26422429a0bb2f15773dacc0fcb1bcddfce68c6b2d41fc14bc7fc17f8c529542", size = 79172, upload-time = "2026-08-08T15:38:33.974Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/1a/b536e571518eb2f4a2db1c6c7c5913af5780ff82c9eefb41f674fed71ceb/pybase64-1.5.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:ccbae849677648be456ea0de769a78e432d2d24f71cbdc739741e69f8160e0d7", size = 93636, upload-time = "2026-08-08T15:38:35.102Z" },
+    { url = "https://files.pythonhosted.org/packages/54/c0/318f79b614fa03089bf4672194325dfa732790546530697b55a53612637b/pybase64-1.5.0-cp312-cp312-win32.whl", hash = "sha256:d691553d1a88ed87cf1837babec3663275b29de906b48433c15b298e262e5243", size = 42443, upload-time = "2026-08-08T15:38:36.217Z" },
+    { url = "https://files.pythonhosted.org/packages/e0/80/eecc05ebac8d08a2bf855cc7bbe6a37d8c76cd19c6337c9b9fbe3225ee19/pybase64-1.5.0-cp312-cp312-win_amd64.whl", hash = "sha256:125945f5b3cde8b79a8f942cfdb0390f4388fb9458a41f5f2a93746e1ef3c546", size = 44565, upload-time = "2026-08-08T15:38:37.734Z" },
+    { url = "https://files.pythonhosted.org/packages/b4/87/193dbb1eaf7751527a7e0510f5670efeed8642ec647b4c7177c384a6f7e9/pybase64-1.5.0-cp312-cp312-win_arm64.whl", hash = "sha256:c8b5f52776f0277e72a9c7e7944f682de2b3ee4655b7972a48c53f871963741a", size = 39918, upload-time = "2026-08-08T15:38:38.808Z" },
+    { url = "https://files.pythonhosted.org/packages/e4/99/9cc7eadd3dcc3b9d814a15381fe78bc59dff133d25ba3a8e49e4380fff30/pybase64-1.5.0-graalpy312-graalpy250_312_native-macosx_10_13_x86_64.whl", hash = "sha256:a9bcbdefd0858372c2e3c657ca8c1e2cdf0af5963cb45085cc861dfac0ddd422", size = 48565, upload-time = "2026-08-08T15:41:27.275Z" },
+    { url = "https://files.pythonhosted.org/packages/77/04/0b073d5fe8d035c3334d44252218e82ca0717f71a1139efdbc1600c38463/pybase64-1.5.0-graalpy312-graalpy250_312_native-macosx_11_0_arm64.whl", hash = "sha256:8b47a5b4a359e42b4b726cbd9558347c5324194aadaf12e4ad219efc89dc9812", size = 43122, upload-time = "2026-08-08T15:41:28.596Z" },
+    { url = "https://files.pythonhosted.org/packages/ba/dc/cd57bd8629965d69eaaa721cf915f3c0590ba468811d290bbcdd3908f0ee/pybase64-1.5.0-graalpy312-graalpy250_312_native-manylinux1_x86_64.manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:b618ecec8f13b3f9dd58e257aa98fc9b017829a1bdc4f576e9146998956ec2c7", size = 54270, upload-time = "2026-08-08T15:41:29.872Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/22/67ad2ddf8ed03e0fc94341ebfc6ed694a36b9c908dd5a08b3ca366e31892/pybase64-1.5.0-graalpy312-graalpy250_312_native-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:5d09d63b219adfb1b40e104036dc2462234d2f06c05e436918e08f31a09a973b", size = 45919, upload-time = "2026-08-08T15:41:31.177Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/bb/4d080faff127cc8e5e0f5f6bb94d3a079235f83d0ef7355663f4bf214935/pybase64-1.5.0-graalpy312-graalpy250_312_native-win_amd64.whl", hash = "sha256:b059b951347a6e16d29b1488f624a7b213c7e8482869b1eac2b684e6fb1ac236", size = 45025, upload-time = "2026-08-08T15:41:32.601Z" },
+    { url = "https://files.pythonhosted.org/packages/88/84/d011c9b098996db666cb971a831c715d693209e39d28690af1b8049ce3fd/pybase64-1.5.0-pp311-pypy311_pp73-macosx_10_15_x86_64.whl", hash = "sha256:89756a61cd09a5669ce923081f518476ff4b960c5d850a5dd54f0cf4406ac684", size = 46808, upload-time = "2026-08-08T15:41:42.904Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/64/8d6c3aea8fc68875a9d1b4fa750911a2e2e019f984498f7a21807fd0cbed/pybase64-1.5.0-pp311-pypy311_pp73-macosx_11_0_arm64.whl", hash = "sha256:0e8691ad425ab8c586ad93a2d71789c6ab86e201377619ea146ab0ed092aa2ab", size = 40032, upload-time = "2026-08-08T15:41:44.26Z" },
+    { url = "https://files.pythonhosted.org/packages/86/d9/399c45ada7e401c927345324baf797b167864b9817be6aa71a1e28a00ad1/pybase64-1.5.0-pp311-pypy311_pp73-manylinux1_i686.manylinux2014_i686.manylinux_2_17_i686.manylinux_2_5_i686.whl", hash = "sha256:adfc52cee3ad56c070e824bee9feda1f13c8679601ff8d0535f03da60bdcdda6", size = 50312, upload-time = "2026-08-08T15:41:45.607Z" },
+    { url = "https://files.pythonhosted.org/packages/62/18/064288c6211c79a27893b70261558cf79a254ca22d80101bd7d05a817a6f/pybase64-1.5.0-pp311-pypy311_pp73-manylinux1_x86_64.manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:2d240554e1a63ad9b7cb128acf94d4bc7d8400c78dfb76521775e767d4aa0b22", size = 50782, upload-time = "2026-08-08T15:41:46.855Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/73/d68d5df0f367613643c9cb9470a25611d2d078471c1eadeb86c00e644182/pybase64-1.5.0-pp311-pypy311_pp73-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:b7af9ad847b351b42ec54b3c0580febe406b28408917b7fc1565c87896ed0c4d", size = 45251, upload-time = "2026-08-08T15:41:48.082Z" },
+    { url = "https://files.pythonhosted.org/packages/63/13/1dc6e9d781a00fc427518ba462d6ed5b15caaabe3aa74aaca24b2b68ad26/pybase64-1.5.0-pp311-pypy311_pp73-win_amd64.whl", hash = "sha256:83496c6800d5e1002d1e923ab5bef49bb67a07c2faac8374364497182f04af72", size = 44720, upload-time = "2026-08-08T15:41:49.384Z" },
 ]
 
 [[package]]
@@ -2208,30 +2151,31 @@ wheels = [
 
 [[package]]
 name = "safetensors"
-version = "0.7.0"
+version = "0.8.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/29/9c/6e74567782559a63bd040a236edca26fd71bc7ba88de2ef35d75df3bca5e/safetensors-0.7.0.tar.gz", hash = "sha256:07663963b67e8bd9f0b8ad15bb9163606cd27cc5a1b96235a50d8369803b96b0", size = 200878, upload-time = "2025-11-19T15:18:43.199Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/45/06/f955dbbb1859e3bd23c8ac6141af5106e7ad5fedec4a3a6e3d60f94b7001/safetensors-0.8.0.tar.gz", hash = "sha256:fabaf3e0f18a6618d9b36560682562157f77c2b71fcffc7b432be2baed9d753d", size = 325846, upload-time = "2026-06-09T07:52:25.563Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/fa/47/aef6c06649039accf914afef490268e1067ed82be62bcfa5b7e886ad15e8/safetensors-0.7.0-cp38-abi3-macosx_10_12_x86_64.whl", hash = "sha256:c82f4d474cf725255d9e6acf17252991c3c8aac038d6ef363a4bf8be2f6db517", size = 467781, upload-time = "2025-11-19T15:18:35.84Z" },
-    { url = "https://files.pythonhosted.org/packages/e8/00/374c0c068e30cd31f1e1b46b4b5738168ec79e7689ca82ee93ddfea05109/safetensors-0.7.0-cp38-abi3-macosx_11_0_arm64.whl", hash = "sha256:94fd4858284736bb67a897a41608b5b0c2496c9bdb3bf2af1fa3409127f20d57", size = 447058, upload-time = "2025-11-19T15:18:34.416Z" },
-    { url = "https://files.pythonhosted.org/packages/f1/06/578ffed52c2296f93d7fd2d844cabfa92be51a587c38c8afbb8ae449ca89/safetensors-0.7.0-cp38-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:e07d91d0c92a31200f25351f4acb2bc6aff7f48094e13ebb1d0fb995b54b6542", size = 491748, upload-time = "2025-11-19T15:18:09.79Z" },
-    { url = "https://files.pythonhosted.org/packages/ae/33/1debbbb70e4791dde185edb9413d1fe01619255abb64b300157d7f15dddd/safetensors-0.7.0-cp38-abi3-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:8469155f4cb518bafb4acf4865e8bb9d6804110d2d9bdcaa78564b9fd841e104", size = 503881, upload-time = "2025-11-19T15:18:16.145Z" },
-    { url = "https://files.pythonhosted.org/packages/8e/1c/40c2ca924d60792c3be509833df711b553c60effbd91da6f5284a83f7122/safetensors-0.7.0-cp38-abi3-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:54bef08bf00a2bff599982f6b08e8770e09cc012d7bba00783fc7ea38f1fb37d", size = 623463, upload-time = "2025-11-19T15:18:21.11Z" },
-    { url = "https://files.pythonhosted.org/packages/9b/3a/13784a9364bd43b0d61eef4bea2845039bc2030458b16594a1bd787ae26e/safetensors-0.7.0-cp38-abi3-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:42cb091236206bb2016d245c377ed383aa7f78691748f3bb6ee1bfa51ae2ce6a", size = 532855, upload-time = "2025-11-19T15:18:25.719Z" },
-    { url = "https://files.pythonhosted.org/packages/a0/60/429e9b1cb3fc651937727befe258ea24122d9663e4d5709a48c9cbfceecb/safetensors-0.7.0-cp38-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:dac7252938f0696ddea46f5e855dd3138444e82236e3be475f54929f0c510d48", size = 507152, upload-time = "2025-11-19T15:18:33.023Z" },
-    { url = "https://files.pythonhosted.org/packages/3c/a8/4b45e4e059270d17af60359713ffd83f97900d45a6afa73aaa0d737d48b6/safetensors-0.7.0-cp38-abi3-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:1d060c70284127fa805085d8f10fbd0962792aed71879d00864acda69dbab981", size = 541856, upload-time = "2025-11-19T15:18:31.075Z" },
-    { url = "https://files.pythonhosted.org/packages/06/87/d26d8407c44175d8ae164a95b5a62707fcc445f3c0c56108e37d98070a3d/safetensors-0.7.0-cp38-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:cdab83a366799fa730f90a4ebb563e494f28e9e92c4819e556152ad55e43591b", size = 674060, upload-time = "2025-11-19T15:18:37.211Z" },
-    { url = "https://files.pythonhosted.org/packages/11/f5/57644a2ff08dc6325816ba7217e5095f17269dada2554b658442c66aed51/safetensors-0.7.0-cp38-abi3-musllinux_1_2_armv7l.whl", hash = "sha256:672132907fcad9f2aedcb705b2d7b3b93354a2aec1b2f706c4db852abe338f85", size = 771715, upload-time = "2025-11-19T15:18:38.689Z" },
-    { url = "https://files.pythonhosted.org/packages/86/31/17883e13a814bd278ae6e266b13282a01049b0c81341da7fd0e3e71a80a3/safetensors-0.7.0-cp38-abi3-musllinux_1_2_i686.whl", hash = "sha256:5d72abdb8a4d56d4020713724ba81dac065fedb7f3667151c4a637f1d3fb26c0", size = 714377, upload-time = "2025-11-19T15:18:40.162Z" },
-    { url = "https://files.pythonhosted.org/packages/4a/d8/0c8a7dc9b41dcac53c4cbf9df2b9c83e0e0097203de8b37a712b345c0be5/safetensors-0.7.0-cp38-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:b0f6d66c1c538d5a94a73aa9ddca8ccc4227e6c9ff555322ea40bdd142391dd4", size = 677368, upload-time = "2025-11-19T15:18:41.627Z" },
-    { url = "https://files.pythonhosted.org/packages/05/e5/cb4b713c8a93469e3c5be7c3f8d77d307e65fe89673e731f5c2bfd0a9237/safetensors-0.7.0-cp38-abi3-win32.whl", hash = "sha256:c74af94bf3ac15ac4d0f2a7c7b4663a15f8c2ab15ed0fc7531ca61d0835eccba", size = 326423, upload-time = "2025-11-19T15:18:45.74Z" },
-    { url = "https://files.pythonhosted.org/packages/5d/e6/ec8471c8072382cb91233ba7267fd931219753bb43814cbc71757bfd4dab/safetensors-0.7.0-cp38-abi3-win_amd64.whl", hash = "sha256:d1239932053f56f3456f32eb9625590cc7582e905021f94636202a864d470755", size = 341380, upload-time = "2025-11-19T15:18:44.427Z" },
+    { url = "https://files.pythonhosted.org/packages/39/a0/f718cda65b05407d228f97602cf60dca269c979867aa5beb25410de26cd3/safetensors-0.8.0-cp310-abi3-macosx_10_12_x86_64.whl", hash = "sha256:c554f85858e05226d3c2828e32395e677434685d6d94594a41643361c5e837f0", size = 473568, upload-time = "2026-06-09T07:52:18.829Z" },
+    { url = "https://files.pythonhosted.org/packages/f5/b1/fa7c600e7dceae12e9606c7578cbc9ff1e1ed55844883ee5c92205e86226/safetensors-0.8.0-cp310-abi3-macosx_11_0_arm64.whl", hash = "sha256:c80201d22cbf405b80647a60ada77bba06c8fba2da2743ba1e89cdcc39a81f25", size = 484562, upload-time = "2026-06-09T07:52:17.518Z" },
+    { url = "https://files.pythonhosted.org/packages/09/7d/65a7de0af421317bb36a067241e4235fff194eed60b961ed6d3f59a3fc60/safetensors-0.8.0-cp310-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:7a46e5ff292c356d6991e60942ba7f79817682d3a2cef0702136448cb9c4d235", size = 502844, upload-time = "2026-06-09T07:52:07.624Z" },
+    { url = "https://files.pythonhosted.org/packages/91/4f/3175c9d75634e0e0dda0082794193521035edd7c70a6f212bf33ca06ddf4/safetensors-0.8.0-cp310-abi3-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:4124502b78f03534117c848f87a39b8f31e577b15eff423bf8bfb95f2a8c30d0", size = 511823, upload-time = "2026-06-09T07:52:09.565Z" },
+    { url = "https://files.pythonhosted.org/packages/20/87/846c289e7aa2299eff406335717cf43ce8777194ece8aad75772e0411615/safetensors-0.8.0-cp310-abi3-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:7bc0a787ba8a35be368ee3574edfa2b1ad389eebd0a72e482ae275490e3f6c98", size = 633461, upload-time = "2026-06-09T07:52:11.128Z" },
+    { url = "https://files.pythonhosted.org/packages/76/22/8d64d9df2c45d5ded401df889d0ad90882804ca172d79ec4f0df8f727fe0/safetensors-0.8.0-cp310-abi3-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:040070828e36dc8e122178bbbd5830ff9e97920affb84cbe0f46442497bed358", size = 545148, upload-time = "2026-06-09T07:52:13.603Z" },
+    { url = "https://files.pythonhosted.org/packages/28/50/f203ff3a3ddfe19308efc83c5a3a29ed02bf786732ec35e68bf9162f3365/safetensors-0.8.0-cp310-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:fd6f3f93c9a0a7cc2788ee63fb763353d4bd2e89b0751bc78fcf7dda00bea774", size = 516040, upload-time = "2026-06-09T07:52:16.29Z" },
+    { url = "https://files.pythonhosted.org/packages/46/fb/cdaed17ceb2948784fd9c36b6fd3e951b608547cea81a48e8ee6f8cfdfcb/safetensors-0.8.0-cp310-abi3-manylinux_2_31_riscv64.whl", hash = "sha256:fcdd41ec4628fee5799f807c73c353629130fbd942aa23d83c623dd6c9d52d78", size = 513832, upload-time = "2026-06-09T07:52:12.37Z" },
+    { url = "https://files.pythonhosted.org/packages/0d/49/1e15de264dcc3b77943d2d0c56a95809956883b1c2d6d585c792523f180b/safetensors-0.8.0-cp310-abi3-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:8e9f537aa183a38ace122d27303dcd986b26bd2a7591f9181d7f0c396f4677ca", size = 559930, upload-time = "2026-06-09T07:52:14.743Z" },
+    { url = "https://files.pythonhosted.org/packages/2a/43/bf38443278eab4b1be1fce2931e2b012ad9cb7df52ada751d0aab8f7659a/safetensors-0.8.0-cp310-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:87eec7ffed2b809f05a398a8becb7d013f19f7837cd15d9748580d6cf30dbaf4", size = 678670, upload-time = "2026-06-09T07:52:20.032Z" },
+    { url = "https://files.pythonhosted.org/packages/72/e3/68cd3fa5b48488e84add63e04cb12f3bc28ae4638c06d4508c6e88823d0e/safetensors-0.8.0-cp310-abi3-musllinux_1_2_armv7l.whl", hash = "sha256:4a95ae2b05d7726d751da4ebf626a2ca782b706e101bd894c95bc2450b1cffcc", size = 786679, upload-time = "2026-06-09T07:52:21.322Z" },
+    { url = "https://files.pythonhosted.org/packages/29/4b/1c19c509d56e01f4fbb3d0a2e597450f6cc04d1d56cf52defb0a62dfd715/safetensors-0.8.0-cp310-abi3-musllinux_1_2_i686.whl", hash = "sha256:3ae091f16662658bdc019a4ff6cb4c085bb7d725eb5978b183ffd265863b6d2d", size = 765683, upload-time = "2026-06-09T07:52:22.594Z" },
+    { url = "https://files.pythonhosted.org/packages/27/43/41c1621732edd934d868a00d1b891584c892a7b62a9aab82ea5a0a5623ee/safetensors-0.8.0-cp310-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:8e080062fcde23be189565e1c3305d16751a218ecf9412c8601e64204eb6f846", size = 722361, upload-time = "2026-06-09T07:52:23.924Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/3f/73ccf82579412b4a71c4ca673f10b5f1f888d7cf5af7fe24f27d30307be4/safetensors-0.8.0-cp310-abi3-win32.whl", hash = "sha256:2ddf52eac562eda224f99acfa7889d02968c1fd59a5b011ae7d8137c37e9c02d", size = 342401, upload-time = "2026-06-09T07:52:28.895Z" },
+    { url = "https://files.pythonhosted.org/packages/1b/6d/3fba214c1e5e0f69991677ec3bc17023f0421776975e1de0c682dca475e2/safetensors-0.8.0-cp310-abi3-win_amd64.whl", hash = "sha256:096ec1a98435df7beb08853bb5aa9081a84f23d0adc67ed1a0a10550f608373f", size = 355540, upload-time = "2026-06-09T07:52:27.832Z" },
+    { url = "https://files.pythonhosted.org/packages/8d/fc/7eedc3510d97878876e32774eebbeb61c43f148a96e915c84229a3e967aa/safetensors-0.8.0-cp310-abi3-win_arm64.whl", hash = "sha256:f7838e5135a406ad3e02efdcb8cf2e5397d368b0154537c4fec682dbc544d452", size = 340500, upload-time = "2026-06-09T07:52:26.745Z" },
 ]
 
 [package.optional-dependencies]
 torch = [
     { name = "numpy" },
-    { name = "packaging" },
     { name = "torch", version = "2.11.0", source = { registry = "https://download.pytorch.org/whl/cpu" }, marker = "sys_platform == 'darwin'" },
     { name = "torch", version = "2.11.0+cpu", source = { registry = "https://download.pytorch.org/whl/cpu" }, marker = "sys_platform != 'darwin'" },
 ]
@@ -2448,7 +2392,7 @@ docling = [
 requires-dist = [
     { name = "authlib", specifier = ">=1.3" },
     { name = "beautifulsoup4", specifier = ">=4.12" },
-    { name = "chromadb", specifier = ">=0.5,<0.6" },
+    { name = "chromadb", specifier = ">=0.6.3,<1.6" },
     { name = "click", specifier = ">=8.1" },
     { name = "cryptography", specifier = ">=42.0" },
     { name = "docling", marker = "extra == 'docling'", specifier = ">=2.0" },
@@ -2517,37 +2461,28 @@ wheels = [
 
 [[package]]
 name = "tokenizers"
-version = "0.20.3"
+version = "0.22.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "huggingface-hub" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/da/25/b1681c1c30ea3ea6e584ae3fffd552430b12faa599b558c4c4783f56d7ff/tokenizers-0.20.3.tar.gz", hash = "sha256:2278b34c5d0dd78e087e1ca7f9b1dcbf129d80211afa645f214bd6e051037539", size = 340513, upload-time = "2024-11-05T17:34:10.403Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/73/6f/f80cfef4a312e1fb34baf7d85c72d4411afde10978d4657f8cdd811d3ccc/tokenizers-0.22.2.tar.gz", hash = "sha256:473b83b915e547aa366d1eee11806deaf419e17be16310ac0a14077f1e28f917", size = 372115, upload-time = "2026-01-05T10:45:15.988Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/c6/93/6742ef9206409d5ce1fdf44d5ca1687cdc3847ba0485424e2c731e6bcf67/tokenizers-0.20.3-cp311-cp311-macosx_10_12_x86_64.whl", hash = "sha256:585b51e06ca1f4839ce7759941e66766d7b060dccfdc57c4ca1e5b9a33013a90", size = 2674224, upload-time = "2024-11-05T17:30:49.972Z" },
-    { url = "https://files.pythonhosted.org/packages/aa/14/e75ece72e99f6ef9ae07777ca9fdd78608f69466a5cecf636e9bd2f25d5c/tokenizers-0.20.3-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:61cbf11954f3b481d08723ebd048ba4b11e582986f9be74d2c3bdd9293a4538d", size = 2558991, upload-time = "2024-11-05T17:30:51.666Z" },
-    { url = "https://files.pythonhosted.org/packages/46/54/033b5b2ba0c3ae01e026c6f7ced147d41a2fa1c573d00a66cb97f6d7f9b3/tokenizers-0.20.3-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ef820880d5e4e8484e2fa54ff8d297bb32519eaa7815694dc835ace9130a3eea", size = 2892476, upload-time = "2024-11-05T17:30:53.505Z" },
-    { url = "https://files.pythonhosted.org/packages/e6/b0/cc369fb3297d61f3311cab523d16d48c869dc2f0ba32985dbf03ff811041/tokenizers-0.20.3-cp311-cp311-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:67ef4dcb8841a4988cd00dd288fb95dfc8e22ed021f01f37348fd51c2b055ba9", size = 2802775, upload-time = "2024-11-05T17:30:55.229Z" },
-    { url = "https://files.pythonhosted.org/packages/1a/74/62ad983e8ea6a63e04ed9c5be0b605056bf8aac2f0125f9b5e0b3e2b89fa/tokenizers-0.20.3-cp311-cp311-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:ff1ef8bd47a02b0dc191688ccb4da53600df5d4c9a05a4b68e1e3de4823e78eb", size = 3086138, upload-time = "2024-11-05T17:30:57.332Z" },
-    { url = "https://files.pythonhosted.org/packages/6b/ac/4637ba619db25094998523f9e6f5b456e1db1f8faa770a3d925d436db0c3/tokenizers-0.20.3-cp311-cp311-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:444d188186eab3148baf0615b522461b41b1f0cd58cd57b862ec94b6ac9780f1", size = 3098076, upload-time = "2024-11-05T17:30:59.455Z" },
-    { url = "https://files.pythonhosted.org/packages/58/ce/9793f2dc2ce529369807c9c74e42722b05034af411d60f5730b720388c7d/tokenizers-0.20.3-cp311-cp311-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:37c04c032c1442740b2c2d925f1857885c07619224a533123ac7ea71ca5713da", size = 3379650, upload-time = "2024-11-05T17:31:01.264Z" },
-    { url = "https://files.pythonhosted.org/packages/50/f6/2841de926bc4118af996eaf0bdf0ea5b012245044766ffc0347e6c968e63/tokenizers-0.20.3-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:453c7769d22231960ee0e883d1005c93c68015025a5e4ae56275406d94a3c907", size = 2994005, upload-time = "2024-11-05T17:31:02.985Z" },
-    { url = "https://files.pythonhosted.org/packages/a3/b2/00915c4fed08e9505d37cf6eaab45b12b4bff8f6719d459abcb9ead86a4b/tokenizers-0.20.3-cp311-cp311-musllinux_1_1_aarch64.whl", hash = "sha256:4bb31f7b2847e439766aaa9cc7bccf7ac7088052deccdb2275c952d96f691c6a", size = 8977488, upload-time = "2024-11-05T17:31:04.424Z" },
-    { url = "https://files.pythonhosted.org/packages/e9/ac/1c069e7808181ff57bcf2d39e9b6fbee9133a55410e6ebdaa89f67c32e83/tokenizers-0.20.3-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:843729bf0f991b29655a069a2ff58a4c24375a553c70955e15e37a90dd4e045c", size = 9294935, upload-time = "2024-11-05T17:31:06.882Z" },
-    { url = "https://files.pythonhosted.org/packages/50/47/722feb70ee68d1c4412b12d0ea4acc2713179fd63f054913990f9e259492/tokenizers-0.20.3-cp311-none-win32.whl", hash = "sha256:efcce3a927b1e20ca694ba13f7a68c59b0bd859ef71e441db68ee42cf20c2442", size = 2197175, upload-time = "2024-11-05T17:31:09.385Z" },
-    { url = "https://files.pythonhosted.org/packages/75/68/1b4f928b15a36ed278332ac75d66d7eb65d865bf344d049c452c18447bf9/tokenizers-0.20.3-cp311-none-win_amd64.whl", hash = "sha256:88301aa0801f225725b6df5dea3d77c80365ff2362ca7e252583f2b4809c4cc0", size = 2381616, upload-time = "2024-11-05T17:31:10.685Z" },
-    { url = "https://files.pythonhosted.org/packages/07/00/92a08af2a6b0c88c50f1ab47d7189e695722ad9714b0ee78ea5e1e2e1def/tokenizers-0.20.3-cp312-cp312-macosx_10_12_x86_64.whl", hash = "sha256:49d12a32e190fad0e79e5bdb788d05da2f20d8e006b13a70859ac47fecf6ab2f", size = 2667951, upload-time = "2024-11-05T17:31:12.356Z" },
-    { url = "https://files.pythonhosted.org/packages/ec/9a/e17a352f0bffbf415cf7d73756f5c73a3219225fc5957bc2f39d52c61684/tokenizers-0.20.3-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:282848cacfb9c06d5e51489f38ec5aa0b3cd1e247a023061945f71f41d949d73", size = 2555167, upload-time = "2024-11-05T17:31:13.839Z" },
-    { url = "https://files.pythonhosted.org/packages/27/37/d108df55daf4f0fcf1f58554692ff71687c273d870a34693066f0847be96/tokenizers-0.20.3-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:abe4e08c7d0cd6154c795deb5bf81d2122f36daf075e0c12a8b050d824ef0a64", size = 2898389, upload-time = "2024-11-05T17:31:15.12Z" },
-    { url = "https://files.pythonhosted.org/packages/b2/27/32f29da16d28f59472fa7fb38e7782069748c7e9ab9854522db20341624c/tokenizers-0.20.3-cp312-cp312-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:ca94fc1b73b3883c98f0c88c77700b13d55b49f1071dfd57df2b06f3ff7afd64", size = 2795866, upload-time = "2024-11-05T17:31:16.857Z" },
-    { url = "https://files.pythonhosted.org/packages/29/4e/8a9a3c89e128c4a40f247b501c10279d2d7ade685953407c4d94c8c0f7a7/tokenizers-0.20.3-cp312-cp312-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:ef279c7e239f95c8bdd6ff319d9870f30f0d24915b04895f55b1adcf96d6c60d", size = 3085446, upload-time = "2024-11-05T17:31:18.392Z" },
-    { url = "https://files.pythonhosted.org/packages/b4/3b/a2a7962c496ebcd95860ca99e423254f760f382cd4bd376f8895783afaf5/tokenizers-0.20.3-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:16384073973f6ccbde9852157a4fdfe632bb65208139c9d0c0bd0176a71fd67f", size = 3094378, upload-time = "2024-11-05T17:31:20.329Z" },
-    { url = "https://files.pythonhosted.org/packages/1f/f4/a8a33f0192a1629a3bd0afcad17d4d221bbf9276da4b95d226364208d5eb/tokenizers-0.20.3-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:312d522caeb8a1a42ebdec87118d99b22667782b67898a76c963c058a7e41d4f", size = 3385755, upload-time = "2024-11-05T17:31:21.778Z" },
-    { url = "https://files.pythonhosted.org/packages/9e/65/c83cb3545a65a9eaa2e13b22c93d5e00bd7624b354a44adbdc93d5d9bd91/tokenizers-0.20.3-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:f2b7cb962564785a83dafbba0144ecb7f579f1d57d8c406cdaa7f32fe32f18ad", size = 2997679, upload-time = "2024-11-05T17:31:23.134Z" },
-    { url = "https://files.pythonhosted.org/packages/55/e9/a80d4e592307688a67c7c59ab77e03687b6a8bd92eb5db763a2c80f93f57/tokenizers-0.20.3-cp312-cp312-musllinux_1_1_aarch64.whl", hash = "sha256:124c5882ebb88dadae1fc788a582299fcd3a8bd84fc3e260b9918cf28b8751f5", size = 8989296, upload-time = "2024-11-05T17:31:24.953Z" },
-    { url = "https://files.pythonhosted.org/packages/90/af/60c957af8d2244321124e893828f1a4817cde1a2d08d09d423b73f19bd2f/tokenizers-0.20.3-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:2b6e54e71f84c4202111a489879005cb14b92616a87417f6c102c833af961ea2", size = 9303621, upload-time = "2024-11-05T17:31:27.341Z" },
-    { url = "https://files.pythonhosted.org/packages/be/a9/96172310ee141009646d63a1ca267c099c462d747fe5ef7e33f74e27a683/tokenizers-0.20.3-cp312-none-win32.whl", hash = "sha256:83d9bfbe9af86f2d9df4833c22e94d94750f1d0cd9bfb22a7bb90a86f61cdb1c", size = 2188979, upload-time = "2024-11-05T17:31:29.483Z" },
-    { url = "https://files.pythonhosted.org/packages/bd/68/61d85ae7ae96dde7d0974ff3538db75d5cdc29be2e4329cd7fc51a283e22/tokenizers-0.20.3-cp312-none-win_amd64.whl", hash = "sha256:44def74cee574d609a36e17c8914311d1b5dbcfe37c55fd29369d42591b91cf2", size = 2380725, upload-time = "2024-11-05T17:31:31.315Z" },
+    { url = "https://files.pythonhosted.org/packages/92/97/5dbfabf04c7e348e655e907ed27913e03db0923abb5dfdd120d7b25630e1/tokenizers-0.22.2-cp39-abi3-macosx_10_12_x86_64.whl", hash = "sha256:544dd704ae7238755d790de45ba8da072e9af3eea688f698b137915ae959281c", size = 3100275, upload-time = "2026-01-05T10:41:02.158Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/47/174dca0502ef88b28f1c9e06b73ce33500eedfac7a7692108aec220464e7/tokenizers-0.22.2-cp39-abi3-macosx_11_0_arm64.whl", hash = "sha256:1e418a55456beedca4621dbab65a318981467a2b188e982a23e117f115ce5001", size = 2981472, upload-time = "2026-01-05T10:41:00.276Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/84/7990e799f1309a8b87af6b948f31edaa12a3ed22d11b352eaf4f4b2e5753/tokenizers-0.22.2-cp39-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:2249487018adec45d6e3554c71d46eb39fa8ea67156c640f7513eb26f318cec7", size = 3290736, upload-time = "2026-01-05T10:40:32.165Z" },
+    { url = "https://files.pythonhosted.org/packages/78/59/09d0d9ba94dcd5f4f1368d4858d24546b4bdc0231c2354aa31d6199f0399/tokenizers-0.22.2-cp39-abi3-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:25b85325d0815e86e0bac263506dd114578953b7b53d7de09a6485e4a160a7dd", size = 3168835, upload-time = "2026-01-05T10:40:38.847Z" },
+    { url = "https://files.pythonhosted.org/packages/47/50/b3ebb4243e7160bda8d34b731e54dd8ab8b133e50775872e7a434e524c28/tokenizers-0.22.2-cp39-abi3-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:bfb88f22a209ff7b40a576d5324bf8286b519d7358663db21d6246fb17eea2d5", size = 3521673, upload-time = "2026-01-05T10:40:56.614Z" },
+    { url = "https://files.pythonhosted.org/packages/e0/fa/89f4cb9e08df770b57adb96f8cbb7e22695a4cb6c2bd5f0c4f0ebcf33b66/tokenizers-0.22.2-cp39-abi3-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:1c774b1276f71e1ef716e5486f21e76333464f47bece56bbd554485982a9e03e", size = 3724818, upload-time = "2026-01-05T10:40:44.507Z" },
+    { url = "https://files.pythonhosted.org/packages/64/04/ca2363f0bfbe3b3d36e95bf67e56a4c88c8e3362b658e616d1ac185d47f2/tokenizers-0.22.2-cp39-abi3-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:df6c4265b289083bf710dff49bc51ef252f9d5be33a45ee2bed151114a56207b", size = 3379195, upload-time = "2026-01-05T10:40:51.139Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/76/932be4b50ef6ccedf9d3c6639b056a967a86258c6d9200643f01269211ca/tokenizers-0.22.2-cp39-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:369cc9fc8cc10cb24143873a0d95438bb8ee257bb80c71989e3ee290e8d72c67", size = 3274982, upload-time = "2026-01-05T10:40:58.331Z" },
+    { url = "https://files.pythonhosted.org/packages/1d/28/5f9f5a4cc211b69e89420980e483831bcc29dade307955cc9dc858a40f01/tokenizers-0.22.2-cp39-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:29c30b83d8dcd061078b05ae0cb94d3c710555fbb44861139f9f83dcca3dc3e4", size = 9478245, upload-time = "2026-01-05T10:41:04.053Z" },
+    { url = "https://files.pythonhosted.org/packages/6c/fb/66e2da4704d6aadebf8cb39f1d6d1957df667ab24cff2326b77cda0dcb85/tokenizers-0.22.2-cp39-abi3-musllinux_1_2_armv7l.whl", hash = "sha256:37ae80a28c1d3265bb1f22464c856bd23c02a05bb211e56d0c5301a435be6c1a", size = 9560069, upload-time = "2026-01-05T10:45:10.673Z" },
+    { url = "https://files.pythonhosted.org/packages/16/04/fed398b05caa87ce9b1a1bb5166645e38196081b225059a6edaff6440fac/tokenizers-0.22.2-cp39-abi3-musllinux_1_2_i686.whl", hash = "sha256:791135ee325f2336f498590eb2f11dc5c295232f288e75c99a36c5dbce63088a", size = 9899263, upload-time = "2026-01-05T10:45:12.559Z" },
+    { url = "https://files.pythonhosted.org/packages/05/a1/d62dfe7376beaaf1394917e0f8e93ee5f67fea8fcf4107501db35996586b/tokenizers-0.22.2-cp39-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:38337540fbbddff8e999d59970f3c6f35a82de10053206a7562f1ea02d046fa5", size = 10033429, upload-time = "2026-01-05T10:45:14.333Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/18/a545c4ea42af3df6effd7d13d250ba77a0a86fb20393143bbb9a92e434d4/tokenizers-0.22.2-cp39-abi3-win32.whl", hash = "sha256:a6bf3f88c554a2b653af81f3204491c818ae2ac6fbc09e76ef4773351292bc92", size = 2502363, upload-time = "2026-01-05T10:45:20.593Z" },
+    { url = "https://files.pythonhosted.org/packages/65/71/0670843133a43d43070abeb1949abfdef12a86d490bea9cd9e18e37c5ff7/tokenizers-0.22.2-cp39-abi3-win_amd64.whl", hash = "sha256:c9ea31edff2968b44a88f97d784c2f16dc0729b8b143ed004699ebca91f05c48", size = 2747786, upload-time = "2026-01-05T10:45:18.411Z" },
+    { url = "https://files.pythonhosted.org/packages/72/f4/0de46cfa12cdcbcd464cc59fde36912af405696f687e53a091fb432f694c/tokenizers-0.22.2-cp39-abi3-win_arm64.whl", hash = "sha256:9ce725d22864a1e965217204946f830c37876eee3b2ba6fc6255e8e903d5fcbc", size = 2612133, upload-time = "2026-01-05T10:45:17.232Z" },
 ]
 
 [[package]]
@@ -2639,23 +2574,22 @@ wheels = [
 
 [[package]]
 name = "transformers"
-version = "4.46.3"
+version = "5.15.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "filelock" },
     { name = "huggingface-hub" },
     { name = "numpy" },
     { name = "packaging" },
     { name = "pyyaml" },
     { name = "regex" },
-    { name = "requests" },
     { name = "safetensors" },
     { name = "tokenizers" },
     { name = "tqdm" },
+    { name = "typer" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/37/5a/58f96c83e566f907ae39f16d4401bbefd8bb85c60bd1e6a95c419752ab90/transformers-4.46.3.tar.gz", hash = "sha256:8ee4b3ae943fe33e82afff8e837f4b052058b07ca9be3cb5b729ed31295f72cc", size = 8627944, upload-time = "2024-11-18T22:13:01.012Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/2a/92/c50c61da7046bbb59a4d011291aeadcfb4d7980ab36fdb31e93823a3fb93/transformers-5.15.1.tar.gz", hash = "sha256:27c996bd9075ddc82d40f8590dfdc81ea45f611bfca477e0db5d7fd257a482f7", size = 9378434, upload-time = "2026-08-19T11:28:20.33Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/51/51/b87caa939fedf307496e4dbf412f4b909af3d9ca8b189fc3b65c1faa456f/transformers-4.46.3-py3-none-any.whl", hash = "sha256:a12ef6f52841fd190a3e5602145b542d03507222f2c64ebb7ee92e8788093aef", size = 10034536, upload-time = "2024-11-18T22:12:57.024Z" },
+    { url = "https://files.pythonhosted.org/packages/41/c4/a12e1d9b387fb0c40a57116db82b457e8c771cb419163cda29204d74a595/transformers-5.15.1-py3-none-any.whl", hash = "sha256:b7cdf238ff583e3a58dbc7fa34da1aaf091ce063141f65a30538160bd5afe93f", size = 11749582, upload-time = "2026-08-19T11:28:16.726Z" },
 ]
 
 [[package]]
@@ -2921,37 +2855,6 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/a5/8f/aea9c71cc92bf9b6cc0f7f70df8f0b420636b6c96ef4feee1e16f80f75dd/websockets-16.0-pp311-pypy311_pp73-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:0298d07ee155e2e9fda5be8a9042200dd2e3bb0b8a38482156576f863a9d457c", size = 176968, upload-time = "2026-01-10T09:23:41.031Z" },
     { url = "https://files.pythonhosted.org/packages/9a/3f/f70e03f40ffc9a30d817eef7da1be72ee4956ba8d7255c399a01b135902a/websockets-16.0-pp311-pypy311_pp73-win_amd64.whl", hash = "sha256:a653aea902e0324b52f1613332ddf50b00c06fdaf7e92624fbf8c77c78fa5767", size = 178735, upload-time = "2026-01-10T09:23:42.259Z" },
     { url = "https://files.pythonhosted.org/packages/6f/28/258ebab549c2bf3e64d2b0217b973467394a9cea8c42f70418ca2c5d0d2e/websockets-16.0-py3-none-any.whl", hash = "sha256:1637db62fad1dc833276dded54215f2c7fa46912301a24bd94d45d46a011ceec", size = 171598, upload-time = "2026-01-10T09:23:45.395Z" },
-]
-
-[[package]]
-name = "wrapt"
-version = "2.1.2"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/2e/64/925f213fdcbb9baeb1530449ac71a4d57fc361c053d06bf78d0c5c7cd80c/wrapt-2.1.2.tar.gz", hash = "sha256:3996a67eecc2c68fd47b4e3c564405a5777367adfd9b8abb58387b63ee83b21e", size = 81678, upload-time = "2026-03-06T02:53:25.134Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/c7/81/60c4471fce95afa5922ca09b88a25f03c93343f759aae0f31fb4412a85c7/wrapt-2.1.2-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:96159a0ee2b0277d44201c3b5be479a9979cf154e8c82fa5df49586a8e7679bb", size = 60666, upload-time = "2026-03-06T02:52:58.934Z" },
-    { url = "https://files.pythonhosted.org/packages/6b/be/80e80e39e7cb90b006a0eaf11c73ac3a62bbfb3068469aec15cc0bc795de/wrapt-2.1.2-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:98ba61833a77b747901e9012072f038795de7fc77849f1faa965464f3f87ff2d", size = 61601, upload-time = "2026-03-06T02:53:00.487Z" },
-    { url = "https://files.pythonhosted.org/packages/b0/be/d7c88cd9293c859fc74b232abdc65a229bb953997995d6912fc85af18323/wrapt-2.1.2-cp311-cp311-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:767c0dbbe76cae2a60dd2b235ac0c87c9cccf4898aef8062e57bead46b5f6894", size = 114057, upload-time = "2026-03-06T02:52:44.08Z" },
-    { url = "https://files.pythonhosted.org/packages/ea/25/36c04602831a4d685d45a93b3abea61eca7fe35dab6c842d6f5d570ef94a/wrapt-2.1.2-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:9c691a6bc752c0cc4711cc0c00896fcd0f116abc253609ef64ef930032821842", size = 116099, upload-time = "2026-03-06T02:54:56.74Z" },
-    { url = "https://files.pythonhosted.org/packages/5c/4e/98a6eb417ef551dc277bec1253d5246b25003cf36fdf3913b65cb7657a56/wrapt-2.1.2-cp311-cp311-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:f3b7d73012ea75aee5844de58c88f44cf62d0d62711e39da5a82824a7c4626a8", size = 112457, upload-time = "2026-03-06T02:53:52.842Z" },
-    { url = "https://files.pythonhosted.org/packages/cb/a6/a6f7186a5297cad8ec53fd7578533b28f795fdf5372368c74bd7e6e9841c/wrapt-2.1.2-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:577dff354e7acd9d411eaf4bfe76b724c89c89c8fc9b7e127ee28c5f7bcb25b6", size = 115351, upload-time = "2026-03-06T02:53:32.684Z" },
-    { url = "https://files.pythonhosted.org/packages/97/6f/06e66189e721dbebd5cf20e138acc4d1150288ce118462f2fcbff92d38db/wrapt-2.1.2-cp311-cp311-musllinux_1_2_riscv64.whl", hash = "sha256:3d7b6fd105f8b24e5bd23ccf41cb1d1099796524bcc6f7fbb8fe576c44befbc9", size = 111748, upload-time = "2026-03-06T02:53:08.455Z" },
-    { url = "https://files.pythonhosted.org/packages/ef/43/4808b86f499a51370fbdbdfa6cb91e9b9169e762716456471b619fca7a70/wrapt-2.1.2-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:866abdbf4612e0b34764922ef8b1c5668867610a718d3053d59e24a5e5fcfc15", size = 113783, upload-time = "2026-03-06T02:53:02.02Z" },
-    { url = "https://files.pythonhosted.org/packages/91/2c/a3f28b8fa7ac2cefa01cfcaca3471f9b0460608d012b693998cd61ef43df/wrapt-2.1.2-cp311-cp311-win32.whl", hash = "sha256:5a0a0a3a882393095573344075189eb2d566e0fd205a2b6414e9997b1b800a8b", size = 57977, upload-time = "2026-03-06T02:53:27.844Z" },
-    { url = "https://files.pythonhosted.org/packages/3f/c3/2b1c7bd07a27b1db885a2fab469b707bdd35bddf30a113b4917a7e2139d2/wrapt-2.1.2-cp311-cp311-win_amd64.whl", hash = "sha256:64a07a71d2730ba56f11d1a4b91f7817dc79bc134c11516b75d1921a7c6fcda1", size = 60336, upload-time = "2026-03-06T02:54:28.104Z" },
-    { url = "https://files.pythonhosted.org/packages/ec/5c/76ece7b401b088daa6503d6264dd80f9a727df3e6042802de9a223084ea2/wrapt-2.1.2-cp311-cp311-win_arm64.whl", hash = "sha256:b89f095fe98bc12107f82a9f7d570dc83a0870291aeb6b1d7a7d35575f55d98a", size = 58756, upload-time = "2026-03-06T02:53:16.319Z" },
-    { url = "https://files.pythonhosted.org/packages/4c/b6/1db817582c49c7fcbb7df6809d0f515af29d7c2fbf57eb44c36e98fb1492/wrapt-2.1.2-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:ff2aad9c4cda28a8f0653fc2d487596458c2a3f475e56ba02909e950a9efa6a9", size = 61255, upload-time = "2026-03-06T02:52:45.663Z" },
-    { url = "https://files.pythonhosted.org/packages/a2/16/9b02a6b99c09227c93cd4b73acc3678114154ec38da53043c0ddc1fba0dc/wrapt-2.1.2-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:6433ea84e1cfacf32021d2a4ee909554ade7fd392caa6f7c13f1f4bf7b8e8748", size = 61848, upload-time = "2026-03-06T02:53:48.728Z" },
-    { url = "https://files.pythonhosted.org/packages/af/aa/ead46a88f9ec3a432a4832dfedb84092fc35af2d0ba40cd04aea3889f247/wrapt-2.1.2-cp312-cp312-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:c20b757c268d30d6215916a5fa8461048d023865d888e437fab451139cad6c8e", size = 121433, upload-time = "2026-03-06T02:54:40.328Z" },
-    { url = "https://files.pythonhosted.org/packages/3a/9f/742c7c7cdf58b59085a1ee4b6c37b013f66ac33673a7ef4aaed5e992bc33/wrapt-2.1.2-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:79847b83eb38e70d93dc392c7c5b587efe65b3e7afcc167aa8abd5d60e8761c8", size = 123013, upload-time = "2026-03-06T02:53:26.58Z" },
-    { url = "https://files.pythonhosted.org/packages/e8/44/2c3dd45d53236b7ed7c646fcf212251dc19e48e599debd3926b52310fafb/wrapt-2.1.2-cp312-cp312-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:f8fba1bae256186a83d1875b2b1f4e2d1242e8fac0f58ec0d7e41b26967b965c", size = 117326, upload-time = "2026-03-06T02:53:11.547Z" },
-    { url = "https://files.pythonhosted.org/packages/74/e2/b17d66abc26bd96f89dec0ecd0ef03da4a1286e6ff793839ec431b9fae57/wrapt-2.1.2-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:e3d3b35eedcf5f7d022291ecd7533321c4775f7b9cd0050a31a68499ba45757c", size = 121444, upload-time = "2026-03-06T02:54:09.5Z" },
-    { url = "https://files.pythonhosted.org/packages/3c/62/e2977843fdf9f03daf1586a0ff49060b1b2fc7ff85a7ea82b6217c1ae36e/wrapt-2.1.2-cp312-cp312-musllinux_1_2_riscv64.whl", hash = "sha256:6f2c5390460de57fa9582bc8a1b7a6c86e1a41dfad74c5225fc07044c15cc8d1", size = 116237, upload-time = "2026-03-06T02:54:03.884Z" },
-    { url = "https://files.pythonhosted.org/packages/88/dd/27fc67914e68d740bce512f11734aec08696e6b17641fef8867c00c949fc/wrapt-2.1.2-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:7dfa9f2cf65d027b951d05c662cc99ee3bd01f6e4691ed39848a7a5fffc902b2", size = 120563, upload-time = "2026-03-06T02:53:20.412Z" },
-    { url = "https://files.pythonhosted.org/packages/ec/9f/b750b3692ed2ef4705cb305bd68858e73010492b80e43d2a4faa5573cbe7/wrapt-2.1.2-cp312-cp312-win32.whl", hash = "sha256:eba8155747eb2cae4a0b913d9ebd12a1db4d860fc4c829d7578c7b989bd3f2f0", size = 58198, upload-time = "2026-03-06T02:53:37.732Z" },
-    { url = "https://files.pythonhosted.org/packages/8e/b2/feecfe29f28483d888d76a48f03c4c4d8afea944dbee2b0cd3380f9df032/wrapt-2.1.2-cp312-cp312-win_amd64.whl", hash = "sha256:1c51c738d7d9faa0b3601708e7e2eda9bf779e1b601dce6c77411f2a1b324a63", size = 60441, upload-time = "2026-03-06T02:52:47.138Z" },
-    { url = "https://files.pythonhosted.org/packages/44/e1/e328f605d6e208547ea9fd120804fcdec68536ac748987a68c47c606eea8/wrapt-2.1.2-cp312-cp312-win_arm64.whl", hash = "sha256:c8e46ae8e4032792eb2f677dbd0d557170a8e5524d22acc55199f43efedd39bf", size = 58836, upload-time = "2026-03-06T02:53:22.053Z" },
-    { url = "https://files.pythonhosted.org/packages/1a/c7/8528ac2dfa2c1e6708f647df7ae144ead13f0a31146f43c7264b4942bf12/wrapt-2.1.2-py3-none-any.whl", hash = "sha256:b8fd6fa2b2c4e7621808f8c62e8317f4aae56e59721ad933bac5239d913cf0e8", size = 43993, upload-time = "2026-03-06T02:53:12.905Z" },
 ]
 
 [[package]]

--- a/uv.lock
+++ b/uv.lock
@@ -87,6 +87,19 @@ wheels = [
 ]
 
 [[package]]
+name = "authlib"
+version = "1.7.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cryptography" },
+    { name = "joserfc" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/36/98/7d93f30d029643c0275dbc0bd6d5a6f670661ee6c9a94d93af7ab4887600/authlib-1.7.2.tar.gz", hash = "sha256:2cea25fefcd4e7173bdf1372c0afc265c8034b23a8cd5dcb6a9164b826c64231", size = 176511, upload-time = "2026-05-06T08:10:23.116Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fb/95/adcb68e20c34162e9135f370d6e31737719c2b6f94bc953fe7ed1f10fe21/authlib-1.7.2-py2.py3-none-any.whl", hash = "sha256:3e1faedc9d87e7d56a164eca3ccb6ace0d61b94abe83e92242f8dc8bba9b4a9f", size = 259548, upload-time = "2026-05-06T08:10:21.436Z" },
+]
+
+[[package]]
 name = "backoff"
 version = "2.2.1"
 source = { registry = "https://pypi.org/simple" }
@@ -174,6 +187,42 @@ wheels = [
 ]
 
 [[package]]
+name = "cffi"
+version = "2.1.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pycparser", marker = "implementation_name != 'PyPy'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/9e/ef/008a1939e372c06329a3fce4279c02f328488f3526744906eeec3da7ad5f/cffi-2.1.1.tar.gz", hash = "sha256:dd31f52ea1086513bb9df30f8fcee9b8918323ae067a3d5b78bc826a000712be", size = 530807, upload-time = "2026-08-03T21:21:18.939Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/70/d2/16d99a0c4948febc0ebd133a13b2f688ff7f8cb04da971e1128872ce0c03/cffi-2.1.1-cp311-cp311-macosx_10_15_x86_64.whl", hash = "sha256:c8d2c9fd1f2d16f780d15127abb050d13d1a76c03a4bd87d7e4980e45e511e12", size = 183838, upload-time = "2026-08-03T21:19:29.637Z" },
+    { url = "https://files.pythonhosted.org/packages/cd/95/31b535a9f0220ae9f357de4a08d57ce89cb417653c2fd9f075f50822a388/cffi-2.1.1-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:398aff33cee2767e3e781d2554c54bd0dff386bb437581e0d8011fde1a942ec1", size = 184168, upload-time = "2026-08-03T21:19:30.764Z" },
+    { url = "https://files.pythonhosted.org/packages/ad/5a/4707a0dc1f203f5dde5a907b0d4e3c25d71120241048bd5bc6f1bb9d4e71/cffi-2.1.1-cp311-cp311-manylinux1_i686.manylinux2014_i686.manylinux_2_17_i686.manylinux_2_5_i686.whl", hash = "sha256:154852545011f779917b11c78db2358d095da62a9a172b78ad0a583ee5adc0d0", size = 211805, upload-time = "2026-08-03T21:19:31.867Z" },
+    { url = "https://files.pythonhosted.org/packages/ad/66/c19feabb28485b6e0bbaaafa90837a1ef5d302e90f2178bd33f17a49879b/cffi-2.1.1-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:3311ed60d36f83378794e1009ac6258bafbf81f7888b4caa7b35a521e3f95813", size = 218716, upload-time = "2026-08-03T21:19:32.896Z" },
+    { url = "https://files.pythonhosted.org/packages/a7/92/500760486c8baab49a7a8a58ba7fc3355ec3974b454b8a09e528efde9e1d/cffi-2.1.1-cp311-cp311-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:6e192623c49c94421616a5778fba35cf0d5a8d000650c1967ef4448ee5cdd990", size = 205569, upload-time = "2026-08-03T21:19:34.142Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/a7/a67c733254d6e7373f7822f8082d8d6beade791e0cf12a7611f376fa61c7/cffi-2.1.1-cp311-cp311-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:a6e721d4b0e45d5b65e87534470e67b18dcd092c83f68fba09f152b9cbc061af", size = 204907, upload-time = "2026-08-03T21:19:35.174Z" },
+    { url = "https://files.pythonhosted.org/packages/f7/a4/4399daaf8f7dfee9d7c3327fdb0426ee041cc63edc358b93911ceb2bfc7a/cffi-2.1.1-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:34e261f78cb6ceaaa36f42f2613f4380d94d9c759a9c73c769ee6e0247364632", size = 217807, upload-time = "2026-08-03T21:19:36.286Z" },
+    { url = "https://files.pythonhosted.org/packages/28/f7/dabe6da2466ecbd82dc62e7342dc6b1065dad990c06f00f0ede9ebf2a0ed/cffi-2.1.1-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:7225e4514edb64eb6740324353e0da0711954fd8d7da4576755b1c6e09b697cd", size = 221252, upload-time = "2026-08-03T21:19:37.416Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/87/616202d8e51342c07d2534c510111c4cc37201775ce8f60802c9335d1edd/cffi-2.1.1-cp311-cp311-musllinux_1_2_i686.whl", hash = "sha256:df913725b79db7bcf03448f36b7bf8815363417d5b58deecf9305e3e30f0f21a", size = 214214, upload-time = "2026-08-03T21:19:38.507Z" },
+    { url = "https://files.pythonhosted.org/packages/b4/c6/ab025d75d2c26c19b087c0124e75ee31cb65032f4fe345d356d8c507ab97/cffi-2.1.1-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:f5cfbc5fe74540d335175b656c725d74d90e3730c626d92575eea35029d9afaa", size = 219408, upload-time = "2026-08-03T21:19:39.809Z" },
+    { url = "https://files.pythonhosted.org/packages/db/e2/7e8109f65445bdc673a7b54f02c677de462db75674220fd1335efc8eb598/cffi-2.1.1-cp311-cp311-win32.whl", hash = "sha256:f8ec5e643a9a937f64e1999eb9f75d072263751912dc5cd06d3c85f8f44be7c3", size = 174470, upload-time = "2026-08-03T21:19:41.246Z" },
+    { url = "https://files.pythonhosted.org/packages/73/c0/77ba02423c2f7d7091143c45cd49e0e6575c4c1967394bb542bd923a9b74/cffi-2.1.1-cp311-cp311-win_amd64.whl", hash = "sha256:42f6930c31dc7f50732c9ae793c2786c7b6b044195967bbdde40bb9be81c4cc0", size = 185096, upload-time = "2026-08-03T21:19:42.615Z" },
+    { url = "https://files.pythonhosted.org/packages/7c/47/9f1f85f9672ceda4984dc6c4f8824e8558992a2972c3d3c81fb8eb28d4ba/cffi-2.1.1-cp311-cp311-win_arm64.whl", hash = "sha256:c7659f22557c5a0bc4855cd635f55edec690cc008a40768527762cb9fb263455", size = 179941, upload-time = "2026-08-03T21:19:43.747Z" },
+    { url = "https://files.pythonhosted.org/packages/10/69/43965eccfdead3b9220015fd1320e117be8c6ed01a62ffab76eeb752f5d5/cffi-2.1.1-cp312-cp312-macosx_10_15_x86_64.whl", hash = "sha256:c8c69575568085ba0b1b10c0249d779a214aea6f6522e949a0fc9fb0fcb449d0", size = 184821, upload-time = "2026-08-03T21:19:44.887Z" },
+    { url = "https://files.pythonhosted.org/packages/54/7d/16e5a096677b5e313ca80cd5e5170efa3ea44624a82bb111925522da64b1/cffi-2.1.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:f81b3b8f3d4e343550fa4baa0e479bba9f2d29ce9c2e9b51d1ce1718d7442fcf", size = 184719, upload-time = "2026-08-03T21:19:46.129Z" },
+    { url = "https://files.pythonhosted.org/packages/56/e6/8941622732edec876dd17d0453dce07317ae96db34f2ec1436c9d3785986/cffi-2.1.1-cp312-cp312-manylinux1_i686.manylinux2014_i686.manylinux_2_17_i686.manylinux_2_5_i686.whl", hash = "sha256:811bd1e21d32de12efca32393a0ab3f5133b54fce9bd44b8bd77ab07da14bf6a", size = 214799, upload-time = "2026-08-03T21:19:47.218Z" },
+    { url = "https://files.pythonhosted.org/packages/44/de/f98430906df1545ffde0d543dd124a7a439bc2cd32b36b9c53f805df7333/cffi-2.1.1-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:68e62fe11f30d5ca8289242866f0a5291402d8529ca2178ab8afc5c9694ae890", size = 222389, upload-time = "2026-08-03T21:19:48.331Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/5b/717f1526b9957b34456313c31645c5b82b8fb5c3fe9e4752999be7128bfc/cffi-2.1.1-cp312-cp312-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:4a7c934f7360e8cd64fe9efadcbd10c7c6364f531e432b9a4bf5ccbc9e0e8b50", size = 210249, upload-time = "2026-08-03T21:19:49.543Z" },
+    { url = "https://files.pythonhosted.org/packages/64/b3/f8aa4f3e34986c7e4ec45072d1b1b9dd295b6b18007b45518d79726dd725/cffi-2.1.1-cp312-cp312-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:3143d81e29e1e20a9ce10901ec369012947876596f75a222235965f2b7ae832e", size = 208775, upload-time = "2026-08-03T21:19:50.918Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/db/dceb9dd5b231e1da801793f8acc9f3c52a7e1afe40bb1aae37e02b0faad5/cffi-2.1.1-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:c1453022f490d2459a11819d83ad1d586e9ff65a12ac3e705ffebd46d3685dcf", size = 221822, upload-time = "2026-08-03T21:19:52.054Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/d2/6cd24ae3be000a634109c247d1475d62e5616d0dc78c82770942ec384248/cffi-2.1.1-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:208f941bb9d18e768138677f0a6d2ce01f590df56043dda1df1535ac57c88517", size = 225232, upload-time = "2026-08-03T21:19:53.109Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/52/3fa190537004dd7f0ab860a6dc7c0175b8667f68d1e618a46f5498d30250/cffi-2.1.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:210019b6c7cf07f081b4c54635c8cf744377001350e29cc0f81c4377b4797735", size = 223597, upload-time = "2026-08-03T21:19:54.515Z" },
+    { url = "https://files.pythonhosted.org/packages/80/fb/0bb75b7039588c074b37ae99f40d9bfddf990ecb2fbc346ebccd2e56b9be/cffi-2.1.1-cp312-cp312-win32.whl", hash = "sha256:046bfc24911b37851ee1b51aab8bffe713d89c68c6a057b09484ce9fd5f69b4e", size = 175292, upload-time = "2026-08-03T21:19:55.566Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/79/615cc094e2fb508cade7de88d3b4f6c4ec2bab695c97bce9153dc65aadf5/cffi-2.1.1-cp312-cp312-win_amd64.whl", hash = "sha256:f53e442b08449d42821fa4a4fba000095af9f62742a500f978a9f557ec44339a", size = 185919, upload-time = "2026-08-03T21:19:56.89Z" },
+    { url = "https://files.pythonhosted.org/packages/70/c6/d0ea84713fe46b243a436a18fcd47d639732747e21635c8a27191b06dc30/cffi-2.1.1-cp312-cp312-win_arm64.whl", hash = "sha256:7bde5e4cc5c10140859842b9d383af292b22639a4dffb725314baf45968cef80", size = 180093, upload-time = "2026-08-03T21:19:58.155Z" },
+]
+
+[[package]]
 name = "charset-normalizer"
 version = "3.4.7"
 source = { registry = "https://pypi.org/simple" }
@@ -236,7 +285,7 @@ wheels = [
 
 [[package]]
 name = "chromadb"
-version = "0.6.3"
+version = "0.5.23"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "bcrypt" },
@@ -268,9 +317,9 @@ dependencies = [
     { name = "typing-extensions" },
     { name = "uvicorn", extra = ["standard"] },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/39/cd/f0f2de3f466ff514fb6b58271c14f6d22198402bb5b71b8d890231265946/chromadb-0.6.3.tar.gz", hash = "sha256:c8f34c0b704b9108b04491480a36d42e894a960429f87c6516027b5481d59ed3", size = 29297929, upload-time = "2025-01-14T22:20:40.184Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/42/64/28daa773f784bcd18de944fe26ed301de844d6ee17188e26a9d6b4baf122/chromadb-0.5.23.tar.gz", hash = "sha256:360a12b9795c5a33cb1f839d14410ccbde662ef1accd36153b0ae22312edabd1", size = 33700455, upload-time = "2024-12-05T06:31:19.81Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/28/8e/5c186c77bf749b6fe0528385e507e463f1667543328d76fd00a49e1a4e6a/chromadb-0.6.3-py3-none-any.whl", hash = "sha256:4851258489a3612b558488d98d09ae0fe0a28d5cad6bd1ba64b96fdc419dc0e5", size = 611129, upload-time = "2025-01-14T22:20:33.784Z" },
+    { url = "https://files.pythonhosted.org/packages/92/8c/a9eb95a28e6c35a0122417976a9d435eeaceb53f596a8973e33b3dd4cfac/chromadb-0.5.23-py3-none-any.whl", hash = "sha256:ffe5bdd7276d12cb682df0d38a13aa37573e6a3678e71889ac45f539ae05ad7e", size = 628347, upload-time = "2024-12-05T06:31:17.231Z" },
 ]
 
 [[package]]
@@ -304,6 +353,49 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/a2/61/f083b5ac52e505dfc1c624eafbf8c7589a0d7f32daa398d2e7590efa5fda/colorlog-6.10.1.tar.gz", hash = "sha256:eb4ae5cb65fe7fec7773c2306061a8e63e02efc2c72eba9d27b0fa23c94f1321", size = 17162, upload-time = "2025-10-16T16:14:11.978Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/6d/c1/e419ef3723a074172b68aaa89c9f3de486ed4c2399e2dbd8113a4fdcaf9e/colorlog-6.10.1-py3-none-any.whl", hash = "sha256:2d7e8348291948af66122cff006c9f8da6255d224e7cf8e37d8de2df3bad8c9c", size = 11743, upload-time = "2025-10-16T16:14:10.512Z" },
+]
+
+[[package]]
+name = "cryptography"
+version = "50.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cffi", marker = "platform_python_implementation != 'PyPy'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/de/41/6cbdcf9142d00fe82836fbb51e503e58088575cf7a0fe1dbff6695bf0840/cryptography-50.0.0.tar.gz", hash = "sha256:eeac2acb5a20ed25e0ad6d1df9891a520b78b404266b6d11778f25d5d691a6c9", size = 880201, upload-time = "2026-07-31T14:25:10.11Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c5/5c/59086b4aac5e879d38ddbcf74e4be7ade89cebc3eb199a55da998c3bb46a/cryptography-50.0.0-cp311-abi3-macosx_11_0_arm64.whl", hash = "sha256:031e2d5dd4bb9caa3ca9c82e5a197fd8ae680232cee62603d1a813f3f07e3d03", size = 4001252, upload-time = "2026-07-31T14:23:33.331Z" },
+    { url = "https://files.pythonhosted.org/packages/57/ef/8f2df13c7216bcad3e1c74e07f6e193d93e998e114f524a53877c9af27ad/cryptography-50.0.0-cp311-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:fd9192b7b70c573d7f214eb1ae35e00d359f6f5e4b27c7e21e30de1fc6204645", size = 4719554, upload-time = "2026-07-31T14:23:35.611Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/41/029086c34d91052fc3b88bcc8056f709a7c915c7a23b235a54eb800b1c97/cryptography-50.0.0-cp311-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:06a32a980526a6ab9a4b9bf8f7385800791e2bb960903cb6b530e4817509a3b7", size = 4702130, upload-time = "2026-07-31T14:23:37.635Z" },
+    { url = "https://files.pythonhosted.org/packages/7d/ff/b6ce0954962e7f7b969f850a883744197bb3910bdfd7b6da162eab7d9f68/cryptography-50.0.0-cp311-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:a1b30560f2acc95aa8b2e06e716a13dbfc97314747b80d9707e307f77b40d6b3", size = 4725244, upload-time = "2026-07-31T14:23:39.471Z" },
+    { url = "https://files.pythonhosted.org/packages/06/1e/63a1027cb7fec360a182208e1b7767d5aa1fe57be3d6aa856e69a321edc0/cryptography-50.0.0-cp311-abi3-manylinux_2_28_ppc64le.whl", hash = "sha256:8d89f3976b10b4ce31118de72329025f70d2c6ead14a8217c5514dd2c6d5a78f", size = 5342265, upload-time = "2026-07-31T14:23:41.286Z" },
+    { url = "https://files.pythonhosted.org/packages/6b/72/a1116d683a6d7ece94590013882515de087edf9ef0e6292aae615a44df73/cryptography-50.0.0-cp311-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:b42a28c1844fd9de8f3f7d540e36b66f3a9c83fceac7170ebc7a6a19edd9dcae", size = 4734609, upload-time = "2026-07-31T14:23:43.139Z" },
+    { url = "https://files.pythonhosted.org/packages/15/37/36a9c479bbe49acea2636c7fd3360d20f7b7e079c300352011c44850b181/cryptography-50.0.0-cp311-abi3-manylinux_2_31_armv7l.whl", hash = "sha256:900131fafd8aead39ac7dd3a7e833be754c17a95cfd91221636949fe4eb0aa8a", size = 4356517, upload-time = "2026-07-31T14:23:44.939Z" },
+    { url = "https://files.pythonhosted.org/packages/32/98/8a151d64367204cbc63ec65d37502f1d9c53cf4bfc6ec3c532614dbec60d/cryptography-50.0.0-cp311-abi3-manylinux_2_34_aarch64.whl", hash = "sha256:07949c449a1abcf60d1ee6e88956d89404c7df3c8258f46589e912988e551987", size = 4724529, upload-time = "2026-07-31T14:23:46.93Z" },
+    { url = "https://files.pythonhosted.org/packages/22/f6/ec13b470172126464a86bf54d2294a46d29837fc51ba3e45d4047946fb5e/cryptography-50.0.0-cp311-abi3-manylinux_2_34_ppc64le.whl", hash = "sha256:f89831ef99dd7dd169ab06d63a831adb9e20a87aac6d380266bbda5823349169", size = 5299852, upload-time = "2026-07-31T14:23:48.851Z" },
+    { url = "https://files.pythonhosted.org/packages/da/3a/f05e32c99d440c9bb891ea0e36c9091891e36be5a9a87ab2ee6ea20729f6/cryptography-50.0.0-cp311-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:82148ec5bddac30b51a5b3c1945075f896fa022cb93f8e4a01e9f6ee95292c5f", size = 4734462, upload-time = "2026-07-31T14:23:50.861Z" },
+    { url = "https://files.pythonhosted.org/packages/ca/dc/bd72b26be8953f80625f63151efd38eee71c76ca6cf591c08ff34615a79e/cryptography-50.0.0-cp311-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:1489e263a8048bb8b6a8bac662eb2d402ea5d2b7b4699b72f385f1e2772db105", size = 4852708, upload-time = "2026-07-31T14:23:52.715Z" },
+    { url = "https://files.pythonhosted.org/packages/27/20/c930314a2ab476d15dec966ec87e2e9637bb02b06106b12c0396c57bb603/cryptography-50.0.0-cp311-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:7cec5b856506da6defb290f30c9ee687d5f5e8cb0bd3f6459dde43b0b4fa40ef", size = 5004179, upload-time = "2026-07-31T14:23:54.887Z" },
+    { url = "https://files.pythonhosted.org/packages/32/2e/c9db68a0c4bfa28e310707527c0ee3a2bd254104d2e02e68f368e197aa4c/cryptography-50.0.0-cp311-abi3-win_amd64.whl", hash = "sha256:bd1c592e4d5974f0d08d4888e432157adba757c66da0246918e43677fafa2d30", size = 3840395, upload-time = "2026-07-31T14:23:56.677Z" },
+    { url = "https://files.pythonhosted.org/packages/03/37/73d005be173aff344af30e9fd2a576575cb2391a7101d9cd3842e1fa8cce/cryptography-50.0.0-cp39-abi3-macosx_11_0_arm64.whl", hash = "sha256:ccdc4a71a4dabae05de219404f9f4abc38e3b58422177ff93d0da05967dafa07", size = 4036009, upload-time = "2026-07-31T14:24:24.122Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/c6/7a6202a534e32103a285b7834a120869557fe198d51d7cfe59754c8bda9c/cryptography-50.0.0-cp39-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:910e1d2668e7de9648f2bcee30e180db2a6b15c30f887d7c4c93ddf96e3992e3", size = 4745252, upload-time = "2026-07-31T14:24:26.118Z" },
+    { url = "https://files.pythonhosted.org/packages/85/4f/0fa8c2f4428198f15d9ff8d63400e27afbf94ce833f6108da1eb3753f945/cryptography-50.0.0-cp39-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:a91296cb61e8df6f86d0c19cc4068228da256bf59bf86049fbd821084565327f", size = 4728939, upload-time = "2026-07-31T14:24:27.994Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/63/54dd723490ba2dc09b299682c10b38db38f159728bcaae8c591b8af2f22d/cryptography-50.0.0-cp39-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:e722f16708d854fe924790e051061f6704a472c3bac347b6fd88033ea8dd0dc5", size = 4748483, upload-time = "2026-07-31T14:24:30.254Z" },
+    { url = "https://files.pythonhosted.org/packages/1d/dd/7c77d26285cc7f6991efce64a0f5b4f9383bfa5dd8c5033003eaf7db4cdb/cryptography-50.0.0-cp39-abi3-manylinux_2_28_ppc64le.whl", hash = "sha256:d764dcf130c428ef66786f866dd750f53182bc608813489915e9fc106bb0c82f", size = 5367599, upload-time = "2026-07-31T14:24:32.457Z" },
+    { url = "https://files.pythonhosted.org/packages/46/c9/f60aed34c013f317f92817b6c171c2d22a78270fa41109bd4b08af26b194/cryptography-50.0.0-cp39-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:105110f43a471dbd0060b9c9516cb8a6a79233631a04cc2ba16f28323ac6e025", size = 4762647, upload-time = "2026-07-31T14:24:34.599Z" },
+    { url = "https://files.pythonhosted.org/packages/be/f3/f9a0173b139372c3a48ed98154b45cc6b9de17c789d5ab552e621c293609/cryptography-50.0.0-cp39-abi3-manylinux_2_31_armv7l.whl", hash = "sha256:828743d939e9629bc267b8e2d08d8bb67cd4319c771a33d4b18b22dd8fb7440a", size = 4385197, upload-time = "2026-07-31T14:24:36.647Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/36/83bb81f6e569bc38e1e4a7bc80f29b46bb9601920bc455fc8e888f5d5742/cryptography-50.0.0-cp39-abi3-manylinux_2_34_aarch64.whl", hash = "sha256:2a8183b489dc1f7f80f135780fadc1108f14b31b8a40411c7a5b17425f65f28b", size = 4748095, upload-time = "2026-07-31T14:24:39.493Z" },
+    { url = "https://files.pythonhosted.org/packages/6b/16/d3008eff98c764979865834c3d386d4fd041b5f52e7f34fc29ac1a5eb515/cryptography-50.0.0-cp39-abi3-manylinux_2_34_ppc64le.whl", hash = "sha256:6e7d61120573a7f2cd94cc095f9e81f6967c61ccdf194285aa143ecec8e0b708", size = 5325948, upload-time = "2026-07-31T14:24:41.556Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/f8/d97f9603efda3888187bfdb893f26c41be4735c10631d05d284ee6b047c4/cryptography-50.0.0-cp39-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:37fdb0d0111f1e2ff07139dfb79f1b49531f8e213c46f1163dd7642979b58c47", size = 4762400, upload-time = "2026-07-31T14:24:43.636Z" },
+    { url = "https://files.pythonhosted.org/packages/64/a2/4615c8f7d81a00b1d6e6afe19f694e1543582349fb5f4076f6cb5dc36485/cryptography-50.0.0-cp39-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:c87f62a3d3b9888ed0fdde100ec06aa61ca9cd44bad9057d1dff9a516b5f5bb9", size = 4878208, upload-time = "2026-07-31T14:24:45.522Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/1a/efcfb02f91407149a0dacffffab791f7e19bf6385f63b3666dc8b5e5c9c8/cryptography-50.0.0-cp39-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:65c2c3add92b45fd0709db8594536aea39c2a67af0e27ffcf049c498501140b7", size = 5037050, upload-time = "2026-07-31T14:24:47.697Z" },
+    { url = "https://files.pythonhosted.org/packages/57/30/4a22984d4f1bdfb8c054f07a92bc176b97a3134cc1d6c4b3bffb1f3688b4/cryptography-50.0.0-cp39-abi3-win_amd64.whl", hash = "sha256:d24fead1d4d076e1bfb006dcec392074a3cd8d7b4fc8a595aa64073b2b7a96ba", size = 3874135, upload-time = "2026-07-31T14:24:50.085Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/3e/e54cde8c01631a5a8226ccd617eab9e57fd5cfdad90f1a9e6bb570794631/cryptography-50.0.0-pp311-pypy311_pp73-macosx_11_0_arm64.whl", hash = "sha256:5e34edd123674534acd70147f0ca331eaa2c74e6325fb2028c886aa26ba0b68c", size = 3963170, upload-time = "2026-07-31T14:24:51.968Z" },
+    { url = "https://files.pythonhosted.org/packages/01/b6/0b9e125e90f3d2dcf599a218a899cda7326a3158cfa258723f0b398b08f6/cryptography-50.0.0-pp311-pypy311_pp73-manylinux_2_28_aarch64.whl", hash = "sha256:8eb5e1172eb569ea8a872796576e6a67c276351728b6455d5beb01242b027c6a", size = 4692441, upload-time = "2026-07-31T14:24:53.743Z" },
+    { url = "https://files.pythonhosted.org/packages/53/c9/a5151588710785a96d7bc4de27d4cd62f263bbbcb203cfe29df537eb6505/cryptography-50.0.0-pp311-pypy311_pp73-manylinux_2_28_x86_64.whl", hash = "sha256:910d11e1a385c654bf738bf3e6b8e6ed5de0f5610fcae2be9e5b398d8081d20e", size = 4699810, upload-time = "2026-07-31T14:24:55.746Z" },
+    { url = "https://files.pythonhosted.org/packages/c7/1a/15b92b25eb6ce3089cd49377ae990a0f3ad485a510f968aed1f19dbdcdf2/cryptography-50.0.0-pp311-pypy311_pp73-manylinux_2_34_aarch64.whl", hash = "sha256:62598a8a57f815db4c6259a4e97d857dab56697e7de8e8ab02352ab74da1995d", size = 4691924, upload-time = "2026-07-31T14:24:58.082Z" },
+    { url = "https://files.pythonhosted.org/packages/62/15/219075012ab13e8905f3cd572204f4acb4b111df787104346b9bc0cea789/cryptography-50.0.0-pp311-pypy311_pp73-manylinux_2_34_x86_64.whl", hash = "sha256:07479a1cb08219ab719147e742e76090c9c773321959bb94946fffdd397a6437", size = 4699593, upload-time = "2026-07-31T14:24:59.951Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/b5/c2c5fce26f0ee40d21bafe7f191d29a34b35a65ac4fe8a1191d1983612e9/cryptography-50.0.0-pp311-pypy311_pp73-win_amd64.whl", hash = "sha256:c99c003e088647b8a5b7c145d6f78c335f6348332b62e142d411c4b63d1460b9", size = 3813796, upload-time = "2026-07-31T14:25:02.298Z" },
 ]
 
 [[package]]
@@ -678,22 +770,21 @@ wheels = [
 
 [[package]]
 name = "huggingface-hub"
-version = "1.13.0"
+version = "0.36.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "filelock" },
     { name = "fsspec" },
-    { name = "hf-xet", marker = "platform_machine == 'AMD64' or platform_machine == 'aarch64' or platform_machine == 'amd64' or platform_machine == 'arm64' or platform_machine == 'x86_64'" },
-    { name = "httpx" },
+    { name = "hf-xet", marker = "platform_machine == 'aarch64' or platform_machine == 'amd64' or platform_machine == 'arm64' or platform_machine == 'x86_64'" },
     { name = "packaging" },
     { name = "pyyaml" },
+    { name = "requests" },
     { name = "tqdm" },
-    { name = "typer" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/89/ff/ec7ed2eb43bd7ce8bb2233d109cc235c3e807ffe5e469dc09db261fac05e/huggingface_hub-1.13.0.tar.gz", hash = "sha256:f6df2dac5abe82ce2fe05873d10d5ff47bc677d616a2f521f4ee26db9415d9d0", size = 781788, upload-time = "2026-04-30T11:57:33.858Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/7c/b7/8cb61d2eece5fb05a83271da168186721c450eb74e3c31f7ef3169fa475b/huggingface_hub-0.36.2.tar.gz", hash = "sha256:1934304d2fb224f8afa3b87007d58501acfda9215b334eed53072dd5e815ff7a", size = 649782, upload-time = "2026-02-06T09:24:13.098Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/93/db/4b1cdae9460ae1f3ca020cd767f013430ce23eb1d9c890ae3a0609b38d26/huggingface_hub-1.13.0-py3-none-any.whl", hash = "sha256:e942cb50d6a08dd5306688b1ac05bda157fd2fcc88b63dae405f7bd0d3234005", size = 660643, upload-time = "2026-04-30T11:57:31.802Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/af/48ac8483240de756d2438c380746e7130d1c6f75802ef22f3c6d49982787/huggingface_hub-0.36.2-py3-none-any.whl", hash = "sha256:48f0c8eac16145dfce371e9d2d7772854a4f591bcb56c9cf548accf531d54270", size = 566395, upload-time = "2026-02-06T09:24:11.133Z" },
 ]
 
 [[package]]
@@ -763,6 +854,18 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/41/f2/d34e8b3a08a9cc79a50b2208a93dce981fe615b64d5a4d4abee421d898df/joblib-1.5.3.tar.gz", hash = "sha256:8561a3269e6801106863fd0d6d84bb737be9e7631e33aaed3fb9ce5953688da3", size = 331603, upload-time = "2025-12-15T08:41:46.427Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/7b/91/984aca2ec129e2757d1e4e3c81c3fcda9d0f85b74670a094cc443d9ee949/joblib-1.5.3-py3-none-any.whl", hash = "sha256:5fc3c5039fc5ca8c0276333a188bbd59d6b7ab37fe6632daa76bc7f9ec18e713", size = 309071, upload-time = "2025-12-15T08:41:44.973Z" },
+]
+
+[[package]]
+name = "joserfc"
+version = "1.7.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cryptography" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/c7/e0/27a6a081ae25420eda6768ceae05d7022a7f2447f420588843f2a44e4298/joserfc-1.7.4.tar.gz", hash = "sha256:b3bc561672ae541b17a9237053b48a03dacddd92d68047b3ecdfb4b5714a88ed", size = 234027, upload-time = "2026-07-19T15:43:02.739Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f9/bf/249dcd99b3376375910b7fa922383b57792975c8758f50d44612e749226c/joserfc-1.7.4-py3-none-any.whl", hash = "sha256:32d46c2cd5e3203c13e87a6c61333cab310b1ba80cd54b4c4f386a848a122463", size = 71000, upload-time = "2026-07-19T15:43:01.299Z" },
 ]
 
 [[package]]
@@ -1587,6 +1690,15 @@ wheels = [
 ]
 
 [[package]]
+name = "pycparser"
+version = "3.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/1b/7d/92392ff7815c21062bea51aa7b87d45576f649f16458d78b7cf94b9ab2e6/pycparser-3.0.tar.gz", hash = "sha256:600f49d217304a5902ac3c37e1281c9fe94e4d0489de643a9504c5cdfdfc6b29", size = 103492, upload-time = "2026-01-21T14:26:51.89Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0c/c3/44f3fbbfa403ea2a7c779186dc20772604442dde72947e7d01069cbe98e3/pycparser-3.0-py3-none-any.whl", hash = "sha256:b727414169a36b7d524c1c3e31839a521725078d7b2ff038656844266160a992", size = 48172, upload-time = "2026-01-21T14:26:50.693Z" },
+]
+
+[[package]]
 name = "pydantic"
 version = "2.13.3"
 source = { registry = "https://pypi.org/simple" }
@@ -2295,12 +2407,15 @@ name = "student-bot"
 version = "0.1.0"
 source = { editable = "." }
 dependencies = [
+    { name = "authlib" },
     { name = "beautifulsoup4" },
     { name = "chromadb" },
     { name = "click" },
+    { name = "cryptography" },
     { name = "fastapi" },
     { name = "httpx" },
     { name = "itsdangerous" },
+    { name = "joserfc" },
     { name = "lingua-language-detector", version = "2.1.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.12'" },
     { name = "lingua-language-detector", version = "2.2.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
     { name = "lxml" },
@@ -2331,13 +2446,16 @@ docling = [
 
 [package.metadata]
 requires-dist = [
+    { name = "authlib", specifier = ">=1.3" },
     { name = "beautifulsoup4", specifier = ">=4.12" },
-    { name = "chromadb", specifier = ">=0.5,<1.6" },
+    { name = "chromadb", specifier = ">=0.5,<0.6" },
     { name = "click", specifier = ">=8.1" },
+    { name = "cryptography", specifier = ">=42.0" },
     { name = "docling", marker = "extra == 'docling'", specifier = ">=2.0" },
     { name = "fastapi", specifier = ">=0.110" },
     { name = "httpx", specifier = ">=0.27" },
     { name = "itsdangerous", specifier = ">=2.2" },
+    { name = "joserfc", specifier = ">=1.0" },
     { name = "lingua-language-detector", specifier = ">=2.0" },
     { name = "lxml", specifier = ">=5.2" },
     { name = "markdown-it-py", specifier = ">=3.0" },
@@ -2399,28 +2517,37 @@ wheels = [
 
 [[package]]
 name = "tokenizers"
-version = "0.22.2"
+version = "0.20.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "huggingface-hub" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/73/6f/f80cfef4a312e1fb34baf7d85c72d4411afde10978d4657f8cdd811d3ccc/tokenizers-0.22.2.tar.gz", hash = "sha256:473b83b915e547aa366d1eee11806deaf419e17be16310ac0a14077f1e28f917", size = 372115, upload-time = "2026-01-05T10:45:15.988Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/da/25/b1681c1c30ea3ea6e584ae3fffd552430b12faa599b558c4c4783f56d7ff/tokenizers-0.20.3.tar.gz", hash = "sha256:2278b34c5d0dd78e087e1ca7f9b1dcbf129d80211afa645f214bd6e051037539", size = 340513, upload-time = "2024-11-05T17:34:10.403Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/92/97/5dbfabf04c7e348e655e907ed27913e03db0923abb5dfdd120d7b25630e1/tokenizers-0.22.2-cp39-abi3-macosx_10_12_x86_64.whl", hash = "sha256:544dd704ae7238755d790de45ba8da072e9af3eea688f698b137915ae959281c", size = 3100275, upload-time = "2026-01-05T10:41:02.158Z" },
-    { url = "https://files.pythonhosted.org/packages/2e/47/174dca0502ef88b28f1c9e06b73ce33500eedfac7a7692108aec220464e7/tokenizers-0.22.2-cp39-abi3-macosx_11_0_arm64.whl", hash = "sha256:1e418a55456beedca4621dbab65a318981467a2b188e982a23e117f115ce5001", size = 2981472, upload-time = "2026-01-05T10:41:00.276Z" },
-    { url = "https://files.pythonhosted.org/packages/d6/84/7990e799f1309a8b87af6b948f31edaa12a3ed22d11b352eaf4f4b2e5753/tokenizers-0.22.2-cp39-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:2249487018adec45d6e3554c71d46eb39fa8ea67156c640f7513eb26f318cec7", size = 3290736, upload-time = "2026-01-05T10:40:32.165Z" },
-    { url = "https://files.pythonhosted.org/packages/78/59/09d0d9ba94dcd5f4f1368d4858d24546b4bdc0231c2354aa31d6199f0399/tokenizers-0.22.2-cp39-abi3-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:25b85325d0815e86e0bac263506dd114578953b7b53d7de09a6485e4a160a7dd", size = 3168835, upload-time = "2026-01-05T10:40:38.847Z" },
-    { url = "https://files.pythonhosted.org/packages/47/50/b3ebb4243e7160bda8d34b731e54dd8ab8b133e50775872e7a434e524c28/tokenizers-0.22.2-cp39-abi3-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:bfb88f22a209ff7b40a576d5324bf8286b519d7358663db21d6246fb17eea2d5", size = 3521673, upload-time = "2026-01-05T10:40:56.614Z" },
-    { url = "https://files.pythonhosted.org/packages/e0/fa/89f4cb9e08df770b57adb96f8cbb7e22695a4cb6c2bd5f0c4f0ebcf33b66/tokenizers-0.22.2-cp39-abi3-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:1c774b1276f71e1ef716e5486f21e76333464f47bece56bbd554485982a9e03e", size = 3724818, upload-time = "2026-01-05T10:40:44.507Z" },
-    { url = "https://files.pythonhosted.org/packages/64/04/ca2363f0bfbe3b3d36e95bf67e56a4c88c8e3362b658e616d1ac185d47f2/tokenizers-0.22.2-cp39-abi3-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:df6c4265b289083bf710dff49bc51ef252f9d5be33a45ee2bed151114a56207b", size = 3379195, upload-time = "2026-01-05T10:40:51.139Z" },
-    { url = "https://files.pythonhosted.org/packages/2e/76/932be4b50ef6ccedf9d3c6639b056a967a86258c6d9200643f01269211ca/tokenizers-0.22.2-cp39-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:369cc9fc8cc10cb24143873a0d95438bb8ee257bb80c71989e3ee290e8d72c67", size = 3274982, upload-time = "2026-01-05T10:40:58.331Z" },
-    { url = "https://files.pythonhosted.org/packages/1d/28/5f9f5a4cc211b69e89420980e483831bcc29dade307955cc9dc858a40f01/tokenizers-0.22.2-cp39-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:29c30b83d8dcd061078b05ae0cb94d3c710555fbb44861139f9f83dcca3dc3e4", size = 9478245, upload-time = "2026-01-05T10:41:04.053Z" },
-    { url = "https://files.pythonhosted.org/packages/6c/fb/66e2da4704d6aadebf8cb39f1d6d1957df667ab24cff2326b77cda0dcb85/tokenizers-0.22.2-cp39-abi3-musllinux_1_2_armv7l.whl", hash = "sha256:37ae80a28c1d3265bb1f22464c856bd23c02a05bb211e56d0c5301a435be6c1a", size = 9560069, upload-time = "2026-01-05T10:45:10.673Z" },
-    { url = "https://files.pythonhosted.org/packages/16/04/fed398b05caa87ce9b1a1bb5166645e38196081b225059a6edaff6440fac/tokenizers-0.22.2-cp39-abi3-musllinux_1_2_i686.whl", hash = "sha256:791135ee325f2336f498590eb2f11dc5c295232f288e75c99a36c5dbce63088a", size = 9899263, upload-time = "2026-01-05T10:45:12.559Z" },
-    { url = "https://files.pythonhosted.org/packages/05/a1/d62dfe7376beaaf1394917e0f8e93ee5f67fea8fcf4107501db35996586b/tokenizers-0.22.2-cp39-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:38337540fbbddff8e999d59970f3c6f35a82de10053206a7562f1ea02d046fa5", size = 10033429, upload-time = "2026-01-05T10:45:14.333Z" },
-    { url = "https://files.pythonhosted.org/packages/fd/18/a545c4ea42af3df6effd7d13d250ba77a0a86fb20393143bbb9a92e434d4/tokenizers-0.22.2-cp39-abi3-win32.whl", hash = "sha256:a6bf3f88c554a2b653af81f3204491c818ae2ac6fbc09e76ef4773351292bc92", size = 2502363, upload-time = "2026-01-05T10:45:20.593Z" },
-    { url = "https://files.pythonhosted.org/packages/65/71/0670843133a43d43070abeb1949abfdef12a86d490bea9cd9e18e37c5ff7/tokenizers-0.22.2-cp39-abi3-win_amd64.whl", hash = "sha256:c9ea31edff2968b44a88f97d784c2f16dc0729b8b143ed004699ebca91f05c48", size = 2747786, upload-time = "2026-01-05T10:45:18.411Z" },
-    { url = "https://files.pythonhosted.org/packages/72/f4/0de46cfa12cdcbcd464cc59fde36912af405696f687e53a091fb432f694c/tokenizers-0.22.2-cp39-abi3-win_arm64.whl", hash = "sha256:9ce725d22864a1e965217204946f830c37876eee3b2ba6fc6255e8e903d5fcbc", size = 2612133, upload-time = "2026-01-05T10:45:17.232Z" },
+    { url = "https://files.pythonhosted.org/packages/c6/93/6742ef9206409d5ce1fdf44d5ca1687cdc3847ba0485424e2c731e6bcf67/tokenizers-0.20.3-cp311-cp311-macosx_10_12_x86_64.whl", hash = "sha256:585b51e06ca1f4839ce7759941e66766d7b060dccfdc57c4ca1e5b9a33013a90", size = 2674224, upload-time = "2024-11-05T17:30:49.972Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/14/e75ece72e99f6ef9ae07777ca9fdd78608f69466a5cecf636e9bd2f25d5c/tokenizers-0.20.3-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:61cbf11954f3b481d08723ebd048ba4b11e582986f9be74d2c3bdd9293a4538d", size = 2558991, upload-time = "2024-11-05T17:30:51.666Z" },
+    { url = "https://files.pythonhosted.org/packages/46/54/033b5b2ba0c3ae01e026c6f7ced147d41a2fa1c573d00a66cb97f6d7f9b3/tokenizers-0.20.3-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ef820880d5e4e8484e2fa54ff8d297bb32519eaa7815694dc835ace9130a3eea", size = 2892476, upload-time = "2024-11-05T17:30:53.505Z" },
+    { url = "https://files.pythonhosted.org/packages/e6/b0/cc369fb3297d61f3311cab523d16d48c869dc2f0ba32985dbf03ff811041/tokenizers-0.20.3-cp311-cp311-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:67ef4dcb8841a4988cd00dd288fb95dfc8e22ed021f01f37348fd51c2b055ba9", size = 2802775, upload-time = "2024-11-05T17:30:55.229Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/74/62ad983e8ea6a63e04ed9c5be0b605056bf8aac2f0125f9b5e0b3e2b89fa/tokenizers-0.20.3-cp311-cp311-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:ff1ef8bd47a02b0dc191688ccb4da53600df5d4c9a05a4b68e1e3de4823e78eb", size = 3086138, upload-time = "2024-11-05T17:30:57.332Z" },
+    { url = "https://files.pythonhosted.org/packages/6b/ac/4637ba619db25094998523f9e6f5b456e1db1f8faa770a3d925d436db0c3/tokenizers-0.20.3-cp311-cp311-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:444d188186eab3148baf0615b522461b41b1f0cd58cd57b862ec94b6ac9780f1", size = 3098076, upload-time = "2024-11-05T17:30:59.455Z" },
+    { url = "https://files.pythonhosted.org/packages/58/ce/9793f2dc2ce529369807c9c74e42722b05034af411d60f5730b720388c7d/tokenizers-0.20.3-cp311-cp311-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:37c04c032c1442740b2c2d925f1857885c07619224a533123ac7ea71ca5713da", size = 3379650, upload-time = "2024-11-05T17:31:01.264Z" },
+    { url = "https://files.pythonhosted.org/packages/50/f6/2841de926bc4118af996eaf0bdf0ea5b012245044766ffc0347e6c968e63/tokenizers-0.20.3-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:453c7769d22231960ee0e883d1005c93c68015025a5e4ae56275406d94a3c907", size = 2994005, upload-time = "2024-11-05T17:31:02.985Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/b2/00915c4fed08e9505d37cf6eaab45b12b4bff8f6719d459abcb9ead86a4b/tokenizers-0.20.3-cp311-cp311-musllinux_1_1_aarch64.whl", hash = "sha256:4bb31f7b2847e439766aaa9cc7bccf7ac7088052deccdb2275c952d96f691c6a", size = 8977488, upload-time = "2024-11-05T17:31:04.424Z" },
+    { url = "https://files.pythonhosted.org/packages/e9/ac/1c069e7808181ff57bcf2d39e9b6fbee9133a55410e6ebdaa89f67c32e83/tokenizers-0.20.3-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:843729bf0f991b29655a069a2ff58a4c24375a553c70955e15e37a90dd4e045c", size = 9294935, upload-time = "2024-11-05T17:31:06.882Z" },
+    { url = "https://files.pythonhosted.org/packages/50/47/722feb70ee68d1c4412b12d0ea4acc2713179fd63f054913990f9e259492/tokenizers-0.20.3-cp311-none-win32.whl", hash = "sha256:efcce3a927b1e20ca694ba13f7a68c59b0bd859ef71e441db68ee42cf20c2442", size = 2197175, upload-time = "2024-11-05T17:31:09.385Z" },
+    { url = "https://files.pythonhosted.org/packages/75/68/1b4f928b15a36ed278332ac75d66d7eb65d865bf344d049c452c18447bf9/tokenizers-0.20.3-cp311-none-win_amd64.whl", hash = "sha256:88301aa0801f225725b6df5dea3d77c80365ff2362ca7e252583f2b4809c4cc0", size = 2381616, upload-time = "2024-11-05T17:31:10.685Z" },
+    { url = "https://files.pythonhosted.org/packages/07/00/92a08af2a6b0c88c50f1ab47d7189e695722ad9714b0ee78ea5e1e2e1def/tokenizers-0.20.3-cp312-cp312-macosx_10_12_x86_64.whl", hash = "sha256:49d12a32e190fad0e79e5bdb788d05da2f20d8e006b13a70859ac47fecf6ab2f", size = 2667951, upload-time = "2024-11-05T17:31:12.356Z" },
+    { url = "https://files.pythonhosted.org/packages/ec/9a/e17a352f0bffbf415cf7d73756f5c73a3219225fc5957bc2f39d52c61684/tokenizers-0.20.3-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:282848cacfb9c06d5e51489f38ec5aa0b3cd1e247a023061945f71f41d949d73", size = 2555167, upload-time = "2024-11-05T17:31:13.839Z" },
+    { url = "https://files.pythonhosted.org/packages/27/37/d108df55daf4f0fcf1f58554692ff71687c273d870a34693066f0847be96/tokenizers-0.20.3-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:abe4e08c7d0cd6154c795deb5bf81d2122f36daf075e0c12a8b050d824ef0a64", size = 2898389, upload-time = "2024-11-05T17:31:15.12Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/27/32f29da16d28f59472fa7fb38e7782069748c7e9ab9854522db20341624c/tokenizers-0.20.3-cp312-cp312-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:ca94fc1b73b3883c98f0c88c77700b13d55b49f1071dfd57df2b06f3ff7afd64", size = 2795866, upload-time = "2024-11-05T17:31:16.857Z" },
+    { url = "https://files.pythonhosted.org/packages/29/4e/8a9a3c89e128c4a40f247b501c10279d2d7ade685953407c4d94c8c0f7a7/tokenizers-0.20.3-cp312-cp312-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:ef279c7e239f95c8bdd6ff319d9870f30f0d24915b04895f55b1adcf96d6c60d", size = 3085446, upload-time = "2024-11-05T17:31:18.392Z" },
+    { url = "https://files.pythonhosted.org/packages/b4/3b/a2a7962c496ebcd95860ca99e423254f760f382cd4bd376f8895783afaf5/tokenizers-0.20.3-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:16384073973f6ccbde9852157a4fdfe632bb65208139c9d0c0bd0176a71fd67f", size = 3094378, upload-time = "2024-11-05T17:31:20.329Z" },
+    { url = "https://files.pythonhosted.org/packages/1f/f4/a8a33f0192a1629a3bd0afcad17d4d221bbf9276da4b95d226364208d5eb/tokenizers-0.20.3-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:312d522caeb8a1a42ebdec87118d99b22667782b67898a76c963c058a7e41d4f", size = 3385755, upload-time = "2024-11-05T17:31:21.778Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/65/c83cb3545a65a9eaa2e13b22c93d5e00bd7624b354a44adbdc93d5d9bd91/tokenizers-0.20.3-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:f2b7cb962564785a83dafbba0144ecb7f579f1d57d8c406cdaa7f32fe32f18ad", size = 2997679, upload-time = "2024-11-05T17:31:23.134Z" },
+    { url = "https://files.pythonhosted.org/packages/55/e9/a80d4e592307688a67c7c59ab77e03687b6a8bd92eb5db763a2c80f93f57/tokenizers-0.20.3-cp312-cp312-musllinux_1_1_aarch64.whl", hash = "sha256:124c5882ebb88dadae1fc788a582299fcd3a8bd84fc3e260b9918cf28b8751f5", size = 8989296, upload-time = "2024-11-05T17:31:24.953Z" },
+    { url = "https://files.pythonhosted.org/packages/90/af/60c957af8d2244321124e893828f1a4817cde1a2d08d09d423b73f19bd2f/tokenizers-0.20.3-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:2b6e54e71f84c4202111a489879005cb14b92616a87417f6c102c833af961ea2", size = 9303621, upload-time = "2024-11-05T17:31:27.341Z" },
+    { url = "https://files.pythonhosted.org/packages/be/a9/96172310ee141009646d63a1ca267c099c462d747fe5ef7e33f74e27a683/tokenizers-0.20.3-cp312-none-win32.whl", hash = "sha256:83d9bfbe9af86f2d9df4833c22e94d94750f1d0cd9bfb22a7bb90a86f61cdb1c", size = 2188979, upload-time = "2024-11-05T17:31:29.483Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/68/61d85ae7ae96dde7d0974ff3538db75d5cdc29be2e4329cd7fc51a283e22/tokenizers-0.20.3-cp312-none-win_amd64.whl", hash = "sha256:44def74cee574d609a36e17c8914311d1b5dbcfe37c55fd29369d42591b91cf2", size = 2380725, upload-time = "2024-11-05T17:31:31.315Z" },
 ]
 
 [[package]]
@@ -2432,13 +2559,13 @@ resolution-markers = [
     "python_full_version < '3.12' and sys_platform == 'darwin'",
 ]
 dependencies = [
-    { name = "filelock", marker = "sys_platform == 'darwin'" },
-    { name = "fsspec", marker = "sys_platform == 'darwin'" },
-    { name = "jinja2", marker = "sys_platform == 'darwin'" },
-    { name = "networkx", marker = "sys_platform == 'darwin'" },
-    { name = "setuptools", marker = "sys_platform == 'darwin'" },
-    { name = "sympy", marker = "sys_platform == 'darwin'" },
-    { name = "typing-extensions", marker = "sys_platform == 'darwin'" },
+    { name = "filelock" },
+    { name = "fsspec" },
+    { name = "jinja2" },
+    { name = "networkx" },
+    { name = "setuptools" },
+    { name = "sympy" },
+    { name = "typing-extensions" },
 ]
 wheels = [
     { url = "https://download-r2.pytorch.org/whl/cpu/torch-2.11.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:d75eadcd97fe0dc7cd0eedc4d72152484c19cb2cfe46ce55766c8e129116425f", upload-time = "2026-03-23T15:16:54Z" },
@@ -2458,13 +2585,13 @@ resolution-markers = [
     "python_full_version < '3.12' and sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32'",
 ]
 dependencies = [
-    { name = "filelock", marker = "sys_platform != 'darwin'" },
-    { name = "fsspec", marker = "sys_platform != 'darwin'" },
-    { name = "jinja2", marker = "sys_platform != 'darwin'" },
-    { name = "networkx", marker = "sys_platform != 'darwin'" },
-    { name = "setuptools", marker = "sys_platform != 'darwin'" },
-    { name = "sympy", marker = "sys_platform != 'darwin'" },
-    { name = "typing-extensions", marker = "sys_platform != 'darwin'" },
+    { name = "filelock" },
+    { name = "fsspec" },
+    { name = "jinja2" },
+    { name = "networkx" },
+    { name = "setuptools" },
+    { name = "sympy" },
+    { name = "typing-extensions" },
 ]
 wheels = [
     { url = "https://download-r2.pytorch.org/whl/cpu/torch-2.11.0%2Bcpu-cp311-cp311-linux_s390x.whl", hash = "sha256:5214b203ee187f8746c66f1378b72611b7c1e15c5cb325037541899e705ea24e", upload-time = "2026-04-27T21:55:40Z" },
@@ -2512,22 +2639,23 @@ wheels = [
 
 [[package]]
 name = "transformers"
-version = "5.7.0"
+version = "4.46.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
+    { name = "filelock" },
     { name = "huggingface-hub" },
     { name = "numpy" },
     { name = "packaging" },
     { name = "pyyaml" },
     { name = "regex" },
+    { name = "requests" },
     { name = "safetensors" },
     { name = "tokenizers" },
     { name = "tqdm" },
-    { name = "typer" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/4d/fe/7e84d20ac7d4d5d14bac2eab5976088d86342959fc2c0da54b4c2fc99856/transformers-5.7.0.tar.gz", hash = "sha256:a9d35cf39804e3456c1f9bc1a79ad5ffa878640a61f51f66f71c97f4b4e2ce10", size = 8401287, upload-time = "2026-04-28T18:30:09.75Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/37/5a/58f96c83e566f907ae39f16d4401bbefd8bb85c60bd1e6a95c419752ab90/transformers-4.46.3.tar.gz", hash = "sha256:8ee4b3ae943fe33e82afff8e837f4b052058b07ca9be3cb5b729ed31295f72cc", size = 8627944, upload-time = "2024-11-18T22:13:01.012Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/60/60/86a9fe3037bec221094e2acb680219ad88b77006edba42fc0407a577ca93/transformers-5.7.0-py3-none-any.whl", hash = "sha256:869660cd8fc92badc041f5551bf755a42f4b9558c93341bf3fa3eeed7065079c", size = 10474236, upload-time = "2026-04-28T18:30:05.655Z" },
+    { url = "https://files.pythonhosted.org/packages/51/51/b87caa939fedf307496e4dbf412f4b909af3d9ca8b189fc3b65c1faa456f/transformers-4.46.3-py3-none-any.whl", hash = "sha256:a12ef6f52841fd190a3e5602145b542d03507222f2c64ebb7ee92e8788093aef", size = 10034536, upload-time = "2024-11-18T22:12:57.024Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Closes #76.

Added SSO authentication using Authlib for OAuth2 client operations and joserfc for RS256 id_token verification. Tested against Auth0 as a live OIDC provider pending KTH production credentials. A full writeup of the implementation can be found in docs/sso_implementation.md.

Future improvements include removing the need for users to manually enter their name after successful login, and ensuring that logging is tied to kthid which is extracted after login.